### PR TITLE
Add term column for votes

### DIFF
--- a/backend/howtheyvote/alembic/versions/9b35d19b64c4_add_term_column_to_votes_table.py
+++ b/backend/howtheyvote/alembic/versions/9b35d19b64c4_add_term_column_to_votes_table.py
@@ -1,0 +1,26 @@
+"""add term column to votes table
+
+Revision ID: 9b35d19b64c4
+Revises: 9200b9028b93
+Create Date: 2024-08-06 18:52:06.033551
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9b35d19b64c4"
+down_revision = "9200b9028b93"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("votes", sa.Column("term", sa.Integer))
+    op.create_index("ix_votes_term", table_name="votes", columns=["term"])
+
+
+def downgrade() -> None:
+    op.drop_column("votes", "term")
+    op.drop_index("ix_votes_term", table_name="votes")

--- a/backend/howtheyvote/models/vote.py
+++ b/backend/howtheyvote/models/vote.py
@@ -73,6 +73,7 @@ class Vote(BaseWithId):
 
     id: Mapped[int] = mapped_column(sa.Integer, primary_key=True)
     timestamp: Mapped[datetime.datetime] = mapped_column(sa.DateTime)
+    term: Mapped[int] = mapped_column(sa.Integer)
     order: Mapped[int] = mapped_column(sa.Integer)
     title: Mapped[str | None] = mapped_column(sa.Unicode)
     procedure_title: Mapped[str | None] = mapped_column(sa.Unicode)

--- a/backend/howtheyvote/scrapers/votes.py
+++ b/backend/howtheyvote/scrapers/votes.py
@@ -128,6 +128,7 @@ class RCVListScraper(BeautifulSoupScraper):
                 "description": description,
                 "reference": reference,
                 "timestamp": timestamp,
+                "term": self.term,
                 "member_votes": self._member_votes(tag),
             },
         )

--- a/backend/howtheyvote/store/mappings.py
+++ b/backend/howtheyvote/store/mappings.py
@@ -63,6 +63,7 @@ def map_vote(record: CompositeRecord) -> Vote:
     return Vote(
         id=record.group_key,
         timestamp=datetime.datetime.fromisoformat(record.first("timestamp")),
+        term=record.first("term"),
         order=record.first("order"),
         title=record.first("title_en") or record.first("title"),
         description=record.first("description_en") or record.first("description"),

--- a/backend/tests/scrapers/test_votes.py
+++ b/backend/tests/scrapers/test_votes.py
@@ -41,6 +41,7 @@ def test_rcv_list_scraper(responses):
             source_url="https://www.europarl.europa.eu/doceo/document/PV-9-2020-07-23-RCV_FR.xml",
             data={
                 "timestamp": datetime.datetime(2020, 7, 23, 12, 49, 32),
+                "term": 9,
                 "title": None,
                 "reference": "B9-0229/2020",
                 "description": "§ 1/1",


### PR DESCRIPTION
We know the term for every vote we scrape, but we currently do not store it in the `votes` table.

Being able to filter votes by term is useful, for example in order to create exports separately for every term (so they don’t become huge), to search within votes of the current term, …

While it’s possible to derive the term from the date, simply storing it as a separate column is much easier :)

- [x] Add separate term column
- [x] Add CLI command to back-fill term for existing votes
- [ ] Add term column to export?