### PR TITLE
Fetch results of evening voting sessions

### DIFF
--- a/backend/howtheyvote/alembic/versions/1f516b18c4f6_rename_result_column_to_status.py
+++ b/backend/howtheyvote/alembic/versions/1f516b18c4f6_rename_result_column_to_status.py
@@ -1,0 +1,23 @@
+"""Rename result column to status
+
+Revision ID: 1f516b18c4f6
+Revises: 9b35d19b64c4
+Create Date: 2024-12-08 11:25:26.051408
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1f516b18c4f6"
+down_revision = "9b35d19b64c4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("pipeline_runs", column_name="result", new_column_name="status")
+
+
+def downgrade() -> None:
+    op.alter_column("pipeline_runs", column_name="status", new_column_name="result")

--- a/backend/howtheyvote/alembic/versions/2f958a6f147d_add_checksum_column_to_pipeline_runs_.py
+++ b/backend/howtheyvote/alembic/versions/2f958a6f147d_add_checksum_column_to_pipeline_runs_.py
@@ -1,0 +1,24 @@
+"""Add checksum column to pipeline_runs table
+
+Revision ID: 2f958a6f147d
+Revises: 1f516b18c4f6
+Create Date: 2024-12-07 17:12:10.792707
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2f958a6f147d"
+down_revision = "1f516b18c4f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("pipeline_runs", sa.Column("checksum", sa.Unicode))
+
+
+def downgrade() -> None:
+    op.drop_column("pipeline_runs", "checksum")

--- a/backend/howtheyvote/models/__init__.py
+++ b/backend/howtheyvote/models/__init__.py
@@ -1,4 +1,4 @@
-from .common import Base, BaseWithId, DataIssue, Fragment, PipelineRun, PipelineRunResult
+from .common import Base, BaseWithId, DataIssue, Fragment, PipelineRun, PipelineStatus
 from .country import Country, CountryType
 from .eurovoc import EurovocConcept, EurovocConceptType
 from .group import Group
@@ -24,7 +24,7 @@ __all__ = [
     "BaseWithId",
     "Fragment",
     "PipelineRun",
-    "PipelineRunResult",
+    "PipelineStatus",
     "DataIssue",
     "Country",
     "CountryType",

--- a/backend/howtheyvote/models/common.py
+++ b/backend/howtheyvote/models/common.py
@@ -51,3 +51,4 @@ class PipelineRun(Base):
     finished_at: Mapped[sa.DateTime] = mapped_column(sa.DateTime)
     pipeline: Mapped[str] = mapped_column(sa.Unicode)
     status: Mapped[PipelineStatus] = mapped_column(sa.Enum(PipelineStatus))
+    checksum: Mapped[str] = mapped_column(sa.Unicode)

--- a/backend/howtheyvote/models/common.py
+++ b/backend/howtheyvote/models/common.py
@@ -36,10 +36,11 @@ class DataIssue(Enum):
     VOTE_GROUP_NO_MAIN_VOTE = "VOTE_GROUP_NO_MAIN_VOTE"
 
 
-class PipelineRunResult(Enum):
+class PipelineStatus(Enum):
     SUCCESS = "SUCCESS"
     FAILURE = "FAILURE"
     DATA_UNAVAILABLE = "DATA_UNAVAILABLE"
+    DATA_UNCHANGED = "DATA_UNCHANGED"
 
 
 class PipelineRun(Base):
@@ -49,4 +50,4 @@ class PipelineRun(Base):
     started_at: Mapped[sa.DateTime] = mapped_column(sa.DateTime)
     finished_at: Mapped[sa.DateTime] = mapped_column(sa.DateTime)
     pipeline: Mapped[str] = mapped_column(sa.Unicode)
-    result: Mapped[PipelineRunResult] = mapped_column(sa.Enum(PipelineRunResult))
+    status: Mapped[PipelineStatus] = mapped_column(sa.Enum(PipelineStatus))

--- a/backend/howtheyvote/pipelines/__init__.py
+++ b/backend/howtheyvote/pipelines/__init__.py
@@ -1,21 +1,11 @@
-from .common import (
-    BasePipeline,
-    DataUnavailableError,
-    DataUnchangedError,
-    PipelineError,
-    PipelineResult,
-)
+from .common import PipelineResult
 from .members import MembersPipeline
 from .press import PressPipeline
 from .rcv_list import RCVListPipeline
 from .sessions import SessionsPipeline
 
 __all__ = [
-    "BasePipeline",
     "PipelineResult",
-    "PipelineError",
-    "DataUnavailableError",
-    "DataUnchangedError",
     "RCVListPipeline",
     "PressPipeline",
     "MembersPipeline",

--- a/backend/howtheyvote/pipelines/__init__.py
+++ b/backend/howtheyvote/pipelines/__init__.py
@@ -1,10 +1,11 @@
-from .common import DataUnavailableError, DataUnchangedError, PipelineError
+from .common import BasePipeline, DataUnavailableError, DataUnchangedError, PipelineError
 from .members import MembersPipeline
 from .press import PressPipeline
 from .rcv_list import RCVListPipeline
 from .sessions import SessionsPipeline
 
 __all__ = [
+    "BasePipeline",
     "PipelineError",
     "DataUnavailableError",
     "DataUnchangedError",

--- a/backend/howtheyvote/pipelines/__init__.py
+++ b/backend/howtheyvote/pipelines/__init__.py
@@ -1,4 +1,4 @@
-from .common import DataUnavailableError, PipelineError
+from .common import DataUnavailableError, DataUnchangedError, PipelineError
 from .members import MembersPipeline
 from .press import PressPipeline
 from .rcv_list import RCVListPipeline
@@ -7,6 +7,7 @@ from .sessions import SessionsPipeline
 __all__ = [
     "PipelineError",
     "DataUnavailableError",
+    "DataUnchangedError",
     "RCVListPipeline",
     "PressPipeline",
     "MembersPipeline",

--- a/backend/howtheyvote/pipelines/__init__.py
+++ b/backend/howtheyvote/pipelines/__init__.py
@@ -1,4 +1,10 @@
-from .common import BasePipeline, DataUnavailableError, DataUnchangedError, PipelineError
+from .common import (
+    BasePipeline,
+    DataUnavailableError,
+    DataUnchangedError,
+    PipelineError,
+    PipelineResult,
+)
 from .members import MembersPipeline
 from .press import PressPipeline
 from .rcv_list import RCVListPipeline
@@ -6,6 +12,7 @@ from .sessions import SessionsPipeline
 
 __all__ = [
     "BasePipeline",
+    "PipelineResult",
     "PipelineError",
     "DataUnavailableError",
     "DataUnchangedError",

--- a/backend/howtheyvote/pipelines/common.py
+++ b/backend/howtheyvote/pipelines/common.py
@@ -1,7 +1,9 @@
+import hashlib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any
 
+from requests import Response
 from structlog import get_logger
 
 from ..models import PipelineStatus
@@ -59,3 +61,8 @@ class BasePipeline(ABC):
     @abstractmethod
     def _run(self) -> None:
         raise NotImplementedError
+
+
+def compute_response_checksum(response: Response) -> str:
+    """Compute the SHA256 hash of the response contents."""
+    return hashlib.sha256(response.content).hexdigest()

--- a/backend/howtheyvote/pipelines/common.py
+++ b/backend/howtheyvote/pipelines/common.py
@@ -4,3 +4,7 @@ class PipelineError(Exception):
 
 class DataUnavailableError(PipelineError):
     pass
+
+
+class DataUnchangedError(PipelineError):
+    pass

--- a/backend/howtheyvote/pipelines/common.py
+++ b/backend/howtheyvote/pipelines/common.py
@@ -1,3 +1,13 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+from structlog import get_logger
+
+from ..scrapers import ScrapingError
+
+log = get_logger(__name__)
+
+
 class PipelineError(Exception):
     pass
 
@@ -8,3 +18,25 @@ class DataUnavailableError(PipelineError):
 
 class DataUnchangedError(PipelineError):
     pass
+
+
+class BasePipeline(ABC):
+    last_run_checksum: str | None
+    checksum: str | None
+
+    def __init__(self, last_run_checksum: str | None = None, **kwargs: Any) -> None:
+        self.last_run_checksum = last_run_checksum
+        self.checksum = None
+        self._log = log.bind(pipeline=type(self).__name__, **kwargs)
+
+    def run(self) -> None:
+        self._log.info("Running pipeline")
+
+        try:
+            self._run()
+        except ScrapingError:
+            self._log.exception("Failed running pipeline")
+
+    @abstractmethod
+    def _run(self) -> None:
+        raise NotImplementedError

--- a/backend/howtheyvote/pipelines/members.py
+++ b/backend/howtheyvote/pipelines/members.py
@@ -13,34 +13,23 @@ from ..scrapers import (
     ScrapingError,
 )
 from ..store import Aggregator, BulkWriter, index_records, map_member
+from .common import BasePipeline
 
 log = get_logger(__name__)
 
 
-class MembersPipeline:
+class MembersPipeline(BasePipeline):
     def __init__(self, term: int):
+        super().__init__(term=term)
         self.term = term
         self._member_ids: set[str] = set()
 
-    def run(self) -> None:
-        log.info(
-            "Running pipeline",
-            name=type(self).__name__,
-            term=self.term,
-        )
-
-        try:
-            self._scrape_members()
-            self._scrape_member_groups()
-            self._scrape_member_infos()
-            self._download_member_photos()
-            self._index_members()
-        except ScrapingError:
-            log.exception(
-                "Failed running pipeline",
-                name=type(self).__name__,
-                term=self.term,
-            )
+    def _run(self) -> None:
+        self._scrape_members()
+        self._scrape_member_groups()
+        self._scrape_member_infos()
+        self._download_member_photos()
+        self._index_members()
 
     def _scrape_members(self) -> None:
         log.info("Scraping RCV lists", term=self.term)

--- a/backend/howtheyvote/pipelines/rcv_list.py
+++ b/backend/howtheyvote/pipelines/rcv_list.py
@@ -27,7 +27,12 @@ from ..scrapers import (
 )
 from ..sharepics import generate_vote_sharepic
 from ..store import Aggregator, BulkWriter, index_records, map_vote, map_vote_group
-from .common import BasePipeline, DataUnavailableError, DataUnchangedError
+from .common import (
+    BasePipeline,
+    DataUnavailableError,
+    DataUnchangedError,
+    compute_response_checksum,
+)
 
 log = get_logger(__name__)
 
@@ -98,13 +103,13 @@ class RCVListPipeline(BasePipeline):
 
         if (
             self.last_run_checksum is not None
-            and self.last_run_checksum == scraper.response_checksum
+            and self.last_run_checksum == compute_response_checksum(scraper.response)
         ):
             raise DataUnchangedError(
                 "The data source hasn't changed since the last pipeline run."
             )
 
-        self.checksum = scraper.response_checksum
+        self.checksum = compute_response_checksum(scraper.response)
 
         writer = BulkWriter()
         writer.add(fragments)

--- a/backend/howtheyvote/pipelines/sessions.py
+++ b/backend/howtheyvote/pipelines/sessions.py
@@ -5,24 +5,21 @@ from structlog import get_logger
 from ..models import PlenarySession
 from ..scrapers import CalendarSessionsScraper, ODPSessionScraper, ScrapingError
 from ..store import Aggregator, BulkWriter, index_records, map_plenary_session
+from .common import BasePipeline
 
 log = get_logger(__name__)
 
 
-class SessionsPipeline:
+class SessionsPipeline(BasePipeline):
     def __init__(self, term: int):
+        super().__init__(term=term)
         self.term = term
         self._session_ids: set[str] = set()
 
-    def run(self) -> None:
-        log.info("Running pipeline", name=type(self).__name__, term=self.term)
-
-        try:
-            self._scrape_sessions()
-            self._scrape_session_locations()
-            self._index_sessions()
-        except ScrapingError:
-            log.exception("Failed running pipeline", name=type(self).__name__, term=self.term)
+    def _run(self) -> None:
+        self._scrape_sessions()
+        self._scrape_session_locations()
+        self._index_sessions()
 
     def _scrape_sessions(self) -> None:
         log.info("Scrapping plenary sessions", term=self.term)

--- a/backend/howtheyvote/scrapers/common.py
+++ b/backend/howtheyvote/scrapers/common.py
@@ -1,3 +1,4 @@
+import hashlib
 import html
 import random
 import time
@@ -94,14 +95,17 @@ ResourceType = TypeVar("ResourceType")
 
 class BaseScraper(ABC, Generic[ResourceType]):
     REQUEST_MAX_RETRIES: int = 0
+    response_checksum: str | None
 
     def __init__(self, request_cache: RequestCache | None = None, **kwargs: Any) -> None:
         self._request_cache = request_cache
         self._log = log.bind(scraper=type(self).__name__, **kwargs)
+        self.response_checksum = None
 
     def run(self) -> Any:
         self._log.info("Running scraper")
         self._response = self._fetch()
+        self.response_checksum = self._compute_checksum(self._response)
         doc = self._parse(self._response)
         return self._extract_data(doc)
 
@@ -163,6 +167,9 @@ class BaseScraper(ABC, Generic[ResourceType]):
             "accept-language": "en-us",
             "user-agent": random.choice(USER_AGENTS),
         }
+
+    def _compute_checksum(self, response: Response) -> str:
+        return hashlib.sha256(response.content).hexdigest()
 
 
 class BeautifulSoupScraper(BaseScraper[BeautifulSoup]):

--- a/backend/howtheyvote/worker/__init__.py
+++ b/backend/howtheyvote/worker/__init__.py
@@ -9,7 +9,7 @@ from .. import config
 from ..db import Session
 from ..export import generate_export
 from ..files import file_path
-from ..models import PipelineRun, PipelineRunResult, PlenarySession
+from ..models import PipelineRun, PlenarySession
 from ..pipelines import MembersPipeline, PressPipeline, RCVListPipeline, SessionsPipeline
 from ..query import session_is_current_at
 from .worker import SkipPipelineError, Weekday, Worker, pipeline_ran_successfully

--- a/backend/howtheyvote/worker/__init__.py
+++ b/backend/howtheyvote/worker/__init__.py
@@ -18,7 +18,13 @@ from ..pipelines import (
     SessionsPipeline,
 )
 from ..query import session_is_current_at
-from .worker import SkipPipelineError, Weekday, Worker, pipeline_ran_successfully
+from .worker import (
+    SkipPipelineError,
+    Weekday,
+    Worker,
+    last_pipeline_run_checksum,
+    pipeline_ran_successfully,
+)
 
 log = get_logger(__name__)
 
@@ -52,7 +58,15 @@ def op_rcv_evening() -> PipelineResult:
     if pipeline_ran_successfully(RCVListPipeline, today, count=2):
         raise SkipPipelineError()
 
-    pipeline = RCVListPipeline(term=config.CURRENT_TERM, date=today)
+    last_run_checksum = last_pipeline_run_checksum(
+        pipeline=RCVListPipeline,
+        date=today,
+    )
+    pipeline = RCVListPipeline(
+        term=config.CURRENT_TERM,
+        date=today,
+        last_run_checksum=last_run_checksum,
+    )
     return pipeline.run()
 
 

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any
 
 from sqlalchemy.orm import DeclarativeBase
@@ -5,3 +6,8 @@ from sqlalchemy.orm import DeclarativeBase
 
 def record_to_dict(record: DeclarativeBase) -> dict[str, Any]:
     return {c.name: getattr(record, c.name) for c in record.__table__.columns}
+
+
+def load_fixture(path: str) -> str:
+    base = Path(__file__).resolve().parent
+    return base.joinpath(path).read_text()

--- a/backend/tests/pipelines/data/rcv-list_pv-9-2024-04-24-rcv-fr-evening.xml
+++ b/backend/tests/pipelines/data/rcv-list_pv-9-2024-04-24-rcv-fr-evening.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PV.RollCallVoteResults xmlns:chart="http://openoffice.org/2000/chart" xmlns:dr3d="http://openoffice.org/2000/dr3d" xmlns:draw="http://openoffice.org/2000/drawing" xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:form="http://openoffice.org/2000/form" xmlns:ino="http://namespaces.softwareag.com/tamino/response2" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:number="http://openoffice.org/2000/datastyle" xmlns:office="http://openoffice.org/2000/office" xmlns:script="http://openoffice.org/2000/script" xmlns:style="http://openoffice.org/2000/style" xmlns:svg="http://www.w3.org/2000/svg" xmlns:table="http://openoffice.org/2000/table" xmlns:text="http://openoffice.org/2000/text" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xql="http://metalab.unc.edu/xql/" Sitting.Identifier="2255" Sitting.Date="2024-04-24" EP.Reference="P9_PV(2024)04-24" EP.Number="PE 762.483" Document.Language="XL">
+  <RollCallVoteResults.PleaseNote>
+    <RollCallVoteResults.PleaseNote.Title>
+      <RollCallVoteResults.PleaseNote.Title.Content Language="FR">AVERTISSEMENT</RollCallVoteResults.PleaseNote.Title.Content>
+      <RollCallVoteResults.PleaseNote.Title.Content Language="EN">NOTICE</RollCallVoteResults.PleaseNote.Title.Content>
+      <RollCallVoteResults.PleaseNote.Title.Content Language="DE">HINWEIS</RollCallVoteResults.PleaseNote.Title.Content>
+    </RollCallVoteResults.PleaseNote.Title>
+    <RollCallVoteResults.PleaseNote.Text>
+      <RollCallVoteResults.PleaseNote.Text.Content Language="FR">Les corrections et intentions de vote sont mentionnées dans ce document sous les points de vote correspondants. Elles sont publiées pour information uniquement et ne modifient en rien le résultat de vote tel qu’annoncé en plénière. Pendant la session, les demandes de corrections et intentions de vote reçues avant 18h30 sont publiées le jour même. Les demandes ultérieures sont publiées à mesure des mises à jour successives de ce document, pendant une durée maximale de deux semaines. Signification des sigles: + (pour), - (contre), 0 (abstention)
+</RollCallVoteResults.PleaseNote.Text.Content>
+      <RollCallVoteResults.PleaseNote.Text.Content Language="EN">Corrections to votes and voting intentions appear below in the section relating to the vote concerned. They are published for information purposes only and do not alter the result of the vote as announced in plenary. During the part-session, requests for corrections to votes and voting intentions received before 18.30 will be published the same day. Subsequent requests will be included in this document each time it is updated in the two weeks following the part-session. Key to symbols: + (in favour), - (against), 0 (abstentions)
+</RollCallVoteResults.PleaseNote.Text.Content>
+      <RollCallVoteResults.PleaseNote.Text.Content Language="DE">In diesem Dokument sind unter den betreffenden Abstimmungspunkten die Berichtigungen des Stimmverhaltens und das beabsichtigte Stimmverhalten aufgeführt. Diese Angaben dienen ausschließlich der Information; keinesfalls wird durch sie das Abstimmungsergebnis geändert, das im Plenum bekannt gegeben wurde. Während der Tagung werden Anträge zu Berichtigungen des Stimmverhaltens und zum beabsichtigten Stimmverhalten, die bis 18.30 Uhr eingehen, am selben Tag veröffentlicht. Später eingehende Anträge werden sukzessive veröffentlicht, indem dieses Dokument während höchstens zwei Wochen regelmäßig aktualisiert wird. Zeichenerklärung: + (dafür), - (dagegen), 0 (Enthaltung)
+</RollCallVoteResults.PleaseNote.Text.Content>
+    </RollCallVoteResults.PleaseNote.Text>
+  </RollCallVoteResults.PleaseNote>
+  <RollCallVoteResults.Titles>
+    <RollCallVoteResults.Title.Text Language="BG">ПРОТОКОЛ<text:line-break/>Резултат от поименни гласувания - Приложение 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="CS">ZÁPIS<text:line-break/>Výsledek jmenovitého hlasování - Příloha 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="DA">PROTOKOL<text:line-break/>Resultat af afstemningerne ved navneopråb - Bilag 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="DE">PROTOKOLL<text:line-break/>Ergebnis der namentlichen Abstimmungen - Anlage 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="EL">ΣΥΝΟΠΤIΚΑ ΠΡΑΚΤIΚΑ<text:line-break/>Αποτέλεσμα των ψηφοφοριών με ονομαστική κλήση - Παράρτηµα 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="EN">MINUTES<text:line-break/>Result of roll-call votes - Annex 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="ES">ACTA<text:line-break/>Resultados de las votaciones nominales - Anexo 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="ET">PROTOKOLL<text:line-break/>Nimelise hääletuse tulemused - lisa 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="FI">PÖYTÄKIRJA<text:line-break/>Nimenhuutoäänestysten tulokset - Liite 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="FR">PROCÈS-VERBAL<text:line-break/>Résultat des votes par appel nominal - Annexe 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="GA">MIONTUAIRISCÍ<text:line-break/>Torthaí na vótála le glaoch rolla - Iarscríbhinn 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="HR">ZAPISNIK<text:line-break/>Rezultat poimeničnog glasovanja - Prilog 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="HU">JEGYZŐKÖNYV<text:line-break/>A név szerinti szavazások eredménye - melléklet 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="IT">PROCESSO VERBALE<text:line-break/>Risultato delle votazioni per appello nominale - Allegato 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="LT">PROTOKOLAS<text:line-break/>Vardinio balsavimo rezultatai - priedas 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="LV">PROTOKOLS<text:line-break/>Rezultāti balsošanai pēc saraksta - pielikums 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="MT">MINUTI<text:line-break/>Riżultat tal-votazzjoni bis-sejħa tal-ismijiet - Anness 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="NL">NOTULEN<text:line-break/>Uitslag van de hoofdelijke stemmingen - Bijlage 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="PL">PROTOKÓŁ<text:line-break/>Wyniki głosowań imiennych - Załącznik 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="PT">ATA<text:line-break/>Resultados das votações nominais - Anexo 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="RO">PROCES-VERBAL<text:line-break/>Rezultatul voturilor prin apel nominal - Anexa 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="SK">ZÁPISNICA<text:line-break/>Výsledok hlasovania podľa mien - Príloha 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="SL">ZAPISNIK<text:line-break/>Izid poimenskega glasovanja - Priloga 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="SV">PROTOKOLL<text:line-break/>Resultat av omröstningarna med namnupprop - Bilaga 2</RollCallVoteResults.Title.Text>
+  </RollCallVoteResults.Titles>
+  <RollCallVote.Result Identifier="168834" DlvId="946131" Date="2024-04-24 12:24:12">
+    <RollCallVote.Description.Text>A9-0163/2024 - Gabriele Bischoff - Article 10, § 6, alinéa 2 - Am 1</RollCallVote.Description.Text>
+    <Result.For Number="1">
+      <Result.PoliticalGroup.List Identifier="PPE">
+        <PoliticalGroup.Member.Name MepId="6883" PersId="197490">Adamowicz</PoliticalGroup.Member.Name>
+      </Result.PoliticalGroup.List>
+    </Result.For>
+  </RollCallVote.Result>
+  <RollCallVote.Result Identifier="168864" DlvId="946098" Date="2024-04-24 17:18:07">
+    <RollCallVote.Description.Text>C9-0120/2024 - Rejet - Am 13= 23=</RollCallVote.Description.Text>
+    <Result.Against Number="1">
+      <Result.PoliticalGroup.List Identifier="PPE">
+        <PoliticalGroup.Member.Name MepId="6883" PersId="197490">Adamowicz</PoliticalGroup.Member.Name>
+      </Result.PoliticalGroup.List>
+    </Result.Against>
+  </RollCallVote.Result>
+  <VoteTitles>
+    <VoteTitle DlvId="946131">Amendments to Parliament’s Rules of Procedure concerning the training on preventing conflict and harassment in the workplace and on good office management</VoteTitle>
+    <VoteTitle DlvId="946098">Good agricultural and environmental condition standards, schemes for climate, environment and animal welfare</VoteTitle>
+  </VoteTitles>
+  <Glossary>
+    <Term Code="100">
+      <Text lang="DE">BERICHTIGUNGEN DES STIMMVERHALTENS UND BEABSICHTIGTES STIMMVERHALTEN</Text>
+      <Text lang="SV">RÄTTELSER/AVSIKTSFÖRKLARINGAR TILL AVGIVNA RÖSTER</Text>
+      <Text lang="FI">ÄÄNESTYSKÄYTTÄYTYMISTÄ JA ÄÄNESTYSAIKEITA KOSKEVAT ILMOITUKSET</Text>
+      <Text lang="PT">CORREÇÕES E INTENÇÕES DE VOTO</Text>
+      <Text lang="BG">ПОПРАВКИ В ПОДАДЕНИТЕ ГЛАСОВЕ И НАМЕРЕНИЯ ЗА ГЛАСУВАНЕ</Text>
+      <Text lang="MT">KORREZZJONIJIET U INTENZJONIJIET GĦALL-VOT</Text>
+      <Text lang="EL">ΔΙΟΡΘΩΣΕΙΣ ΚΑΙ ΠΡΟΘΕΣΕΙΣ ΨΗΦΟΥ</Text>
+      <Text lang="LT">BALSAVIMO PATAISYMAI IR KETINIMAI</Text>
+      <Text lang="EN">CORRECTIONS TO VOTES AND VOTING INTENTIONS</Text>
+      <Text lang="LV">BALSOJUMU LABOJUMI UN NODOMI BALSOT</Text>
+      <Text lang="HR">IZMJENE DANIH GLASOVA I NAMJERE GLASAČA</Text>
+      <Text lang="IT">CORREZIONI E INTENZIONI DI VOTO</Text>
+      <Text lang="FR">CORRECTIONS ET INTENTIONS DE VOTE</Text>
+      <Text lang="HU">SZAVAZATOK HELYESBÍTÉSEI ÉS SZAVAZÁSI SZÁNDÉKOK</Text>
+      <Text lang="ES">CORRECCIONES E INTENCIONES DE VOTO</Text>
+      <Text lang="ET">HÄÄLETUSE PARANDUSED JA HÄÄLETUSKAVATSUSED</Text>
+      <Text lang="CS">OPRAVY HLASOVÁNÍ A SDĚLENÍ O ÚMYSLU HLASOVAT</Text>
+      <Text lang="SK">OPRAVY HLASOVANIA A ZÁMERY PRI HLASOVANÍ</Text>
+      <Text lang="SL">POPRAVKI IN NAMERE GLASOVANJA</Text>
+      <Text lang="GA">CEARTÚCHÁIN AR AN VÓTA AGUS INTINNÍ VÓTÁLA</Text>
+      <Text lang="PL">KOREKTY GŁOSOWANIA I ZAMIAR GŁOSOWANIA</Text>
+      <Text lang="RO">CORECTĂRI ŞI INTENŢII DE VOT</Text>
+      <Text lang="DA">STEMMERETTELSER OG -INTENTIONER</Text>
+      <Text lang="NL">RECTIFICATIES STEMGEDRAG/ VOORGENOMEN STEMGEDRAG</Text>
+    </Term>
+  </Glossary>
+</PV.RollCallVoteResults>

--- a/backend/tests/pipelines/data/rcv-list_pv-9-2024-04-24-rcv-fr-noon.xml
+++ b/backend/tests/pipelines/data/rcv-list_pv-9-2024-04-24-rcv-fr-noon.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PV.RollCallVoteResults xmlns:chart="http://openoffice.org/2000/chart" xmlns:dr3d="http://openoffice.org/2000/dr3d" xmlns:draw="http://openoffice.org/2000/drawing" xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:form="http://openoffice.org/2000/form" xmlns:ino="http://namespaces.softwareag.com/tamino/response2" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:number="http://openoffice.org/2000/datastyle" xmlns:office="http://openoffice.org/2000/office" xmlns:script="http://openoffice.org/2000/script" xmlns:style="http://openoffice.org/2000/style" xmlns:svg="http://www.w3.org/2000/svg" xmlns:table="http://openoffice.org/2000/table" xmlns:text="http://openoffice.org/2000/text" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xql="http://metalab.unc.edu/xql/" Sitting.Identifier="2255" Sitting.Date="2024-04-24" EP.Reference="P9_PV(2024)04-24" EP.Number="PE 762.483" Document.Language="XL">
+  <RollCallVoteResults.PleaseNote>
+    <RollCallVoteResults.PleaseNote.Title>
+      <RollCallVoteResults.PleaseNote.Title.Content Language="FR">AVERTISSEMENT</RollCallVoteResults.PleaseNote.Title.Content>
+      <RollCallVoteResults.PleaseNote.Title.Content Language="EN">NOTICE</RollCallVoteResults.PleaseNote.Title.Content>
+      <RollCallVoteResults.PleaseNote.Title.Content Language="DE">HINWEIS</RollCallVoteResults.PleaseNote.Title.Content>
+    </RollCallVoteResults.PleaseNote.Title>
+    <RollCallVoteResults.PleaseNote.Text>
+      <RollCallVoteResults.PleaseNote.Text.Content Language="FR">Les corrections et intentions de vote sont mentionnées dans ce document sous les points de vote correspondants. Elles sont publiées pour information uniquement et ne modifient en rien le résultat de vote tel qu’annoncé en plénière. Pendant la session, les demandes de corrections et intentions de vote reçues avant 18h30 sont publiées le jour même. Les demandes ultérieures sont publiées à mesure des mises à jour successives de ce document, pendant une durée maximale de deux semaines. Signification des sigles: + (pour), - (contre), 0 (abstention)
+</RollCallVoteResults.PleaseNote.Text.Content>
+      <RollCallVoteResults.PleaseNote.Text.Content Language="EN">Corrections to votes and voting intentions appear below in the section relating to the vote concerned. They are published for information purposes only and do not alter the result of the vote as announced in plenary. During the part-session, requests for corrections to votes and voting intentions received before 18.30 will be published the same day. Subsequent requests will be included in this document each time it is updated in the two weeks following the part-session. Key to symbols: + (in favour), - (against), 0 (abstentions)
+</RollCallVoteResults.PleaseNote.Text.Content>
+      <RollCallVoteResults.PleaseNote.Text.Content Language="DE">In diesem Dokument sind unter den betreffenden Abstimmungspunkten die Berichtigungen des Stimmverhaltens und das beabsichtigte Stimmverhalten aufgeführt. Diese Angaben dienen ausschließlich der Information; keinesfalls wird durch sie das Abstimmungsergebnis geändert, das im Plenum bekannt gegeben wurde. Während der Tagung werden Anträge zu Berichtigungen des Stimmverhaltens und zum beabsichtigten Stimmverhalten, die bis 18.30 Uhr eingehen, am selben Tag veröffentlicht. Später eingehende Anträge werden sukzessive veröffentlicht, indem dieses Dokument während höchstens zwei Wochen regelmäßig aktualisiert wird. Zeichenerklärung: + (dafür), - (dagegen), 0 (Enthaltung)
+</RollCallVoteResults.PleaseNote.Text.Content>
+    </RollCallVoteResults.PleaseNote.Text>
+  </RollCallVoteResults.PleaseNote>
+  <RollCallVoteResults.Titles>
+    <RollCallVoteResults.Title.Text Language="BG">ПРОТОКОЛ<text:line-break/>Резултат от поименни гласувания - Приложение 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="CS">ZÁPIS<text:line-break/>Výsledek jmenovitého hlasování - Příloha 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="DA">PROTOKOL<text:line-break/>Resultat af afstemningerne ved navneopråb - Bilag 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="DE">PROTOKOLL<text:line-break/>Ergebnis der namentlichen Abstimmungen - Anlage 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="EL">ΣΥΝΟΠΤIΚΑ ΠΡΑΚΤIΚΑ<text:line-break/>Αποτέλεσμα των ψηφοφοριών με ονομαστική κλήση - Παράρτηµα 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="EN">MINUTES<text:line-break/>Result of roll-call votes - Annex 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="ES">ACTA<text:line-break/>Resultados de las votaciones nominales - Anexo 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="ET">PROTOKOLL<text:line-break/>Nimelise hääletuse tulemused - lisa 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="FI">PÖYTÄKIRJA<text:line-break/>Nimenhuutoäänestysten tulokset - Liite 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="FR">PROCÈS-VERBAL<text:line-break/>Résultat des votes par appel nominal - Annexe 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="GA">MIONTUAIRISCÍ<text:line-break/>Torthaí na vótála le glaoch rolla - Iarscríbhinn 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="HR">ZAPISNIK<text:line-break/>Rezultat poimeničnog glasovanja - Prilog 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="HU">JEGYZŐKÖNYV<text:line-break/>A név szerinti szavazások eredménye - melléklet 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="IT">PROCESSO VERBALE<text:line-break/>Risultato delle votazioni per appello nominale - Allegato 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="LT">PROTOKOLAS<text:line-break/>Vardinio balsavimo rezultatai - priedas 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="LV">PROTOKOLS<text:line-break/>Rezultāti balsošanai pēc saraksta - pielikums 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="MT">MINUTI<text:line-break/>Riżultat tal-votazzjoni bis-sejħa tal-ismijiet - Anness 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="NL">NOTULEN<text:line-break/>Uitslag van de hoofdelijke stemmingen - Bijlage 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="PL">PROTOKÓŁ<text:line-break/>Wyniki głosowań imiennych - Załącznik 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="PT">ATA<text:line-break/>Resultados das votações nominais - Anexo 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="RO">PROCES-VERBAL<text:line-break/>Rezultatul voturilor prin apel nominal - Anexa 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="SK">ZÁPISNICA<text:line-break/>Výsledok hlasovania podľa mien - Príloha 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="SL">ZAPISNIK<text:line-break/>Izid poimenskega glasovanja - Priloga 2</RollCallVoteResults.Title.Text>
+    <RollCallVoteResults.Title.Text Language="SV">PROTOKOLL<text:line-break/>Resultat av omröstningarna med namnupprop - Bilaga 2</RollCallVoteResults.Title.Text>
+  </RollCallVoteResults.Titles>
+  <RollCallVote.Result Identifier="168834" DlvId="946131" Date="2024-04-24 12:24:12">
+    <RollCallVote.Description.Text>A9-0163/2024 - Gabriele Bischoff - Article 10, § 6, alinéa 2 - Am 1</RollCallVote.Description.Text>
+    <Result.For Number="1">
+      <Result.PoliticalGroup.List Identifier="PPE">
+        <PoliticalGroup.Member.Name MepId="6883" PersId="197490">Adamowicz</PoliticalGroup.Member.Name>
+      </Result.PoliticalGroup.List>
+    </Result.For>
+  </RollCallVote.Result>
+  <VoteTitles>
+    <VoteTitle DlvId="946131">Amendments to Parliament’s Rules of Procedure concerning the training on preventing conflict and harassment in the workplace and on good office management</VoteTitle>
+  </VoteTitles>
+  <Glossary>
+    <Term Code="100">
+      <Text lang="DE">BERICHTIGUNGEN DES STIMMVERHALTENS UND BEABSICHTIGTES STIMMVERHALTEN</Text>
+      <Text lang="SV">RÄTTELSER/AVSIKTSFÖRKLARINGAR TILL AVGIVNA RÖSTER</Text>
+      <Text lang="FI">ÄÄNESTYSKÄYTTÄYTYMISTÄ JA ÄÄNESTYSAIKEITA KOSKEVAT ILMOITUKSET</Text>
+      <Text lang="PT">CORREÇÕES E INTENÇÕES DE VOTO</Text>
+      <Text lang="BG">ПОПРАВКИ В ПОДАДЕНИТЕ ГЛАСОВЕ И НАМЕРЕНИЯ ЗА ГЛАСУВАНЕ</Text>
+      <Text lang="MT">KORREZZJONIJIET U INTENZJONIJIET GĦALL-VOT</Text>
+      <Text lang="EL">ΔΙΟΡΘΩΣΕΙΣ ΚΑΙ ΠΡΟΘΕΣΕΙΣ ΨΗΦΟΥ</Text>
+      <Text lang="LT">BALSAVIMO PATAISYMAI IR KETINIMAI</Text>
+      <Text lang="EN">CORRECTIONS TO VOTES AND VOTING INTENTIONS</Text>
+      <Text lang="LV">BALSOJUMU LABOJUMI UN NODOMI BALSOT</Text>
+      <Text lang="HR">IZMJENE DANIH GLASOVA I NAMJERE GLASAČA</Text>
+      <Text lang="IT">CORREZIONI E INTENZIONI DI VOTO</Text>
+      <Text lang="FR">CORRECTIONS ET INTENTIONS DE VOTE</Text>
+      <Text lang="HU">SZAVAZATOK HELYESBÍTÉSEI ÉS SZAVAZÁSI SZÁNDÉKOK</Text>
+      <Text lang="ES">CORRECCIONES E INTENCIONES DE VOTO</Text>
+      <Text lang="ET">HÄÄLETUSE PARANDUSED JA HÄÄLETUSKAVATSUSED</Text>
+      <Text lang="CS">OPRAVY HLASOVÁNÍ A SDĚLENÍ O ÚMYSLU HLASOVAT</Text>
+      <Text lang="SK">OPRAVY HLASOVANIA A ZÁMERY PRI HLASOVANÍ</Text>
+      <Text lang="SL">POPRAVKI IN NAMERE GLASOVANJA</Text>
+      <Text lang="GA">CEARTÚCHÁIN AR AN VÓTA AGUS INTINNÍ VÓTÁLA</Text>
+      <Text lang="PL">KOREKTY GŁOSOWANIA I ZAMIAR GŁOSOWANIA</Text>
+      <Text lang="RO">CORECTĂRI ŞI INTENŢII DE VOT</Text>
+      <Text lang="DA">STEMMERETTELSER OG -INTENTIONER</Text>
+      <Text lang="NL">RECTIFICATIES STEMGEDRAG/ VOORGENOMEN STEMGEDRAG</Text>
+    </Term>
+  </Glossary>
+</PV.RollCallVoteResults>

--- a/backend/tests/pipelines/test_rcv_list.py
+++ b/backend/tests/pipelines/test_rcv_list.py
@@ -1,8 +1,12 @@
 import datetime
 
 import pytest
+from sqlalchemy import select
 
-from howtheyvote.pipelines import DataUnavailableError, RCVListPipeline
+from howtheyvote.models import Group, GroupMembership, Member, Vote
+from howtheyvote.pipelines import DataUnavailableError, DataUnchangedError, RCVListPipeline
+
+from ..helpers import load_fixture
 
 
 @pytest.mark.always_mock_requests
@@ -10,3 +14,63 @@ def test_run_source_not_available(responses, db_session):
     with pytest.raises(DataUnavailableError):
         pipe = RCVListPipeline(term=9, date=datetime.date(2024, 4, 10))
         pipe.run()
+
+
+def test_run_data_unchanged(responses, db_session):
+    responses.get(
+        "https://www.europarl.europa.eu/doceo/document/PV-9-2024-04-24-RCV_FR.xml",
+        body=load_fixture("pipelines/data/rcv-list_pv-9-2024-04-24-rcv-fr-noon.xml"),
+    )
+
+    member = Member(
+        id=197490,
+        first_name="Magdalena",
+        last_name="ADAMOWICZ",
+        group_memberships=[
+            GroupMembership(
+                term=9,
+                start_date=datetime.datetime(2019, 7, 2),
+                end_date=datetime.datetime(2024, 7, 15),
+                group=Group["EPP"],
+            ),
+        ],
+    )
+    db_session.add(member)
+    db_session.commit()
+
+    # Run the pipeline for the first time
+    pipe = RCVListPipeline(
+        term=9,
+        date=datetime.date(2024, 4, 24),
+    )
+    pipe.run()
+    last_run_checksum = pipe.checksum
+
+    vote_ids = list(db_session.execute(select(Vote.id)).scalars())
+    assert vote_ids == [168834]
+
+    # Run the pipeline again and provide the checksum of the first run
+    with pytest.raises(DataUnchangedError):
+        pipe = RCVListPipeline(
+            term=9,
+            date=datetime.date(2024, 4, 24),
+            last_run_checksum=last_run_checksum,
+        )
+        pipe.run()
+
+    # Simulate that the source data has been updated in the meantime
+    responses.get(
+        "https://www.europarl.europa.eu/doceo/document/PV-9-2024-04-24-RCV_FR.xml",
+        body=load_fixture("pipelines/data/rcv-list_pv-9-2024-04-24-rcv-fr-evening.xml"),
+    )
+
+    # Run the pipeline again and provide the checksum of the first run
+    pipe = RCVListPipeline(
+        term=9,
+        date=datetime.date(2024, 4, 24),
+        last_run_checksum=last_run_checksum,
+    )
+    pipe.run()
+
+    vote_ids = list(db_session.execute(select(Vote.id)).scalars())
+    assert vote_ids == [168834, 168864]

--- a/backend/tests/pipelines/test_rcv_list.py
+++ b/backend/tests/pipelines/test_rcv_list.py
@@ -3,17 +3,17 @@ import datetime
 import pytest
 from sqlalchemy import select
 
-from howtheyvote.models import Group, GroupMembership, Member, Vote
-from howtheyvote.pipelines import DataUnavailableError, DataUnchangedError, RCVListPipeline
+from howtheyvote.models import Group, GroupMembership, Member, PipelineStatus, Vote
+from howtheyvote.pipelines import RCVListPipeline
 
 from ..helpers import load_fixture
 
 
 @pytest.mark.always_mock_requests
 def test_run_source_not_available(responses, db_session):
-    with pytest.raises(DataUnavailableError):
-        pipe = RCVListPipeline(term=9, date=datetime.date(2024, 4, 10))
-        pipe.run()
+    pipe = RCVListPipeline(term=9, date=datetime.date(2024, 4, 10))
+    result = pipe.run()
+    assert result.status == PipelineStatus.DATA_UNAVAILABLE
 
 
 def test_run_data_unchanged(responses, db_session):
@@ -43,20 +43,24 @@ def test_run_data_unchanged(responses, db_session):
         term=9,
         date=datetime.date(2024, 4, 24),
     )
-    pipe.run()
-    last_run_checksum = pipe.checksum
+    result = pipe.run()
+    assert result.status == PipelineStatus.SUCCESS
+    assert (
+        result.checksum == "c01379e8e00e9d8e60c71eebf90941c3318be9751a911d4f08b24aa9d0be26af"
+    )
 
     vote_ids = list(db_session.execute(select(Vote.id)).scalars())
     assert vote_ids == [168834]
 
     # Run the pipeline again and provide the checksum of the first run
-    with pytest.raises(DataUnchangedError):
-        pipe = RCVListPipeline(
-            term=9,
-            date=datetime.date(2024, 4, 24),
-            last_run_checksum=last_run_checksum,
-        )
-        pipe.run()
+    pipe = RCVListPipeline(
+        term=9,
+        date=datetime.date(2024, 4, 24),
+        last_run_checksum="c01379e8e00e9d8e60c71eebf90941c3318be9751a911d4f08b24aa9d0be26af",
+    )
+    result = pipe.run()
+    assert result.status == PipelineStatus.DATA_UNCHANGED
+    assert result.checksum is None
 
     # Simulate that the source data has been updated in the meantime
     responses.get(
@@ -68,9 +72,13 @@ def test_run_data_unchanged(responses, db_session):
     pipe = RCVListPipeline(
         term=9,
         date=datetime.date(2024, 4, 24),
-        last_run_checksum=last_run_checksum,
+        last_run_checksum="c01379e8e00e9d8e60c71eebf90941c3318be9751a911d4f08b24aa9d0be26af",
     )
-    pipe.run()
+    result = pipe.run()
+    assert result.status == PipelineStatus.SUCCESS
+    assert (
+        result.checksum == "743bf734045d7c797afea9e8c1127c047a4924bcd5090883ff8a74421376d511"
+    )
 
     vote_ids = list(db_session.execute(select(Vote.id)).scalars())
     assert vote_ids == [168834, 168864]

--- a/backend/tests/scrapers/helpers.py
+++ b/backend/tests/scrapers/helpers.py
@@ -1,7 +1,0 @@
-from pathlib import Path
-
-FIXTURES_BASE = Path(__file__).resolve().parent / "data"
-
-
-def load_fixture(path: str) -> str:
-    return FIXTURES_BASE.joinpath(path).read_text()

--- a/backend/tests/scrapers/test_members.py
+++ b/backend/tests/scrapers/test_members.py
@@ -1,17 +1,14 @@
 from datetime import date
-from pathlib import Path
 
 from howtheyvote.scrapers import MemberGroupsScraper, MemberInfoScraper, MembersScraper
 
-from .helpers import load_fixture
-
-TEST_DATA_DIR = Path(__file__).resolve().parent / "data"
+from ..helpers import load_fixture
 
 
 def test_members_scraper(responses):
     responses.get(
         "https://www.europarl.europa.eu/meps/en/directory/xml/?leg=9",
-        body=load_fixture("members/members_directory_term_9.xml"),
+        body=load_fixture("scrapers/data/members/members_directory_term_9.xml"),
     )
 
     scraper = MembersScraper(term=9)
@@ -27,7 +24,7 @@ def test_members_scraper(responses):
 def test_member_info_scraper(responses):
     responses.get(
         "https://www.europarl.europa.eu/meps/en/124834/NAME/home",
-        body=load_fixture("members/member_info_sonneborn_home.html"),
+        body=load_fixture("scrapers/data/members/member_info_sonneborn_home.html"),
     )
 
     scraper = MemberInfoScraper(web_id=124834)
@@ -48,7 +45,7 @@ def test_member_info_scraper(responses):
 def test_member_info_scraper_date_of_birth_without(responses):
     responses.get(
         "https://www.europarl.europa.eu/meps/en/124831/NAME/home",
-        body=load_fixture("members/member_info_adinolfi_home.html"),
+        body=load_fixture("scrapers/data/members/member_info_adinolfi_home.html"),
     )
 
     scraper = MemberInfoScraper(web_id=124831)
@@ -59,7 +56,7 @@ def test_member_info_scraper_date_of_birth_without(responses):
 def test_member_info_scraper_multiple_emails(responses):
     responses.get(
         "https://www.europarl.europa.eu/meps/en/28229/NAME/home",
-        body=load_fixture("members/member_info_weber_home.html"),
+        body=load_fixture("scrapers/data/members/member_info_weber_home.html"),
     )
 
     scraper = MemberInfoScraper(web_id=28229)
@@ -70,7 +67,7 @@ def test_member_info_scraper_multiple_emails(responses):
 def test_member_info_scraper_no_social_media(responses):
     responses.get(
         "https://www.europarl.europa.eu/meps/en/124831/NAME/home",
-        body=load_fixture("members/member_info_adinolfi_home.html"),
+        body=load_fixture("scrapers/data/members/member_info_adinolfi_home.html"),
     )
 
     scraper = MemberInfoScraper(web_id=124831)
@@ -81,7 +78,7 @@ def test_member_info_scraper_no_social_media(responses):
 def test_member_groups_scraper(responses):
     responses.get(
         "https://www.europarl.europa.eu/meps/en/124831/NAME/history/8",
-        body=load_fixture("members/member_groups_adinolfi_term_8.html"),
+        body=load_fixture("scrapers/data/members/member_groups_adinolfi_term_8.html"),
     )
 
     scraper = MemberGroupsScraper(web_id=124831, term=8)
@@ -114,7 +111,7 @@ def test_member_groups_scraper(responses):
 def test_member_groups_scraper_ongoing(responses):
     responses.get(
         "https://www.europarl.europa.eu/meps/en/28229/NAME/history/10",
-        body=load_fixture("members/member_groups_weber_term_10.html"),
+        body=load_fixture("scrapers/data/members/member_groups_weber_term_10.html"),
     )
 
     scraper = MemberGroupsScraper(web_id=28229, term=10)

--- a/backend/tests/scrapers/test_sessions.py
+++ b/backend/tests/scrapers/test_sessions.py
@@ -3,13 +3,13 @@ import datetime
 from howtheyvote.models import PlenarySessionLocation
 from howtheyvote.scrapers import ODPSessionScraper
 
-from .helpers import load_fixture
+from ..helpers import load_fixture
 
 
 def test_odp_session_scraper(responses):
     responses.get(
         "https://data.europarl.europa.eu/api/v1/meetings/MTG-PL-2024-07-16",
-        body=load_fixture("sessions/odp_mtg-pl-2024-07-16.xml"),
+        body=load_fixture("scrapers/data/sessions/odp_mtg-pl-2024-07-16.xml"),
     )
 
     scraper = ODPSessionScraper(start_date=datetime.date(2024, 7, 16))

--- a/backend/tests/scrapers/test_votes.py
+++ b/backend/tests/scrapers/test_votes.py
@@ -11,15 +11,14 @@ from howtheyvote.scrapers.votes import (
     RCVListScraper,
 )
 
-from ..helpers import record_to_dict
-from .helpers import load_fixture
+from ..helpers import load_fixture, record_to_dict
 
 
 @pytest.mark.always_mock_requests
 def test_rcv_list_scraper(responses):
     responses.get(
         "https://www.europarl.europa.eu/doceo/document/PV-9-2020-07-23-RCV_FR.xml",
-        body=load_fixture("votes/rcv_list_pv-9-2020-07-23-rcv-fr.xml"),
+        body=load_fixture("scrapers/data/votes/rcv_list_pv-9-2020-07-23-rcv-fr.xml"),
     )
 
     scraper = RCVListScraper(
@@ -65,7 +64,7 @@ def test_rcv_list_scraper(responses):
 def test_rcv_list_scraper_incorrect_totals(responses):
     responses.get(
         "https://www.europarl.europa.eu/doceo/document/PV-9-2020-07-23-RCV_FR.xml",
-        body=load_fixture("votes/rcv_list_incorrect_pv-9-2020-07-23-rcv-fr.xml"),
+        body=load_fixture("scrapers/data/votes/rcv_list_incorrect_pv-9-2020-07-23-rcv-fr.xml"),
     )
 
     scraper = RCVListScraper(
@@ -88,7 +87,7 @@ def test_rcv_list_scraper_incorrect_totals(responses):
 def test_rcv_list_scraper_did_not_vote(responses):
     responses.get(
         "https://www.europarl.europa.eu/doceo/document/PV-9-2020-07-23-RCV_FR.xml",
-        body=load_fixture("votes/rcv_list_pv-9-2020-07-23-rcv-fr.xml"),
+        body=load_fixture("scrapers/data/votes/rcv_list_pv-9-2020-07-23-rcv-fr.xml"),
     )
 
     scraper = RCVListScraper(
@@ -118,7 +117,7 @@ def test_rcv_list_scraper_did_not_vote(responses):
 def test_rcv_list_scraper_same_name(responses):
     responses.get(
         "https://www.europarl.europa.eu/doceo/document/PV-9-2020-09-15-RCV_FR.xml",
-        body=load_fixture("votes/rcv_list_pv-9-2020-09-15-rcv-fr.xml"),
+        body=load_fixture("scrapers/data/votes/rcv_list_pv-9-2020-09-15-rcv-fr.xml"),
     )
 
     scraper = RCVListScraper(
@@ -144,7 +143,7 @@ def test_rcv_list_scraper_same_name(responses):
 def test_rcv_list_scraper_pers_id(responses):
     responses.get(
         "https://www.europarl.europa.eu/doceo/document/PV-9-2023-12-12-RCV_FR.xml",
-        body=load_fixture("votes/rcv_list_pv-9-2023-12-12-rcv-fr.xml"),
+        body=load_fixture("scrapers/data/votes/rcv_list_pv-9-2023-12-12-rcv-fr.xml"),
     )
 
     # The voting list has a different spelling ("Glueck" instead of "Glück"). Cases like this
@@ -171,7 +170,7 @@ def test_rcv_list_scraper_pers_id(responses):
 def test_rcv_list_scraper_pers_id_unknown(responses):
     responses.get(
         "https://www.europarl.europa.eu/doceo/document/PV-9-2023-12-12-RCV_FR.xml",
-        body=load_fixture("votes/rcv_list_pv-9-2023-12-12-rcv-fr.xml"),
+        body=load_fixture("scrapers/data/votes/rcv_list_pv-9-2023-12-12-rcv-fr.xml"),
     )
 
     scraper = RCVListScraper(
@@ -192,7 +191,7 @@ def test_rcv_list_scraper_document_register(responses):
     )
     register_mock = responses.get(
         "https://www.europarl.europa.eu/RegData/seance_pleniere/proces_verbal/2020/07-23/liste_presence/P9_PV(2020)07-23(RCV)_XC.xml",
-        body=load_fixture("votes/rcv_list_p9-pv(2020)07-23(rcv)_xc.xml"),
+        body=load_fixture("scrapers/data/votes/rcv_list_p9-pv(2020)07-23(rcv)_xc.xml"),
     )
 
     scraper = RCVListScraper(
@@ -216,7 +215,7 @@ def test_rcv_list_scraper_document_register(responses):
 def test_rcv_list_scraper_timestamp_from_text(responses):
     responses.get(
         "https://www.europarl.europa.eu/doceo/document/PV-9-2019-07-15-RCV_FR.xml",
-        body=load_fixture("votes/rcv_list_pv-9-2019-07-15-rcv-fr.xml"),
+        body=load_fixture("scrapers/data/votes/rcv_list_pv-9-2019-07-15-rcv-fr.xml"),
     )
 
     scraper = RCVListScraper(
@@ -234,7 +233,7 @@ def test_rcv_list_scraper_timestamp_from_text(responses):
 def test_procedure_scraper(responses):
     responses.get(
         "https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2023/2019(INI)",
-        body=load_fixture("votes/oeil-procedure-file_2023-2019-ini.html"),
+        body=load_fixture("scrapers/data/votes/oeil-procedure-file_2023-2019-ini.html"),
     )
 
     scraper = ProcedureScraper(vote_id=162214, procedure_reference="2023/2019(INI)")
@@ -258,7 +257,7 @@ def test_procedure_scraper(responses):
 def test_procedure_scraper_geo_areas(responses):
     responses.get(
         "https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2022/2852(RSP)",
-        body=load_fixture("votes/oeil-procedure-file_2022-2852-rsp.html"),
+        body=load_fixture("scrapers/data/votes/oeil-procedure-file_2022-2852-rsp.html"),
     )
 
     scraper = ProcedureScraper(vote_id=149218, procedure_reference="2022/2852(RSP)")
@@ -269,7 +268,7 @@ def test_procedure_scraper_geo_areas(responses):
 def test_procedure_scraper_geo_areas_fuzzy(responses):
     responses.get(
         "https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2022/2201(INI)",
-        body=load_fixture("votes/oeil-procedure-file_2022-2201-ini.html"),
+        body=load_fixture("scrapers/data/votes/oeil-procedure-file_2022-2201-ini.html"),
     )
 
     scraper = ProcedureScraper(vote_id=155056, procedure_reference="2022/2201(INI)")
@@ -280,7 +279,7 @@ def test_procedure_scraper_geo_areas_fuzzy(responses):
 def test_eurlex_procedure_scraper_eurovoc_concepts(responses):
     responses.get(
         "https://eur-lex.europa.eu/procedure/EN/2021_106",
-        body=load_fixture("votes/eurlex-procedure_2021-106.html"),
+        body=load_fixture("scrapers/data/votes/eurlex-procedure_2021-106.html"),
     )
 
     scraper = EurlexProcedureScraper(vote_id=166051, procedure_reference="2021/0106(COD)")
@@ -304,7 +303,7 @@ def test_eurlex_procedure_scraper_eurovoc_concepts(responses):
 def test_eurlex_procedure_scraper_geo_areas(responses):
     responses.get(
         "https://eur-lex.europa.eu/procedure/EN/2023_102",
-        body=load_fixture("votes/eurlex-procedure_2023-102.html"),
+        body=load_fixture("scrapers/data/votes/eurlex-procedure_2023-102.html"),
     )
 
     scraper = EurlexProcedureScraper(vote_id=161383, procedure_reference="2023/0102(NLE)")
@@ -326,7 +325,7 @@ def test_eurlex_procedure_scraper_geo_areas(responses):
 def test_eurlex_document_scraper_eurovoc_concepts(responses):
     responses.get(
         "https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=EP:P9_A(2021)0270",
-        body=load_fixture("votes/eurlex-document_p9-a-2021-0270.html"),
+        body=load_fixture("scrapers/data/votes/eurlex-document_p9-a-2021-0270.html"),
     )
 
     scraper = EurlexDocumentScraper(vote_id=136238, reference="A9-0270/2021")
@@ -348,7 +347,7 @@ def test_eurlex_document_scraper_eurovoc_concepts(responses):
 def test_eurlex_document_scraper_geo_areas(responses):
     responses.get(
         "https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=EP:P9_A(2023)0369",
-        body=load_fixture("votes/eurlex-document_p9-a-2023-0369.html"),
+        body=load_fixture("scrapers/data/votes/eurlex-document_p9-a-2023-0369.html"),
     )
 
     scraper = EurlexDocumentScraper(vote_id=136238, reference="A9-0369/2023")

--- a/backend/tests/worker/test_worker.py
+++ b/backend/tests/worker/test_worker.py
@@ -3,7 +3,7 @@ import datetime
 import time_machine
 from sqlalchemy import select
 
-from howtheyvote.models import PipelineRun, PipelineRunResult
+from howtheyvote.models import PipelineRun, PipelineStatus
 from howtheyvote.pipelines import DataUnavailableError, PipelineError
 from howtheyvote.worker.worker import Weekday, Worker, pipeline_ran_successfully
 
@@ -133,7 +133,7 @@ def test_worker_schedule_pipeline_log_runs(db_session):
 
         run = runs[0]
         assert run.pipeline == "test"
-        assert run.result == PipelineRunResult.SUCCESS
+        assert run.status == PipelineStatus.SUCCESS
         assert run.started_at.date() == datetime.date(2024, 1, 1)
         assert run.finished_at.date() == datetime.date(2024, 1, 1)
 
@@ -166,10 +166,10 @@ def test_worker_schedule_pipeline_log_runs_exceptions(db_session):
         assert len(runs) == 2
 
         assert runs[0].pipeline == "data_unavailable_error"
-        assert runs[0].result == PipelineRunResult.DATA_UNAVAILABLE
+        assert runs[0].status == PipelineStatus.DATA_UNAVAILABLE
 
         assert runs[1].pipeline == "pipeline_error"
-        assert runs[1].result == PipelineRunResult.FAILURE
+        assert runs[1].status == PipelineStatus.FAILURE
 
 
 def test_pipeline_ran_successfully(db_session):
@@ -183,7 +183,7 @@ def test_pipeline_ran_successfully(db_session):
         started_at=now,
         finished_at=now,
         pipeline=TestPipeline.__name__,
-        result=PipelineRunResult.FAILURE,
+        status=PipelineStatus.FAILURE,
     )
     db_session.add(run)
     db_session.commit()
@@ -194,7 +194,7 @@ def test_pipeline_ran_successfully(db_session):
         started_at=now,
         finished_at=now,
         pipeline=TestPipeline.__name__,
-        result=PipelineRunResult.SUCCESS,
+        status=PipelineStatus.SUCCESS,
     )
     db_session.add(run)
     db_session.commit()
@@ -206,7 +206,7 @@ def test_pipeline_ran_successfully(db_session):
         started_at=now,
         finished_at=now,
         pipeline=TestPipeline.__name__,
-        result=PipelineRunResult.SUCCESS,
+        status=PipelineStatus.SUCCESS,
     )
     db_session.add(run)
     db_session.commit()


### PR DESCRIPTION
While on most plenary days, there is only one voting session around midday, on some days there is another sesssion in the evening, usually around 17:00. The vote results of the evening sessions are appended to the same source document that also contains the results of the midday votes.

Currently, we only run the `RCVListPipeline` between 12:00 and 15:00 until we’ve been able to fetch vote results successfully. Once we’ve fetched the results, we do not attempt to fetch them again. That means that so far we did not (automatically) fetch results of the evening voting session.

The easy approach to this problem would be to simply keep running the `RCVListPipeline` until the evening, even after it has successfully completed for the first time. However, this approach has a few disadvantages:

* We store timestamps of when we accessed the data sources related for a specific vote. Following the easy approach means we’d store the timestamp when the data was last accessed. For diagnostics and analysis, it’s nice to keep the timestamp of the first access.
* Every pipeline triggers multiple requests for each vote. As it’s not uncommon to see hundreds of votes per day, this would be quite wasteful and not appropriate for a well-behaved scraper.

Instead, we do the following:

* Between 12:00 and 15:00, we periodically check if the vote results are available until we’ve been able to fetch the vote results successfully (just as we did before).
* Between 17:00 and 20:00, we periodically check if an updated RCV list has been published. When an updated list has been published, we rerun the entire pipeline and stop the periodic checks afterwards. When the list remains unchanged, we don’t rerun subsequent steps of the pipeline.

This is implemented as follows:

* When a pipeline has run successfully, it can return a checksum. The checksum is stored and is provided to subsequent runs of the pipeline.
* The checksum can be any value, but in case of the `RCVListPipeline`, it is a simple hash of the contents of the RCV list. (In theory, we could make use of HTTP caching mechanisms and try to e.g. store the response ETag. In practice, many of the official sources do not include an ETag in responses, and this would add unnecessary complexity for irrelevant savings.)
* If during a subsequent run, the hash of RCV list contents hasn’t changed, the pipeline exists early to skip unnecessary requests. Once the pipeline has been run successfully for a second time, we also stop periodically checking if the RCV list contents have changed.

Fixes #917