### PR TITLE
Sort groups and countries alphabetically instead of implicitly by size

### DIFF
--- a/frontend/src/components/CountriesFilterSelect.tsx
+++ b/frontend/src/components/CountriesFilterSelect.tsx
@@ -14,7 +14,9 @@ export default function CountriesFilterSelect({
   onChange,
 }: CountriesFilterSelectProps) {
   const options = Object.fromEntries(
-    countries.map((country) => [country.code, country.label]),
+    countries
+      .map((country) => [country.code, country.label])
+      .sort((a, b) => a[1].localeCompare(b[1])),
   );
 
   return (

--- a/frontend/src/components/GroupsFilterSelect.tsx
+++ b/frontend/src/components/GroupsFilterSelect.tsx
@@ -14,7 +14,9 @@ export default function GroupsFilterSelect({
   onChange,
 }: GroupsFilterSelectProps) {
   const options = Object.fromEntries(
-    groups.map((group) => [group.code, group.short_label || group.label]),
+    groups
+      .map((group) => [group.code, group.short_label || group.label])
+      .sort((a, b) => a[1].localeCompare(b[1])),
   );
 
   return (


### PR DESCRIPTION
When I filtered a bunch in order to prepare some slides for our talk, I found that not having the lists sorted by alphabet is a bit stressful. This makes it way easier in my opinion to find the country one is looking for. I have basically sorted the group list for the sake of consistency. The sorting in the position dropdown makes sense as is in my opinion, and also we know for sure that these options will never change, which is (more or less in theory) possible for the other values.