### PR TITLE
Remove single line breaks in documentation

### DIFF
--- a/backend/howtheyvote/helpers.py
+++ b/backend/howtheyvote/helpers.py
@@ -155,4 +155,7 @@ def get_normalized_docstring(type_: type) -> str:
     docstring = inspect.cleandoc(docstring)
     docstring = docstring.strip()
 
+    # Remove single line breaks, but keep double line breaks
+    docstring = re.sub(r"(?<!\n)\n(?!\n)", " ", docstring, flags=re.MULTILINE)
+
     return docstring

--- a/backend/tests/test_helpers.py
+++ b/backend/tests/test_helpers.py
@@ -4,6 +4,7 @@ from howtheyvote.helpers import (
     ProcedureReference,
     Reference,
     flatten_dict,
+    get_normalized_docstring,
     parse_procedure_reference,
     parse_reference,
     subset_dict,
@@ -97,3 +98,15 @@ def test_subset_dict():
     }
 
     assert subset_dict(data, keys) == expected
+
+
+def test_get_normalized_docstring():
+    class TestClass:
+        """Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+        Aenean commodo ligula eget dolor.
+
+        Aenean massa. Cum sociis natoque penatibus et magnis dis parturient
+        montes, nascetur ridiculus mus."""
+
+    expected = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor.\n\nAenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus."
+    assert get_normalized_docstring(TestClass) == expected


### PR DESCRIPTION
Some Markdown renderers convert even a single line break to a <br> which is undesired in this case.