### PR TITLE
Enhancement/accessibility

### DIFF
--- a/frontend/src/components/Tabs.tsx
+++ b/frontend/src/components/Tabs.tsx
@@ -74,7 +74,6 @@ const Tabs: TabsComponent = ({ children }) => {
             id={panel.props.id}
             role="tab"
             aria-selected={selectedIndex === index}
-            tabIndex={selectedIndex === index ? 0 : -1}
             onClick={() => setSelectedIndex(index)}
           >
             {panel.props.label}

--- a/frontend/src/components/Thumb.tsx
+++ b/frontend/src/components/Thumb.tsx
@@ -17,6 +17,7 @@ export default function Thumb({ position, style, className }: ThumbProps) {
     <span
       className={`${bem("thumb", [modifier, style])} ${className || ""}`}
       title={label}
+      aria-label={label}
     >
       {position !== "DID_NOT_VOTE" && (
         <svg aria-hidden="true">

--- a/frontend/src/components/VoteResultChart.css
+++ b/frontend/src/components/VoteResultChart.css
@@ -1,21 +1,15 @@
 .vote-result-chart__bars {
   display: flex;
+  gap: 2px;
   min-height: calc(2 * var(--space-xs));
   border-radius: var(--border-radius-sm);
   overflow: hidden;
-  background-color: var(--gray-light);
-  box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.25);
   margin-bottom: var(--space-xxs);
-}
-
-.vote-result-chart__bars > * + * {
-  margin-left: 1px;
 }
 
 .vote-result-chart__bar {
   width: calc(var(--ratio) * 100%);
   padding: var(--space-xs) 0;
-
   color: white;
   text-align: center;
   font-weight: 600;
@@ -23,7 +17,7 @@
 }
 
 .vote-result-chart--slim .vote-result-chart__bars {
-  min-height: 6px;
+  min-height: 10px;
 }
 
 .vote-result-chart--slim .vote-result-chart__bar {

--- a/frontend/src/components/VoteResultChart.css
+++ b/frontend/src/components/VoteResultChart.css
@@ -24,9 +24,20 @@
   padding: 3px 0;
 }
 
-.vote-result-chart--slim .vote-result-chart__thumb,
-.vote-result-chart--slim .vote-result-chart__percentage {
+.vote-result-chart--slim .vote-result-chart__text {
   display: none;
+}
+
+.vote-result-chart__text {
+  padding: 2px;
+}
+
+.vote-result-chart__bar--for .vote-result-chart__text {
+  background: var(--green);
+}
+
+.vote-result-chart__bar--against .vote-result-chart__text {
+  background: var(--red);
 }
 
 .vote-result-chart__bar--for {
@@ -43,8 +54,7 @@
   background-color: var(--blue);
 }
 
-.vote-result-chart__bar--small .vote-result-chart__thumb,
-.vote-result-chart__bar--small .vote-result-chart__percentage {
+.vote-result-chart__bar--small .vote-result-chart__text {
   display: none;
 }
 

--- a/frontend/src/components/VoteResultChart.tsx
+++ b/frontend/src/components/VoteResultChart.tsx
@@ -42,8 +42,10 @@ function Bar({ value, total, position }: BarProps) {
       className={bem("vote-result-chart__bar", [style, size])}
       style={{ "--ratio": ratio }}
     >
-      <Thumb position={position} className="vote-result-chart__thumb" />
-      <span class="vote-result-chart__percentage">{percentage}%</span>
+      <span className="vote-result-chart__text">
+        <Thumb position={position} className="vote-result-chart__thumb" />
+        <span class="vote-result-chart__percentage">{percentage}%</span>
+      </span>
     </div>
   );
 }

--- a/frontend/src/css/variables.css
+++ b/frontend/src/css/variables.css
@@ -42,7 +42,7 @@
   --green: hsl(var(--green-h), var(--green-s), var(--green-l));
   --green-dark: hsl(var(--green-h), var(--green-s), calc(var(--green-l) - 10%));
 
-  --green-pattern: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Cpath d='M -2 2 l 3 -3 M -1 11 l 11 -11 M 8 12 l 3 -3' stroke='rgba(255, 255, 255, .2)' stroke-width='1'/%3E%3C/svg%3E%0A");
+  --green-pattern: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Cpath d='M -2 2 l 3 -3 M -1 11 l 11 -11 M 8 12 l 3 -3' stroke='rgba(255, 255, 255, .5)' stroke-width='1'/%3E%3C/svg%3E%0A");
 
   --red-h: 365;
   --red-s: 100%;
@@ -50,7 +50,7 @@
   --red: hsl(var(--red-h), var(--red-s), var(--red-l));
   --red-dark: hsl(var(--red-h), var(--red-s), calc(var(--red-l) - 10%));
 
-  --red-pattern: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Cpath d='M -2 2 l 3 -3 M -1 11 l 11 -11 M 8 12 l 3 -3' stroke='rgba(255, 255, 255, .2)' stroke-width='1' transform='scale(1, -1) translate(0, -10)'/%3E%3C/svg%3E%0A");
+  --red-pattern: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Cpath d='M -2 2 l 3 -3 M -1 11 l 11 -11 M 8 12 l 3 -3' stroke='rgba(255, 255, 255, .5)' stroke-width='1' transform='scale(1, -1) translate(0, -10)'/%3E%3C/svg%3E%0A");
 
   --blue-h: 203;
   --blue-s: 100%;


### PR DESCRIPTION
Fixes #1023, #1021, #1022.

---

Before:

![image](https://github.com/user-attachments/assets/96e5aa6a-738f-4cda-a2ad-c6cee306d49d)

After:
![image](https://github.com/user-attachments/assets/09d6604e-42ad-4da8-8e16-40b98738fa79)
---

@tillprochaska contrast comes down to around 1.5:1-1.6:1 now. I opted for the same "level of whiteness" for both green and red, and then just made it high enough so that the contrast works for both colors. Having different "whiteness" levels looked weird to me, but I imagine you might have thoughts :upside_down_face:.

Also, I am unsure with the gaps - first question is if those even are the gaps that were meant? Or have I completely misunderstood the problem? If those are the correct gaps - the result looks weird to me, but I think that will always be the case once we need to add space between them. Might just be a question of familiarization on my end. 