### PR TITLE
Update scraper after markup of source website changed

### DIFF
--- a/backend/howtheyvote/scrapers/votes.py
+++ b/backend/howtheyvote/scrapers/votes.py
@@ -424,7 +424,7 @@ class ProcedureScraper(BeautifulSoupScraper):
         )
 
     def _title(self, doc: BeautifulSoup) -> str | None:
-        title = doc.select_one("#procedure-file-header .ep-layout_underline")
+        title = doc.select_one("#website-body h2.erpl_title-h2")
 
         if not title:
             return None

--- a/backend/tests/scrapers/data/votes/procedure_ficheprocedure-2023-2019-ini.html
+++ b/backend/tests/scrapers/data/votes/procedure_ficheprocedure-2023-2019-ini.html
@@ -1,3452 +1,2505 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html lang="en">
+
 
 <head>
-      <title>Procedure File: 2023/2019(INI) | Legislative Observatory | European Parliament</title>
 
-  <!--  Debut de commons/HEAD -->
-  <!-- OEIL::date et heure de compilation:  GENERATED ON DEVELOPPER WORKSTATION (UPDATED BY MAVEN) -->
-  <meta content="https://www.europarl.europa.eu"/>
-    <meta http-equiv="Content-Security-Policy" content="img-src *;default-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.europarl.europa.eu *.europarl.europa.eu *.ep.parl.union.eu;">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-  <meta content="IE=edge" http-equiv="X-UA-Compatible" />
-  <meta content="no-cache" http-equiv="cache-control" />
-  <meta content="-1" http-equiv="expires" />
-  <meta content="no-cache" http-equiv="pragma" />
-  <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    
+    <title>Procedure File: 2023/2019(INI) | Legislative Observatory | European Parliament</title>
 
-  <meta http-equiv="last-modified" content="06/06/2023 14:02" />
-  <meta name="keywords" content="OEIL, Legislative Observatory, Observatoire législatif,2023/2019(INI),INI/2023/2019,2019/2023,2019/23,MAZUREK Beata, ECR, VERHEYEN Sabine, EPP, MELCHIOR Karen, Renew, ,2 Internal market, single market,3.50.15 Intellectual property, copyright ,3.45.05 Business policy, e-commerce, after-sales service, commercial distribution,4.60.06 Consumers' economic and legal interests,3.30.25 International information networks and society, internet,PE749.206,PE750.251,PE746.896,PE749.286,A9-0335/2023,T9-0473/2023,"/>
-      <meta content="European Parliament Legislative Observatory Procedure" name="description" />
-  <meta content="en" name="language" />
-    <meta content="en" http-equiv="Content-Language" />
-  <meta content="23-12-2023" name="available">
-  <meta content="index, follow, noodp, noydir, notranslate, noarchive" name="robots" />
-    <meta content="� European Union, 2023 - Source: European Parliament" name="copyright" />
-  <meta content="Legislative Observatory" name="planet" />
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta content="@project.version@" name="project_version"/>
+    <meta content="@build.number@" name="build_number"/>
+    <meta content="@build.time@" name="build_time"/>
 
+    <!-- Commons meta tags -->
+    <meta content="https://www.europarl.europa.eu">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta content="IE=edge" http-equiv="X-UA-Compatible">
+    <meta content="no-cache" http-equiv="cache-control">
+    <meta content="-1" http-equiv="expires">
+    <meta content="no-cache" http-equiv="pragma">
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+    <meta content="en" name="language">
+    <meta content="en" http-equiv="Content-Language">
+    <meta content="European Parliament Legislative Observatory Procedure" name="description">
+    <meta content="index, follow, noodp, noydir, notranslate, noarchive" name="robots">
+    <meta content="European Union, 2024 - Source: European Parliament" name="copyright">
+    <meta content="Legislative Observatory" name="planet">
+    <meta content="14-11-2024" name="available">
 
-  <!-- CSS -->
-  <style type="text/css" media="screen,projection">@import url(../rwd/css/evostrap.css);</style>
-  <style type="text/css" media="screen,projection">@import url(../rwd/css/atomicdesign.css);</style>
-  <style type="text/css" media="screen,projection">@import url(../rwd/css/structure.css);</style>
-  <style type="text/css" media="screen,projection">@import url(../rwd/css/legislative-observatory.css);</style>
-  <style type="text/css" media="screen,projection">@import url(../rwd/css/jquery-ui.theme.css);</style>
-  <style type="text/css" media="screen,projection">@import url(../rwd/css/oeil-datepicker.css);</style>
-  <!--  JAVASCRIPT -->
-  <script type="text/javascript" src="/oeil/js/jquery-3.5.1.min.js"></script>
-  <script type="text/javascript" src="/oeil/js/jquery-1.8.3.min.js"></script>
-  <script type="text/javascript" src="/oeil/rwd/js/handlebars-v4.7.6.js"></script>
-  <script type="text/javascript" src="/oeil/js/xss.min.js"></script>
-  <script type="text/javascript" src="/oeil/js/accTabs1.js"></script>
-  <script type="text/javascript" src="/oeil/js/jquery.form-defaults.js"></script>
-  <!--  script type="text/javascript" src="/oeil/js/jquery-treeview/jquery.treeview.min.js"></script -->
-  <script type="text/javascript" src="/oeil/js/jquery.cookies.js"></script>
-  <script type="text/javascript" src="/oeil/js/jquery.maskedinput-1.4.1.min.js"></script>
-  <script type="text/javascript" src="/oeil/js/jquery.oeil6DatePicker/js/eye.js"></script>
-  <script type="text/javascript" src="/oeil/js/validate/jquery.validate.min.js"></script>
-  <script type="text/javascript" src="/oeil/js/jquery.scrollTo-1.4.3.1-min.js"></script>
-  <script type="text/javascript" src="/oeil/js/jquery.localscroll-1.2.7-min.js"></script>
-  <script type="text/javascript" src="/oeil/js/jquery-ui-1.8.2.custom.min.js"></script>
-  <script type="text/javascript" src="/oeil/js/jquerytiptip.js"></script>
-  <script type="text/javascript" src="/oeil/js/jquery.json-2.2.min.js"></script>
-  <script type="text/javascript" src="/oeil/js/jqueru.ui.datepicker.js"></script>
-  <script type="text/javascript" src="/oeil/js/jquery.oeil6DatePicker/js/jquery.ui.datepicker-en-GB.js"></script>
-  <script type="text/javascript" src="/oeil/js/jquery.oeil6DatePicker/js/jquery.ui.datepicker-fr.js"></script>
-  <script type="text/javascript" src="/oeil/js/blockUI-2.70.js"></script>
-  <script type="text/javascript" src="/oeil/js/jquery.url.js"></script>
-  <!--
-  <script type="text/javascript" src="/oeil/js/oeil6.js"></script>
-  -->
-  <script type="text/javascript" src="/oeil/rwd/js/behaviour.js"></script>
-  <script type="text/javascript" src="/oeil/rwd/js/jquery.sticky.js"></script>
-  <script type="text/javascript" src="/oeil/rwd/js/oeil6rwd.js"></script>
-  <!--
-  <script type="text/javascript">jQuery(document).ready(function(){OEIL6_RWD_Lib.core.initPage();});</script>
-  -->
-  <script type="text/javascript" defer data-tracker-name="ATInternet" data-value="https://www.europarl.europa.eu/website/webanalytics/ati-oeil.js"
-  src="https://www.europarl.europa.eu/website/privacy-policy/privacy-policy.js"></script>
-  <!--<script src="https://www.europarl.europa.eu/website/webanalytics/ati-oeil.js"  type="text/javascript"></script>
-  <script type="text/javascript" src="/oeil/js/cookie-policy.js" defer></script>-->
-  <!--  Fin de commons/HEAD -->
-  <script type="text/javascript" src="/oeil/js/evostrap.js"></script>
+    <!-- Dynamics meta tags -->
+    
+        <meta content="OEIL, Legislative Observatory, Observatoire législatif, 2023/2019(INI), MAZUREK Beata, ECR, VERHEYEN Sabine, EPP, MELCHIOR Karen, Renew, 2 Internal market, single market, 3.30.25 International information networks and society, internet, 3.45.05 Business policy, e-commerce, after-sales service, commercial distribution, 3.50.15 Intellectual property, copyright , 4.60.06 Consumers&#39; economic and legal interests, A9-0335/2023, T9-0473/2023" name="keywords">
+    
 
+    <!-- HTML <link> tags -->
+    <link rel="icon" href="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/assets/img/favicon.ico">
+
+    
+    <link href="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/dist/css/evostrap.css" rel="stylesheet">
+    <link href="https://www.europarl.europa.eu/commonFrontResources/evostrap-oeil/1.0.0//dist/css/oeil.css" rel="stylesheet">
 </head>
 
-<body lang="en">
-<div id="website">
+<body id="main-content" data-app-context="/oeil/">
 
-    <!-- views/partials/header.ejs -->
+    <header class="erpl_header">
+    <nav class="erpl_wai-access" aria-label="Shortcuts">
+        <ul>
+            <li> <a href="#website-body" class="erpl_smooth-scroll"> <span class="btn btn-primary">Access to page content (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#languageSelectorDropdownButton" class="erpl_smooth-scroll"> <span class="btn btn-primary">Direct access to language menu (press &quot;Enter&quot;)</span> </a> </li>
 
-    <div id="website-header">
-        <!-- COMPOSANT "WAI SHORTCUTS" -->
-        <ul class="ep_waiaccess" arial-label="Shortcuts" id="waimenu" title="Shortcuts"  role="listbox">
-            <li aria-labelledby="waimenu"  aria-checked="true" role="option"><a href="#website-body"><span class="ep_name">Access to page content (press "Enter")</span><span class="ep_icon">&nbsp;</span></a></li>
-            <li aria-labelledby="waimenu"  aria-checked="true" role="option"><a href="#language-select"><span class="ep_name">Direct access to language menu (press "Enter")</span><span class="ep_icon">&nbsp;</span></a></li>
-            <li aria-labelledby="waimenu"  aria-checked="true" role="option"><a href="#search-field"><span class="ep_name">Direct access to search menu (press "Enter")</span><span class="ep_icon">&nbsp;</span></a></li>
+            <li> <a href="#mainSearch" class="erpl_smooth-scroll"> <span class="btn btn-primary">Direct access to search menu (press &quot;Enter&quot;)</span> </a> </li>
         </ul>
+    </nav>
 
-        <!-- "HEADER" COMPOSANT -->
-        <header class="ep_header" role="banner">
-            <div>
-                <div class="ep_title ep_parliament">
-                    <a href="http://www.europarl.europa.eu/portal/en" title="Go back to the Europarl portal"><span class="ep_name">European Parliament</span><span class="ep_icon">&nbsp;</span></a>
-                </div>
-                <div class="ep_title ep_website">
-                    <a href="/oeil?lang=en" title="Return to homepage"><span class="ep_name">Legislative Observatory</span><span class="ep_icon">&nbsp;</span></a>
-                </div>
-            </div>
-
-            <span class="ep_background">&nbsp;</span>
-        </header>
-
-        <div class="lo_large-search">
-            <div>
-
-                <input
-          id='find-a-procedure'
-          type="text"
-          placeholder="Find a procedure"
-          onkeypress="OEIL6_RWD_Lib.core.submitEnter(this, event)">
-                <button type="submit" onclick="OEIL6_RWD_Lib.core.find(document.getElementById('find-a-procedure').value);"><span class="ep_hidden">Search</span></button>
-            </div>
-        </div>
-
-        <!-- "TOOLBAR" COMPOSANT -->
-        <div class="ep_toolbar ep_bottom ">
-            <div>
-
-                    <!-- "NAVIGATION MENU" COMPOSANT -->
-<nav class="ep_navigation-menu wtf" id="authentication" role="navigation" aria-labelledby="navigation-label">
-
-    <div id="auth-navigation" class="ep_menu-access ep_openaccess" data-expanded="true" aria-expanded="true">
-        <div class="ep_button">
-            <span>
-                <span id="user_icon" class="ep_icon">&nbsp;</span>
+    
+    <div class="erpl_header-top border-bottom mb-3 mb-xl-4 a-i">
+        <div class="container">
+            <div class="row no-gutters">
+                <div class="col-auto"><div class="erpl_header-language-selector">
+    <div class="erpl_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute"
+         data-content-width="auto">
+        <button class="erpl_dropdown-btn input-group collapsed" type="button" data-toggle="collapse"
+                id="languageSelectorDropdownButton"
+                data-target="#languageSelectorDropdownContent"
+                aria-expanded="false"
+                aria-controls="languageSelectorDropdownContent">
+            <span class="value form-control">EN - English</span>
+            
+            <span class="input-group-append">
+                <span class="input-group-icon">
+                    <svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false">
+                        <use xlink:href="#es_icon-arrow"></use>
+                    </svg>
+                    <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-flip-y text-primary"
+                         data-show-expanded="true">
+                        <use xlink:href="#es_icon-arrow"></use>
+                    </svg>
+                </span>
             </span>
+        </button>
 
-        </div>
-
-        <div class="ep_button"><a id="navigation-label" href="#navigation" title="Open the menu" aria-control="navigation-panel"><span class="ep_name"><span class="ep_hidden">Log in Navigation (</span><span class="ep_hidden">)</span></span><span class="ep_icon">&nbsp;</span></a></div>
-    </div>
-
-    <div class="ep_menu-container" id="navigation-panel">
         <div>
-            <div class="ep_menu-content">
-                <div class="ep_menu-links" role="menu">
+            <div class="erpl_dropdown-content collapse" id="languageSelectorDropdownContent">
+                <div class="border border-light">
                     <div>
-                        <div class="ep_menu" role="tree" aria-labelby="navigation-label" aria-multiselectable="false" aria-controls="website-body">
-                <!-- -->
-                                <div class="login-content">
-                                      <h3 class="ep-a_heading login-header">
-                      <span class="userinfo-dropdown-title">Log in</span>
-                      <span class="close-dropdown-button" onclick="OEIL6_RWD_Lib.core.toggleMyObservatory(); return false;"></span>
-                    </h3>
-
-                    <form action="/oeil/j_spring_security_check" method="post" id="loginFrm">
-
-                      <input id="j_username" class="auth_field" value="" name="j_username" type="text" placeholder="Your e-mail"  tabindex="1">
-                      <input type="password" value="" class="auth_field" id="j_password" name="j_password" tabindex="2" placeholder="Password">
-
-
-                      <button class="btn btn-blue" type="submit">
-                        <span class="ep_name"></span>Log in</span>
-                      </button>
-
-
-                                        <p class="rememberme">
-                      <input
-                        role="combobox"
-                        type="checkbox"
-                        name='_spring_security_remember_me'
-                        id='_spring_security_remember_me'
-                        aria-checked="true"
-                        tabindex="3">
-                                            <label for="_spring_security_remember_me">Remember me on this computer</label>
-                                        </p>
-
-                    <p class="auth_links">
-                                            <a class="btn-link" title="Go to the page" title="Forgotten your password?" href="/oeil/myoeil/resetpassword.do">
-                                                <span class="ep_name">&gt; Forgotten your password?</span>
-                                            </a>
-                                        </p>
-
-                                        <p class="auth_links">
-                                            <a class="btn-link" href="/oeil/myoeil/register.do" title="Create an account">
-                                                <span class="ep_name">&gt;  Create an account</span>
-                                            </a>
-                                        </p>
-
-                    </form>
-
-                                    </div>
-                  <!-- -->
-                        </div>
+                        <ul class="erpl_topbar-list list-unstyled erpl_dropdown-menu">
+                            <li class="t-x-block" data-selected="false">
+                                <!-- localized version URL is here -->
+                                <a class="erpl_dropdown-menu-item"
+                                   lang="fr"
+                                   href="https://oeil.secure.europarl.europa.eu/oeil/fr/procedure-file?reference=2023/2019(INI)">
+                                    
+                                    <span class="t-item">FR - français</span>
+                                </a>
+                            </li>
+                            <li class="t-x-block" data-selected="true">
+                                <!-- localized version URL is here -->
+                                <a class="erpl_dropdown-menu-item"
+                                   lang="en"
+                                   href="https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2023/2019(INI)">
+                                    <span class="t-item">EN - English</span>
+                                    
+                                </a>
+                            </li>
+                        </ul>
                     </div>
                 </div>
             </div>
         </div>
-        <div class="ep_menu-access ep_closeaccess">
-            <div class="ep_button"><a href="#navigation-label"><span class="ep_name" title="Close the menu">
-        <span class="ep_hidden">Close the Log in navigation (</span>menu<span class="ep_hidden">)</span></span><span class="ep_icon">&nbsp;</span></a></div>
-        </div>
     </div>
-    <span class="ep_background"><span>&nbsp;</span></span>
-</nav>                    <!-- "NAVIGATION MENU" COMPOSANT -->
-<nav class="ep_navigation-menu" id="navigation" role="navigation" aria-labelledby="navigation-label">
+</div></div>
+                <div class="col">
+                    <nav class="erpl_header-other-websites d-flex justify-content-end align-items-center" aria-label="Other websites">
+                        <ul class="d-flex list-unstyled">
 
-  <div class="ep_menu-access ep_openaccess" data-expanded="true" aria-expanded="true">
-        <div class="ep_button"><span><span class="ep_name"><span class="ep_hidden">Navigation (</span>menu<span class="ep_hidden">)</span></span><span class="ep_icon">&nbsp;</span></span>
-        </div>
-        <div class="ep_button"><a id="navigation-label" href="#navigation" title="Open the menu" aria-control="navigation-panel"><span class="ep_name"><span class="ep_hidden">Navigation (</span>menu<span class="ep_hidden">)</span></span><span class="ep_icon">&nbsp;</span></a></div>
-    </div>
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/news/en">
+                                    <span class="t-item">News</span>
+                                </a>
+                            </li>
 
-    <div class="ep_menu-container" id="navigation-panel">
-        <div>
-            <div class="ep_menu-content">
-                <div class="ep_menu-links" role="menu">
-                    <div>
-                        <div class="ep_menu" role="tree" aria-labelby="navigation-label" aria-multiselectable="false" aria-controls="website-body">
-                            <ol role="group">
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/topics/en">
+                                    <span class="t-item">Topics</span>
+                                </a>
+                            </li>
 
-                <li role="treeitem" class="ep_item ep_level0 ep_directlink" aria-selected="true">
-                                    <div class="ep_button">
-                    <a href="/oeil/home/home.do" title="Go to the page">
-                      <span class="ep_name">Home</span><span class="ep_icon">&nbsp;</span>
-                    </a>
-                  </div>
-                                </li>
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/meps/en">
+                                    <span class="t-item">MEPs</span>
+                                </a>
+                            </li>
 
-                <li role="treeitem" class="ep_item ep_level0 ep_directlink" >
-                                    <div class="ep_button">
-                    <a href="/oeil/search/search.do?searchTab=y" title="Go to the page">
-                      <span class="ep_name">Search</span><span class="ep_icon">&nbsp;</span>
-                    </a>
-                  </div>
-                                </li>
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/about-parliament/en">
+                                    <span class="t-item">About Parliament</span>
+                                </a>
+                            </li>
 
-                                <li role="treeitem" class="ep_item ep_level0 ep_directlink" >
-                                    <div class="ep_button">
-                    <a href="/oeil/themes/list.do" title="Go to the page">
-                      <span class="ep_name">Legislative priorities</span><span class="ep_icon">&nbsp;</span>
-                    </a>
-                  </div>
-                                </li>
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/plenary/en">
+                                    <span class="t-item">Plenary</span>
+                                </a>
+                            </li>
 
-                                <li role="treeitem" class="ep_item ep_level0 ep_directlink" >
-                                    <div class="ep_button"><a href="/oeil/info/info2.do" title="Go to the page"><span class="ep_name">Find out more</span><span class="ep_icon">&nbsp;</span></a></div>
-                                </li>
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/committees/en">
+                                    <span class="t-item">Committees</span>
+                                </a>
+                            </li>
 
-                <li role="treeitem" class="ep_item ep_level0 ep_directlink"  >
-                                    <div class="ep_button"><a href="/oeil/info/contact2.do" title="Go to the page"><span class="ep_name">Contact us</span><span class="ep_icon">&nbsp;</span></a></div>
-                                </li>
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/delegations/en">
+                                    <span class="t-item">Delegations</span>
+                                </a>
+                            </li>
 
-                                <!--
-                                <li class="ep_user">
-                                    <div class="ep_button"><a href="/oeil/myoeil/storedsearch.do" title="Go to the page"><span class="ep_name">My Observatory</span></a></div>
-                                </li>
-                -->
-
-                                <li class="ep_user">
-                                    <div class="ep_button">
-                    <a id="login-trigger" href="#" title="Go to the page" onclick="OEIL6_RWD_Lib.core.toggleMyObservatory(); return false;">
-                      <span class="ep_name">My Observatory</span>
-                    </a>
-
-
-                    <article>
-                      <ul>
-                      <li id="login">
-                        <div id="login-content">
-                                                  <h3 class="ep-a_heading login-header">
-                            <span class="userinfo-dropdown-title">Log in</span>
-                            <span class="close-dropdown-button" onclick="OEIL6_RWD_Lib.core.toggleMyObservatory(); return false;"></span>
-                          </h3>
-
-                          <form action="/oeil/j_spring_security_check" method="post" id="loginFrm">
-                            <fieldset id="inputs">
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://elections.europa.eu/en/">
+                                    <span class="t-item">Elections</span>
+                                </a>
+                            </li>
 
 
+                            <li class="erpl_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute">
+                               <button class="erpl_dropdown-btn input-group collapsed d-xl-flex pl-1 align-items-center t-y-block flex-nowrap"
+                                       data-toggle="collapse"
+                                       data-target="#otherWebsiteSubmenu"
+                                       aria-expanded="false"
+                                       aria-controls="otherWebsiteSubmenu" aria-label="More other websites">
+                                    <span class="value">
+											<span class="d-none d-xl-inline">Other websites</span>
+											<span class="d-xl-none">View other websites</span>
+                                    </span>
+                                   <span class="input-group-append">
+											<span class="input-group-icon">
+												<svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false">
+													<use xlink:href="#es_icon-arrow"></use>
+												</svg>
 
-                            <input id="j_username" class="auth_field" value="" name="j_username" type="text" placeholder="Your e-mail"  tabindex="1">
-                      <input type="password" value="" class="auth_field" id="j_password" name="j_password" tabindex="2" placeholder="Password">
+												<svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-flip-y text-primary" data-show-expanded="true">
+													<use xlink:href="#es_icon-arrow"></use>
+												</svg>
+											</span>
+										</span>
+                                </button>
+                                <div>
+                                    <div id="otherWebsiteSubmenu" class="erpl_dropdown-content collapse">
+                                        <ul class="erpl_header-other-websites-submenu list-unstyled erpl_dropdown-menu">
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/news/en">
+                                                    <span class="t-item">News</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/topics/en">
+                                                    <span class="t-item">Topics</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/meps/en">
+                                                    <span class="t-item">MEPs</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/about-parliament/en">
+                                                    <span class="t-item">About Parliament</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/plenary/en">
+                                                    <span class="t-item">Plenary</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/committees/en">
+                                                    <span class="t-item">Committees</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/delegations/en">
+                                                    <span class="t-item">Delegations</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://elections.europa.eu/en/">
+                                                    <span class="t-item">Elections</span>
+                                                </a>
+                                            </li>
 
-                            </fieldset>
-                            <fieldset id="actions">
-                            <input type="submit" id="submit" value="Log in">
-                            </fieldset>
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://multimedia.europarl.europa.eu/en/home">
+                                                    <span class="t-item">Multimedia Centre</span>
+                                                </a>
+                                            </li>
 
-                            <fieldset id="remember">
-                            <input role="combobox"
-                                type="checkbox"
-                                name='_spring_security_remember_me'
-                                id='_spring_security_remember_me'
-                                aria-checked="true"
-                                tabindex="3">
-                              <label for="_spring_security_remember_me">Remember me on this computer</label>
-                            </fieldset>
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/the-president/en">
+                                                    <span class="t-item">President&#39;s website</span>
+                                                </a>
+                                            </li>
 
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/the-secretary-general/en">
+                                                    <span class="t-item">Secretariat-general</span>
+                                                </a>
+                                            </li>
 
-                          </form>
-                          <p class="links">
-                            <a class="btn-link" title="Go to the page" title="Forgotten your password?" href="/oeil/myoeil/resetpassword.do">
-                              <span class="ep_name">&gt; Forgotten your password?</span>
-                            </a>
-                          </p>
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/thinktank/en">
+                                                    <span class="t-item">Thinktank</span>
+                                                </a>
+                                            </li>
 
-                          <p class="links">
-                            <a class="btn-link" title="Go to the page" href="/oeil/myoeil/register.do" title="Create an account">
-                              <span class="ep_name">&gt;  Create an account</span>
-                            </a>
-                          </p>
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.epnewshub.eu">
+                                                    <span class="t-item">EP Newshub</span>
+                                                </a>
+                                            </li>
 
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/at-your-service/en">
+                                                    <span class="t-item">At your service</span>
+                                                </a>
+                                            </li>
 
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/visiting/en">
+                                                    <span class="t-item">Visits</span>
+                                                </a>
+                                            </li>
 
-                        </div>
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/legislative-train">
+                                                    <span class="t-item">Legislative train</span>
+                                                </a>
+                                            </li>
 
-                      </li>
-                      </ul>
-                    </article>
-                  </div>
-                                </li>
-                            </ol>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="ep_menu-access ep_closeaccess">
-            <div class="ep_button"><a href="#navigation-label"><span class="ep_name" title="Close the menu"><span class="ep_hidden">Close the navigation (</span>menu<span class="ep_hidden">)</span></span><span class="ep_icon">&nbsp;</span></a></div>
-        </div>
-    </div>
-    <span class="ep_background"><span>&nbsp;</span></span>
-</nav>
-            </div>
-        </div>
-        <div class="ep_toolbar ep_top">
-            <div>
-                <!-- "LANGUAGE MENU" COMPOSANT -->
-                <div class="ep_language-menu">
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/contracts-and-grants/en/">
+                                                    <span class="t-item">Contracts and Grants</span>
+                                                </a>
+                                            </li>
 
-                    <form class="ep_form" id="langbox" method="post" action="/oeil/home/home.do" role="complementary">
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/RegistreWeb/home/welcome.htm?language=en">
+                                                    <span class="t-item">Register</span>
+                                                </a>
+                                            </li>
 
-                        <label for="language-select" class="ep_hidden">
-              <span class="ep_name">Change the navigation language</span>
-              <span class="ep_icon">&nbsp;</span>
-            </label>
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://data.europarl.europa.eu/en">
+                                                    <span class="t-item">Open Data Portal</span>
+                                                </a>
+                                            </li>
 
-                        <div class="ep_select">
-                            <div class="ep_field"><span class="ep_hidden">Current language:</span><span class="ep_name">en - English</span><span class="ep_icon">&nbsp;</span></div>
-                            <select class="ep_field" id="language-select" required="required" aria-required="true">
-                            <option lang="en" hreflang="en" data-textcustom="EN" value="en" selected="selected">EN - English</option>
-                            <option lang="fr" hreflang="fr" data-textcustom="FR" value="fr" >FR - français</option>
-                        </select>
-                        </div>
-                        <button class="ep_button" type="submit" title="Change the navigation language"><span class="ep_name">Select</span><span class="ep_icon">&nbsp;</span></button>
-
-            <input id="lngHidFld" type="hidden" name="lang" value="fr" ></input>
-            <input id="redirect" type="hidden" name="redirect" value="true"></input>
-            <input id="l" type="hidden" name="l" value="fr" ></input>
-                    </form>
-
-          <input type="hidden" id="pageLanguage" value="en"/>
-          <input type="hidden" id="contextPath" value="/oeil"/>
-
-
-                </div>
-
-
-                <!-- COMPOSANT "OTHER WEBSITES" -->
-                <div class="ep_otherwebsites-menu" id="otherwebsites" role="complementary" aria-labelledby="otherwebsites-label">
-                    <div class="ep_menu-access ep_openaccess">
-                        <div class="ep_hidden" id="otherwebsites-label"><span class="ep_name">Other sites</span><span class="ep_icon">&nbsp;</span></div>
-                        <a class="ep_button" href="#otherwebsites" id="otherwebsites-access"><span class="ep_name">Other sites</span><span class="ep_icon">&nbsp;</span></a>
-                        <span class="ep_button"><span class="ep_name">Other sites</span><span class="ep_icon">&nbsp;</span></span>
-                    </div>
-                    <div class="ep_menu-content">
-                        <div>
-                            <ol role="list">
-                                <li class="ep_item"><a href="http://www.europarl.europa.eu/news/en/" title="Go to the page"><span class="ep_name">News</span><span class="ep_icon">&nbsp;</span></a></li>
-                                <li class="ep_item"><a href="http://www.europarl.europa.eu/meps/en/" title="Go to the page"><span class="ep_name">MEPs</span><span class="ep_icon">&nbsp;</span></a></li>
-                                <li class="ep_item"><a href="http://www.europarl.europa.eu/aboutparliament/en/" title="Go to the page"><span class="ep_name">About Parliament</span><span class="ep_icon">&nbsp;</span></a></li>
-                                <li class="ep_item"><a href="http://www.europarl.europa.eu/plenary/en/" title="Go to the page"><span class="ep_name">Plenary</span><span class="ep_icon">&nbsp;</span></a></li>
-                                <li class="ep_item"><a href="http://www.europarl.europa.eu/committees/en/" title="Go to the page"><span class="ep_name">Committees</span><span class="ep_icon">&nbsp;</span></a></li>
-                                <li class="ep_item"><a href="http://www.europarl.europa.eu/delegations/en/" title="Go to the page"><span class="ep_name">Delegations</span><span class="ep_icon">&nbsp;</span></a></li>
-                                <li class="ep_item ep_more" id="more-otherwebsites">
-                                    <div class="ep_menu-access ep_openaccess">
-                                        <div class="ep_hidden" id="more-otherwebsites-label"><span class="ep_name"><span>Other websites</span><span class="ep_hidden"> (more)</span></span><span class="ep_icon">&nbsp;</span></div>
-                                        <a class="ep_button" href="#more-otherwebsites" id="more-otherwebsites-access"><span class="ep_name"><span class="ep_hidden">View </span><span>Other websites</span><span class="ep_hidden"> (more)</span></span><span class="ep_icon">&nbsp;</span></a>
-                                        <span class="ep_button"><span class="ep_name"><span>Other websites</span><span class="ep_hidden"> (more)</span></span><span class="ep_icon">&nbsp;</span></span>
-                                    </div>
-                                    <div class="ep_menu-content">
-                                        <ol role="list">
-                                            <li class="ep_item"><a href="https://multimedia.europarl.europa.eu/en/home" title="Go to the page"><span class="ep_name">Medias</span><span class="ep_icon">&nbsp;</span></a></li>
-                                            <li class="ep_item"><a href="http://www.europarl.europa.eu/the-president/en/" title="Go to the page"><span class="ep_name">President website</span><span class="ep_icon">&nbsp;</span></a></li>
-                                            <li class="ep_item"><a href="http://www.europarl.europa.eu/the-secretary-general/en" title="Go to the page"><span class="ep_name">Secretary General website</span><span class="ep_icon">&nbsp;</span></a></li>
-                                            <li class="ep_item"><a href="http://www.europarl.europa.eu/thinktank/en/home.html" title="Go to the page"><span class="ep_name">Think Tank</span><span class="ep_icon">&nbsp;</span></a></li>
-                                            <li class="ep_item"><a href="http://www.epnewshub.eu/#/?_k=ye8v71" title="Go to the page"><span class="ep_name">EP Newshub</span><span class="ep_icon">&nbsp;</span></a></li>
-                                            <li class="ep_item"><a href="http://www.europarl.europa.eu/atyourservice/en/" title="Go to the page"><span class="ep_name">At your service</span><span class="ep_icon">&nbsp;</span></a></li>
-                                            <li class="ep_item"><a href="http://www.europarl.europa.eu/visiting/en/" title="Go to the page"><span class="ep_name">Visits</span><span class="ep_icon">&nbsp;</span></a></li>
-                                            <li class="ep_item"><a href="http://www.europarl.europa.eu/legislative-train/" title="Go to the page"><span class="ep_name">Legislative train</span><span class="ep_icon">&nbsp;</span></a></li>
-                                            <li class="ep_item"><a href="http://www.europarl.europa.eu/contracts-and-grants/en/" title="Go to the page"><span class="ep_name">Contract and grants</span><span class="ep_icon">&nbsp;</span></a></li>
-                                            <li class="ep_item"><a href="http://www.europarl.europa.eu/RegistreWeb/search/simple.htm?language=en" title="Go to the page"><span class="ep_name">Register</span><span class="ep_icon">&nbsp;</span></a></li>
-                                            <li class="ep_item"><a href="https://data.europarl.europa.eu/en/home" title="Go to the page"><span class="ep_name">Open Data Portal</span><span class="ep_icon">&nbsp;</span></a></li>
-                                            <li class="ep_item"><a href="https://liaison-offices.europarl.europa.eu/en" title="Go to the page"><span class="ep_name">Liaison offices</span><span class="ep_icon">&nbsp;</span></a></li>
-                                          </ol>
-                                        <div class="ep_menu-access ep_closeaccess">
-                                            <a class="ep_button" href="#more-otherwebsites-access"><span class="ep_name"><span class="ep_hidden">Hide </span><span>Other sites</span><span class="ep_hidden"> (more)</span></span><span class="ep_icon">&nbsp;</span></a>
-                                        </div>
-                                    </div>
-                                </li>
-                            </ol>
-                        </div>
-                        <div class="ep_menu-access ep_closeaccess">
-                            <a class="ep_button" href="#otherwebsites-access"><span class="ep_name">Hide other websites</span><span class="ep_icon">&nbsp;</span></a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <!-- "BREADCRUMB" COMPONENT -->
-        <!--<nav id="website-breadcrumb" class="ep_breadcrumb" role="navigation" aria-label="You are here:">
-
-    </nav>-->
-    </div>
-
-    <div id="website-body" role="main">
-
-
-
-<div class="ep_gridrow ep-o_headerpage ep-layout_greycolor lo_white">
-</div>
-
-
-  <div class="ep_gridrow ep_tableofcontent-menu" id="procedure-file-dropdown-menu">
-        <div class="ep_gridrow-content">
-            <div class="ep_gridcolumn ep-m_product ep-layout_border" data-layout1200="center" data-layout1020="center" data-layout750="center" data-layout640="center" data-layout480="center" data-layout320="center" data-view1200="8" data-view1020="8" data-view750="12"
-                data-view640="8" data-view480="8" data-view320="4">
-                <div class="ep_gridrow">
-                    <div class="ep_gridrow-content">
-                        <div class="ep_gridcolumn " data-view1200="6" data-view1020="6" data-view750="8" data-view640="8" data-view480="8" data-view320="4">
-                            <div class="ep_gridcolumn-content">
-                                <div class="ep-a_field ep-layout_execute">
-                                    <div class="ep-p_select">
-                                        <label for="select-date"><span class="ep_name">Procedure file menu</span><span class="ep_icon">&nbsp;</span></label>
-                                        <div class="ep_select">
-                                            <select class="ep_field" id="select-procedure-section">
-
-                                                      <option value="Placeholder" selected="selected">Procedure file</option>
-
-
-                                                <option value="#basicInformation">Basic information</option>
-                                                <option value="#keyPlayers">Key players</option>
-
-                                                                        <option value="#keyEvents">Key events</option>
-
-
-                                                <option value="#technicalInformation">Technical information</option>
-
-                                                                        <option value="#documentGateway">Documentation gateway</option>
-
-
-
-                                                                        <option value="#transparency">Transparency</option>
-                                                                    </select>
-                                        </div>
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://liaison-offices.europarl.europa.eu/en">
+                                                    <span class="t-item">Liaison offices</span>
+                                                </a>
+                                            </li>
+                                        </ul>
                                     </div>
                                 </div>
-                            </div>
-                        </div>
-
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-
-<div class="ep_gridrow">
-
-    <div class="ep_gridrow-content">
-
-            <div class="ep_gridcolumn ep-layout_tableofcontent" data-view1200="3" data-view1020="3" data-view750="12" data-view640="0" data-view480="0" data-view320="0">
-                <div class="ep_gridcolumn-content">
-                    <nav class="ep_tableofcontent-menu" aria-label="Procedure file sections">
-                        <div>
-                            <div class="ep_content">
-                                <div class="ep_title" id="procedure-title">
-                                    <a onclick='return false;' title="Go to the page" style="color: black; pointer-events:none;"><span class="ep_name">
-                                          Procedure file
-                                      </span><span class="ep_icon">&nbsp;</span></a>
-                                </div>
-                                <div class="ep_list">
-                                    <ul aria-labelledby="procedure-title">
-                                        <li class="ep_item">
-                                            <a  id="basicInformation-menu"
-                        onclick='OEIL6_RWD_Lib.core.gotoSection("#basicInformation"); return false;'
-                        href="#"
-                        title="Go to the page" aria-selected="false">
-                          <span class="ep_name">
-                          Basic information
-                      </span><span class="ep_icon">&nbsp;</span></a>
-                                        </li>
-                                        <li class="ep_item">
-                                            <a id="keyPlayers-menu" onclick='OEIL6_RWD_Lib.core.gotoSection("#keyPlayers"); return false;' href="#" title="Go to the page"><span class="ep_name">Key players</span><span class="ep_icon">&nbsp;</span></a>
-                                        </li>
-
-                                        <li class="ep_item">
-                                            <a id="keyEvents-menu" onclick='OEIL6_RWD_Lib.core.gotoSection("#keyEvents"); return false;' href="#" title="Go to the page"><span class="ep_name">Key events</span><span class="ep_icon">&nbsp;</span></a>
-                                        </li>
-
-
-                                        <li class="ep_item">
-                                            <a id="technicalInformation-menu" onclick='OEIL6_RWD_Lib.core.gotoSection("#technicalInformation"); return false;' href="#" title="Go to the page"><span class="ep_name">Technical information</span><span class="ep_icon">&nbsp;</span></a>
-                                        </li>
-
-                                                            <li class="ep_item">
-                                            <a id="documentGateway-menu" onclick='OEIL6_RWD_Lib.core.gotoSection("#documentGateway"); return false;' href="#" title="Go to the page"><span class="ep_name">Documentation gateway</span><span class="ep_icon">&nbsp;</span></a>
-                                        </li>
-
-
-                                        <li class="ep_item">
-                                            <a id="transparency-menu" onclick='OEIL6_RWD_Lib.core.gotoSection("#transparency"); return false;' href="#" title="Go to the page"><span class="ep_name">Transparency</span><span class="ep_icon">&nbsp;</span></a>
-                                        </li>
-                                                        </ul>
-                                </div>
-                            </div>
-                        </div>
+                            </li>
+                        </ul>
                     </nav>
                 </div>
             </div>
-            <!-- End Side menu -->
+        </div>
+    </div>
+    <div class="erpl_header-middle mb-3">
+        <div class="container">
+            <div class="row">
+                <div class="col-12 col-md">
+                    <div class="erpl_header-website-title a-i">
+                        <div class="erpl_header-website-title-main">
+                            <a href="/oeil/en" class="t-x">
+                                <span>Legislative Observatory</span>
+                            </a>
+                        </div>
+                        <div class="erpl_header-website-title-sub">
+                            <a class="t-x-block" href="https://www.europarl.europa.eu" target="_blank" >
+                                <span class="t-item">European Parliament</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
 
-      <!-- leave one column as space -->
-            <div class="ep_gridcolumn" data-view1200="1" data-view1020="0" data-view750="12" data-view640="0" data-view480="0" data-view320="0">
-                <div class="ep_gridcolumn-content">
+                
+                <div class="col-auto d-none d-xl-flex justify-content-end align-items-center erpl_header-search-container">
+                    <form class="erpl_header-search" method="GET" action="/oeil/en/search"> <label for="mainSearch" class="sr-only">Find a procedure</label>
+                        <div class="input-group" style="width: 300px">
+                            <input type="text" class="form-control"
+                                   id="mainSearch"
+                                   placeholder="Find a procedure..."
+                                   name="fullText.term"
+                                   aria-describedby="mainSearchHelper">
+                            <div class="input-group-append">
+                                <button class="btn btn-primary align-items-center d-flex" title="Start find a procedure" disabled="">
+                                    <svg aria-hidden="true" class="es_icon es_icon-search erpl_header-search-icon">
+                                        <use xlink:href="#es_icon-search"></use>
+                                    </svg>
+                                </button>
+                            </div>
+                        </div> <span id="mainSearchHelper" class="form-text text-muted sr-only">Please fill in this field to find a procedure</span>
+                    </form>
                 </div>
             </div>
-            <!-- End leave one column as space -->
-
-
-    <input type="hidden" id="pageLanguage" value ="en"/>
-
-
-      <!-- procedure file content-->
-            <div class="ep_gridcolumn" data-view1200="8" data-view1020="9" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
-
-        <!-- title/header -->
-        <h3 class="ep_hidden">Document reference</h3>
-<div class="ep_gridrow ep-o_product" id="procedure-file-header">
-  <div class="ep_gridrow-content">
-    <div class="ep_gridcolumn ep-m_header" data-view1200="7" data-view1020="7" data-view750="11" data-view640="7" data-view480="8" data-view320="4">
-      <div class="ep_gridcolumn-content">
-        <div class="ep-a_heading ep-layout_level1">
-          <div class="ep_title">
-            <div class="ep-p_text">
-              <span class="ep_name">
-                2023/2019(INI)
-              </span>
-              <span class="ep_icon">&nbsp;</span>
-            </div>
-          </div>
         </div>
-      </div>
     </div>
-    <div class="ep_gridcolumn" data-view1200="1" data-view1020="1" data-view750="1" data-view640="1" data-view480="8" data-view320="4">
-      <div class="ep_gridcolumn-content">
-
-        <div class="ep-a_links doc-right">
-          <ul class="ep_list">
-            <li class="ep-p_text ep-layout_pdf">
-              <a title="open this PDF in a new window" target="_blank" href="/oeil/popups/printficheglobal.pdf?id=743156&l=en">
-                <span class="ep_name">
-                  <span class="ep_format">&nbsp;</span>
-                </span>
-                <span class="ep_icon">&nbsp;</span>
-              </a>
-            </li>
-          </ul>
+    <div class="erpl_header-bottom">
+        <div class="erpl_header-menu-container">
+            <div class="container"><nav class="erpl_header-menu" aria-label="Main navigation">
+    <div class="erpl_header-menu-top row align-items-center">
+        <div class="col d-md-none d-flex align-items-center">
+            <svg aria-hidden="true" class="es_icon es_icon-ep-logo-w erpl_header-menu-top-logo">
+                <use xlink:href="#es_icon-ep-logo-w"></use>
+            </svg>
         </div>
 
-      </div>
+        <span class="erpl_header-menu-top-title offset-3 col-6 text-center d-none d-md-block" aria-hidden="true">
+								<span>European Parliament</span></span>
+
+        <div class="erpl_header-menu-top-controls col-auto col-md-3 text-right">
+            <button type="button" class="btn btn-sm btn-dark-primary erpl_header-menu-top-controls-toggle-search" id="headerMenuToggleSearch" aria-haspopup="true" aria-expanded="false">
+                <span class="sr-only">Search</span>
+                <svg aria-hidden="true" class="es_icon es_icon-search">
+                    <use xlink:href="#es_icon-search"></use>
+                </svg>
+            </button>
+            <button type="button"
+                    class="btn btn-sm btn-dark-primary erpl_header-menu-top-controls-toggle-menu"
+                    id="headerMenuToggleMenu"
+                    aria-haspopup="true"
+                    aria-expanded="false">
+                <span class="mr-25">Menu</span> <span class="erpl_header-menu-icon" aria-hidden="true"></span>
+            </button>
+        </div>
     </div>
 
-    <div class="ep_gridcolumn ep-m_header ep-layout_underline"  data-view1200="8" data-view1020="8" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
-      <div class="ep_gridcolumn-content">
-        <div class="ep-a_heading ep-layout_level2-large">
-          <div class="ep_title">
-            <div class="ep-p_text">
-              <span class="ep_name">
-                  Implementation of the 2018 Geoblocking Regulation in the Digital Single Market
-              </span>
-              <span class="ep_icon">&nbsp;</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>        <!-- title/header -->
-
-
-        <!-- Basic information -->
-        <!-- Basic Information -->
-<div class="ep_gridrow ep-o_product" id="basicInformation">
-  <div class="ep_gridrow-content">
-    <!-- SECTION HEADER -->
-    <div class="ep_gridcolumn ep-m_header" data-view1200="8" data-view1020="8" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
-      <div class="ep_gridrow">
-        <div class="ep_gridrow-content">
-          <div class="ep_gridcolumn" data-view1200="4" data-view1020="4" data-view750="6" data-view640="8" data-view480="8" data-view320="4">
-            <div class="ep_gridcolumn-content">
-              <div class="ep-a_heading ep-layout_level2-large">
-                <div class="ep_title">
-                  <div class="ep-p_text">
-                    <span class="ep_name">
-                      <span class="open proc-section-switch" title="Open / Close section" data-id="basic-information-data"></span> Basic information
-                    </span>
-                    <span class="ep_icon">&nbsp;</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="ep_gridcolumn" data-view1200="4" data-view1020="4" data-view750="6" data-view640="8" data-view480="8" data-view320="4">
-            <div class="ep_gridcolumn-content">
-                            <div class="ep-a_links doc-right">
-  <ul class="ep_list">
-    <li class="ep-p_text ep-layout_pdf">
-      <a title="open this PDF in a new window" target="_blank" href="/oeil/popups/printbasicinformation.pdf?id=743156&lang=en">
-        <span class="ep_name">
-          Basic information <!-- in PDF format -->
-          <span class="ep_format">&nbsp;</span>
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-    </li>
-  </ul>
-</div>
-
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="ep_gridrow ep-o_product" id="basic-information-data">
-  <div class="ep_gridrow-content">
-    <!-- SECTION HEADER -->
-    <div class="ep_gridcolumn ep-m_header" data-view1200="8" data-view1020="8" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
-      <div class="ep_gridrow">
-        <div class="ep_gridrow-content">
-          <div class="ep_gridcolumn" data-view1200="4" data-view1020="4" data-view750="6" data-view640="8" data-view480="8" data-view320="4">
-            <div class="ep_gridcolumn-content">
-              <div class="ep-a_text">
-                <p><strong>2023/2019(INI)</strong></p>
-                <p>
-                  INI - Own-initiative procedure
-                                  </p>
-
-                                      <p>
-
-                                                    <br/><strong>Subject</strong><br />
-                                                          2 Internal market, single market<br/>
-                                                        3.30.25 International information networks and society, internet<br/>
-                                                        3.45.05 Business policy, e-commerce, after-sales service, commercial distribution<br/>
-                                                        3.50.15 Intellectual property, copyright <br/>
-                                                        4.60.06 Consumers' economic and legal interests<br/>
-                                                                                                                          </p>
-                                </div>
-            </div>
-          </div>
-          <div class="ep_gridcolumn" data-view1200="4" data-view1020="4" data-view750="6" data-view640="8" data-view480="8" data-view320="4">
-            <div class="ep_gridcolumn-content">
-              <div class="ep-a_text">
-                <p><strong>Status</strong></p>
-                <p class="procedure-status">
-                                      Procedure completed
-                                  </p>
-                <p>&nbsp;</p>
-
-
-
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-        <div class="ep_gridcolumn ep-m_footer" data-view1200="8" data-view1020="8" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
-      <div class="ep_gridcolumn-content">
-        <div class="ep-a_loadmore">
-          <div class="ep_button">
-
-            <a onclick='OEIL6_RWD_Lib.core.gotoSection("#documentGateway"); return false;' href="#" class="ep-p_text">
-              <span class="ep_name">Please go to Documentation gateway for any follow-up documents.<span class="ep_hidden">: Please go to Documentation gateway for any follow-up documents.</span></span><span class="ep_icon">&nbsp;</span>
-            </a>
-
-          </div>
-        </div>
-      </div>
-    </div>
-      </div>
-</div>
-
-        <!-- /Basic information -->
-
-        <!-- Key Players -->
-        <div class="ep_gridrow ep-o_product" id="keyPlayers">
-  <div class="ep_gridrow-content">
-    <!-- SECTION HEADER -->
-    <div class="ep_gridcolumn ep-m_header" data-view1200="8" data-view1020="8" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
-      <div class="ep_gridrow">
-        <div class="ep_gridrow-content">
-          <div class="ep_gridcolumn" data-view1200="4" data-view1020="4" data-view750="6" data-view640="8" data-view480="8" data-view320="4">
-            <div class="ep_gridcolumn-content">
-              <div class="ep-a_heading ep-layout_level2-large">
-                <div class="ep_title">
-                  <div class="ep-p_text">
-                    <span class="ep_name">
-                      <span class="open proc-section-switch" title="Open / Close section" data-id="key_players-data"></span>
-                      Key players
-                    </span>
-                    <span class="ep_icon">&nbsp;</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="ep_gridcolumn" data-view1200="4" data-view1020="4" data-view750="6" data-view640="8" data-view480="8" data-view320="4">
-            <div class="ep_gridcolumn-content">
-                            <div class="ep-a_links doc-right">
-  <ul class="ep_list">
-    <li class="ep-p_text ep-layout_pdf">
-      <a title="open this PDF in a new window" target="_blank" href="/oeil/popups/printficheplayers.pdf?id=743156&lang=en">
-        <span class="ep_name">
-          Key players <!-- in PDF format -->
-          <span class="ep_format">&nbsp;</span>
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-    </li>
-  </ul>
-</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- ep_gridrow-content -->
-</div>
-
-<div id="key_players-data" class="ep_gridrow ep-o_product">
-  <div class="ep_gridrow-content">
-    <div class="ep_gridcolumn ep-m_product ep-layout_accordion" data-view1200="8" data-view1020="8" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
-
-      <div class="ep_gridcolumn-content">
-        <ul class="ep_accordion">
-                                <!-- EUROPEAN PARLIAMENT -->
-
-<li class="ep_accordion-item expanded" id="keyplayers_sectionPE" data-selected="true">
-  <div class="ep_accordion-title" id="keyplayers_sectionPE-title">
-    <span>
-      <span class="ep_name">
-                  <a href="http://www.europarl.europa.eu/" title="European Parliament" target="_blank">European Parliament</a>
-              </span>
-      <span class="ep_icon">&nbsp;</span>
-    </span>
-  </div>
-
-  <div class="ep_accordion-content" id="keyplayers_sectionPE-content">
-    <div class="ep-table keyplayers-table">
-              <div class="ep-table-row ep-table-heading-row">
-          <div class="ep-table-cell ep-table-cell-xl">
-            <span class="ep_name">
-              Committee responsible
-            </span>
-          </div>
-          <div class="ep-table-cell ep-table-cell-xl">
-            <span class="ep_name">
-              Rapporteur
-            </span>
-          </div>
-          <div class="ep-table-cell ep-table-cell-s">
-            <span class="ep_name">
-              Appointed
-            </span>
-          </div>
-        </div>
-                          <div class="ep-table-row">
-  <div class="ep-table-cell ep-table-cell-xl" data-column-head="Committee responsible">
-    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
-      <span class="ep_name" title="Internal Market and Consumer Protection">
-        <abbr title="IMCO">IMCO</abbr>
-      </span>
-      <span class="ep_icon">&nbsp;</span>
-    </div>
-    <div class="ep-p_text">
-      <span class="ep_name">
-                  <a href="http://www.europarl.europa.eu/committees/en/imco/home.html" title="Internal Market and Consumer Protection" target="_blank">Internal Market and Consumer Protection</a>
-                      </span>
-    </div>
-  </div>
-
-  <div class="ep-table-cell ep-table-cell-xl" data-column-head="Rapporteur">
-    <div class="ep-a_text">
-    <div>
-                                    <span id="x2" class="ep_name">
-                               <span class="tiptip" title="ECR - European Conservatives and Reformists Group
-
-"><a href="https://www.ecrgroup.eu/" target="blank"><img src="/oeil/IMG?t=pg&i=587005&l=en" class="pg_image"></img></a></span>
-                          </span>
-
-            <a href="http://www.europarl.europa.eu/meps/en/197538" target = "_blank" class="photo" rel="http://www.europarl.europa.eu/mepphoto/197538.jpg">
-              <span id="x3" class="ep_name">
-                                MAZUREK Beata
-              </span>
-            </a>
-            <br/>
-                              </div>
-
-            <div class="rapporter-button">
-          <a  href="#"
-            title="Shadow rapporteur"
-            onclick="OEIL6_RWD_Lib.core.showRapporter(this, 'IMCO'); return false;">
-            <span class="ep_name shifted-up">
-              Shadow rapporteur
-            </span>
-          </a>
-        </div>
-
-        <div id="shadow-rapporteur-IMCO" class="shadow-rapporteur">
-                  <span class="ep_name">
-                          <span class="tiptip" title="EPP - Group of European People's Party
-
-"><a href="https://www.eppgroup.eu" target="blank"><img src="/oeil/IMG?t=pg&i=587000&l=en" class="pg_image"></img></a></span>
-                      </span>
-
-          <a href="http://www.europarl.europa.eu/meps/en/124988" target = "_blank" class="photo" rel="http://www.europarl.europa.eu/mepphoto/124988.jpg">
-            <span class="ep_name">CLUNE Deirdre </span>
-          </a>
-
-          <br />
-                  <span class="ep_name">
-                          <span class="tiptip" title="S&D - Group of Progressive Alliance of Socialists and Democrats
-
-"><a href="https://www.socialistsanddemocrats.eu/" target="blank"><img src="/oeil/IMG?t=pg&i=587001&l=en" class="pg_image"></img></a></span>
-                      </span>
-
-          <a href="http://www.europarl.europa.eu/meps/en/202073" target = "_blank" class="photo" rel="http://www.europarl.europa.eu/mepphoto/202073.jpg">
-            <span class="ep_name">ANGEL Marc </span>
-          </a>
-
-          <br />
-                  <span class="ep_name">
-                          <span class="tiptip" title="Renew Europe group
-
-"><a href="https://www.alde.eu/en/" target="blank"><img src="/oeil/IMG?t=pg&i=587002&l=en" class="pg_image"></img></a></span>
-                      </span>
-
-          <a href="http://www.europarl.europa.eu/meps/en/96776" target = "_blank" class="photo" rel="http://www.europarl.europa.eu/mepphoto/96776.jpg">
-            <span class="ep_name">THUN UND HOHENSTEIN R&oacute;&#380;a </span>
-          </a>
-
-          <br />
-                  <span class="ep_name">
-                          <span class="tiptip" title="Greens/EFA - Group of the Greens/European Free Alliance
-
-"><a href="https://www.greens-efa.eu/en/" target="blank"><img src="/oeil/IMG?t=pg&i=587003&l=en" class="pg_image"></img></a></span>
-                      </span>
-
-          <a href="http://www.europarl.europa.eu/meps/en/197870" target = "_blank" class="photo" rel="http://www.europarl.europa.eu/mepphoto/197870.jpg">
-            <span class="ep_name">VAN SPARRENTAK Kim </span>
-          </a>
-
-          <br />
-                  <span class="ep_name">
-                          <span class="tiptip" title="ID - Identity and Democracy
-"><img src="/oeil/IMG?t=pg&i=587004&l=en" class="pg_image"></img></span>
-                      </span>
-
-          <a href="http://www.europarl.europa.eu/meps/en/128483" target = "_blank" class="photo" rel="http://www.europarl.europa.eu/mepphoto/128483.jpg">
-            <span class="ep_name">BUCHHEIT Markus </span>
-          </a>
-
-          <br />
-                  <span class="ep_name">
-                          <span class="tiptip" title="The Left group in the European Parliament - GUE/NGL"><a href="https://www.guengl.eu/" target="blank"><img src="/oeil/IMG?t=pg&i=604000&l=en" class="pg_image"></img></a></span>
-                      </span>
-
-          <a href="http://www.europarl.europa.eu/meps/en/130833" target = "_blank" class="photo" rel="http://www.europarl.europa.eu/mepphoto/130833.jpg">
-            <span class="ep_name">KOULOGLOU Stelios </span>
-          </a>
-
-          <br />
-
-
-      </div>
-          </div>
-  </div>
-
-  <div class="ep-table-cell ep-table-cell-s" data-column-head="Appointed">
-    <div class="ep-p_text">
-        <span class="ep_name">
-                                                    01/03/2023
-                                            </span>
-      </div>
-   </div>
-   </div>
-
-
-
-
-
-
-
-
-            <div class="ep-table-row ep-table-heading-row">
-        <div class="ep-table-cell ep-table-cell-xl">
-          <span class="ep_name">
-          Committee for opinion
-            </span>
-        </div>
-        <div class="ep-table-cell ep-table-cell-xl">
-          <span class="ep_name">
-              Rapporteur for opinion
-            </span>
-        </div>
-        <div class="ep-table-cell ep-table-cell-s">
-          <span class="ep_name">
-              Appointed
-            </span>
-        </div>
-      </div>
-                                        <div class="ep-table-row">
-  <div class="ep-table-cell ep-table-cell-xl" data-column-head="Committee for opinion">
-    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
-      <span class="ep_name" title="Culture and Education
-
-">
-        <abbr title="CULT">CULT</abbr>
-      </span>
-      <span class="ep_icon">&nbsp;</span>
-    </div>
-    <div class="ep-p_text">
-      <span class="ep_name">
-                  <a href="http://www.europarl.europa.eu/committees/en/cult/home.html" title="Culture and Education
-
-" target="_blank">Culture and Education
-
-</a>
-                          <br/>(Associated committee)
-              </span>
-    </div>
-  </div>
-
-  <div class="ep-table-cell ep-table-cell-xl" data-column-head="Rapporteur">
-    <div class="ep-a_text">
-    <div>
-                                    <span id="x2" class="ep_name">
-                               <span class="tiptip" title="EPP - Group of European People's Party
-
-"><a href="https://www.eppgroup.eu" target="blank"><img src="/oeil/IMG?t=pg&i=587000&l=en" class="pg_image"></img></a></span>
-                          </span>
-
-            <a href="http://www.europarl.europa.eu/meps/en/96756" target = "_blank" class="photo" rel="http://www.europarl.europa.eu/mepphoto/96756.jpg">
-              <span id="x3" class="ep_name">
-                                VERHEYEN Sabine
-              </span>
-            </a>
-            <br/>
-                              </div>
-
-          </div>
-  </div>
-
-  <div class="ep-table-cell ep-table-cell-s" data-column-head="Appointed">
-    <div class="ep-p_text">
-        <span class="ep_name">
-                                                    09/02/2023
-                                            </span>
-      </div>
-   </div>
-   </div>
-                                  <div class="ep-table-row">
-  <div class="ep-table-cell ep-table-cell-xl" data-column-head="Committee for opinion">
-    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
-      <span class="ep_name" title="Legal Affairs
-
-">
-        <abbr title="JURI">JURI</abbr>
-      </span>
-      <span class="ep_icon">&nbsp;</span>
-    </div>
-    <div class="ep-p_text">
-      <span class="ep_name">
-                  <a href="http://www.europarl.europa.eu/committees/en/juri/home.html" title="Legal Affairs
-
-" target="_blank">Legal Affairs
-
-</a>
-                          <br/>(Associated committee)
-              </span>
-    </div>
-  </div>
-
-  <div class="ep-table-cell ep-table-cell-xl" data-column-head="Rapporteur">
-    <div class="ep-a_text">
-    <div>
-                                    <span id="x2" class="ep_name">
-                               <span class="tiptip" title="Renew Europe group
-
-"><a href="https://www.alde.eu/en/" target="blank"><img src="/oeil/IMG?t=pg&i=587002&l=en" class="pg_image"></img></a></span>
-                          </span>
-
-            <a href="http://www.europarl.europa.eu/meps/en/197567" target = "_blank" class="photo" rel="http://www.europarl.europa.eu/mepphoto/197567.jpg">
-              <span id="x3" class="ep_name">
-                                MELCHIOR Karen
-              </span>
-            </a>
-            <br/>
-                              </div>
-
-          </div>
-  </div>
-
-  <div class="ep-table-cell ep-table-cell-s" data-column-head="Appointed">
-    <div class="ep-p_text">
-        <span class="ep_name">
-                                                    28/02/2023
-                                            </span>
-      </div>
-   </div>
-   </div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    </div>
-  </div>
-</li>            <!-- END EUROPEAN PARLIAMENT -->
-                                          <!-- COMMISSION -->
-
-<li class="ep_accordion-item" id="keyplayers_sectionEC" data-selected="false">
-  <div class="ep_accordion-title" id="keyplayers_sectionEC-title">
-    <span><span class="ep_name">
-                    <a href="http://ec.europa.eu/" title="European Commission" target="_blank">European Commission</a>
-          </span><span class="ep_icon">&nbsp;</span></span>
-  </div>
-
-  <div class="ep_accordion-content" id="keyplayers_sectionEC-content">
-    <div class="ep-table keyplayers-table">
-      <div class="ep-table-row ep-table-heading-row">
-        <div class="ep-table-cell ep-table-cell-xl">
-          <span class="ep_name">
-            Commission DG
-          </span>
-        </div>
-        <div class="ep-table-cell ep-table-cell-xl">
-          <span class="ep_name">
-            Commissioner
-          </span>
-        </div>
-      </div>
-      <div class="ep-table-row">
-        <div class="ep-table-cell ep-table-cell-xl" data-column-head="Commission DG">
-
-          <div class="ep-p_text">
-
-
-                                  <a href="http://ec.europa.eu/info/departments/internal-market-industry-entrepreneurship-and-smes_en" title="Internal Market, Industry, Entrepreneurship and SMEs" target="_blank">
-                    <span class="ep_name">
-                      Internal Market, Industry, Entrepreneurship and SMEs
-                    <span class="ep_icon">&nbsp;</span>
-                  </a>
-
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-xl" data-column-head="Commissioner">
-          <div class="ep-p_text">
-
-              <span class="ep_name">
-                                                                            BRETON  Thierry
-                                                                    </span>
-              <span class="ep_icon">&nbsp;</span>
-
-          </div>
-
-
-        </div>
-      </div>
-
-
-
-</div>
-</div>
+    <ul class="erpl_header-menu-list list-unstyled">
+        
+<li class="erpl_header-menu-item">
+    <a class="erpl_header-menu-item-title"
+       href="/oeil/en" data-selected="false">
+        <span class="t-y">Home</span>
+    </a>
+</li>
+<li class="erpl_header-menu-item">
+    <a class="erpl_header-menu-item-title"
+       href="/oeil/en/search" data-selected="false">
+        <span class="t-y">Search</span>
+    </a>
+</li>
+<li class="erpl_header-menu-item">
+    <a class="erpl_header-menu-item-title"
+       href="/oeil/en/legislative-priorities" data-selected="false">
+        <span class="t-y">Legislative priorities</span>
+    </a>
+</li>
+<li class="erpl_header-menu-item">
+    <a class="erpl_header-menu-item-title"
+       href="/oeil/en/find-out-more" data-selected="false">
+        <span class="t-y">Find out more</span>
+    </a>
+</li>
+<li class="erpl_header-menu-item">
+    <a class="erpl_header-menu-item-title"
+       href="/oeil/en/contact" data-selected="false">
+        <span class="t-y">Contact us</span>
+    </a>
 </li>
 
-            <!-- END COMMISSION -->
-
-        </ul>
-      </div>
-
-
-
-
-
+    </ul>
+</nav></div>
+        </div>
     </div>
-  </div>
-</div>
+</header>
 
+    <div class="container">
+        <div class="breadcrumb"></div>
+    </div>
 
-
-
-
-        <!-- /Key Players -->
-
-        <!-- Key Events -->
-        <div class="ep_gridrow ep-o_headerpage ep-layout_greycolor lo_white">
-</div>
-<div class="ep_gridrow ep-o_product" id="keyEvents">
-  <div class="ep_gridrow-content">
-    <!-- SECTION HEADER -->
-    <div class="ep_gridcolumn ep-m_header ep-layout_underline" data-view1200="8" data-view1020="8" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
-      <div class="ep_gridrow">
-        <div class="ep_gridrow-content">
-          <div class="ep_gridcolumn" data-view1200="4" data-view1020="4" data-view750="6" data-view640="8" data-view480="8" data-view320="4">
-            <div class="ep_gridcolumn-content">
-              <div class="ep-a_heading ep-layout_level2-large">
-                <div class="ep_title">
-                  <div class="ep-p_text">
-                    <span class="ep_name">
-                      <span class="open proc-section-switch" title="Open / Close section" data-id="key_events-data"></span>
-                      Key events
-                    </span>
-                    <span class="ep_icon">&nbsp;</span>
-                  </div>
+    
+    <main id="website-body">
+<div class="container">
+    <div class="row">
+        <div class="col-12 col-xl-8">
+            <div class="row">
+                <div class="col-12 col-lg"><h2 class="erpl_title-h1 mb-3">2023/2019(INI)</h2>
                 </div>
-              </div>
-            </div>
-          </div>
-          <div class="ep_gridcolumn" data-view1200="4" data-view1020="4" data-view750="6" data-view640="8" data-view480="8" data-view320="4">
-            <div class="ep_gridcolumn-content">
-                            <div class="ep-a_links doc-right">
-  <ul class="ep_list">
-    <li class="ep-p_text ep-layout_pdf">
-      <a title="open this PDF in a new window" target="_blank" href="/oeil/popups/printficheevents.pdf?id=743156&lang=en">
-        <span class="ep_name">
-          Key events <!-- in PDF format -->
-          <span class="ep_format">&nbsp;</span>
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-    </li>
-  </ul>
-</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- ep_gridrow-content -->
-</div>
-
-
-<div id="key_events-data" class="ep_gridcolumn ep-m_product" data-view1200="8" data-view1020="8" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
-  <div class="ep_gridcolumn-content">
-    <div class="ep-table ep-table-heading">
-
-
-                    <div class="ep-table-row">
-        <div class="ep-table-cell ep-table-cell-s ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name">16/02/2023</span>
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-xl ep-table-column-head">
-            <div class="ep-p_text">
-              <span class="ep_name">Committee referral announced in Parliament</span>
-            </div>
-          </div>
-        <div class="ep-table-cell ep-table-cell-m center-cell">
-          <div class="ep-p_text">
-            <span class="ep_name">
-
-                                                                          </span>
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-m center-cell">
-                  </div>
-      </div>
-
-                            <div class="ep-table-row">
-        <div class="ep-table-cell ep-table-cell-s ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name">16/02/2023</span>
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-xl ep-table-column-head">
-            <div class="ep-p_text">
-              <span class="ep_name">Referral to associated committees announced in Parliament</span>
-            </div>
-          </div>
-        <div class="ep-table-cell ep-table-cell-m center-cell">
-          <div class="ep-p_text">
-            <span class="ep_name">
-
-                                                                          </span>
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-m center-cell">
-                  </div>
-      </div>
-
-                            <div class="ep-table-row">
-        <div class="ep-table-cell ep-table-cell-s ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name">25/10/2023</span>
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-xl ep-table-column-head">
-            <div class="ep-p_text">
-              <span class="ep_name">Vote in committee</span>
-            </div>
-          </div>
-        <div class="ep-table-cell ep-table-cell-m center-cell">
-          <div class="ep-p_text">
-            <span class="ep_name">
-
-                                                                          </span>
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-m center-cell">
-                  </div>
-      </div>
-
-                            <div class="ep-table-row">
-        <div class="ep-table-cell ep-table-cell-s ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name">07/11/2023</span>
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-xl ep-table-column-head">
-            <div class="ep-p_text">
-              <span class="ep_name">Committee report tabled for plenary</span>
-            </div>
-          </div>
-        <div class="ep-table-cell ep-table-cell-m center-cell">
-          <div class="ep-p_text">
-            <span class="ep_name">
-                                                <a class="externalDocument" href="https://www.europarl.europa.eu/doceo/document/A-9-2023-0335_EN.html" target="externalDocument">A9-0335/2023</a>
-                                                                        </span>
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-m center-cell">
-                    <div class="ep-a_button ep-layout_neutral">
-            <div class="ep-p_button ep-p_smallbutton">
-              <button id="summary" type="button" onclick="location.href='/oeil/popups/summary.do?id=1764550&t=e&l=en'" title="Summary for Committee report tabled for plenary" target="_blank">
-                <span class="ep_name">Summary</span><span class="ep_icon">&nbsp;</span>
-              </button>
-            </div>
-          </div>
-                  </div>
-      </div>
-
-                            <div class="ep-table-row">
-        <div class="ep-table-cell ep-table-cell-s ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name">13/12/2023</span>
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-xl ep-table-column-head">
-            <div class="ep-p_text">
-              <span class="ep_name">Decision by Parliament</span>
-            </div>
-          </div>
-        <div class="ep-table-cell ep-table-cell-m center-cell">
-          <div class="ep-p_text">
-            <span class="ep_name">
-                                                <a class="externalDocument" href="https://www.europarl.europa.eu/doceo/document/TA-9-2023-0473_EN.html" target="externalDocument">T9-0473/2023</a>
-                                                                        </span>
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-m center-cell">
-                  </div>
-      </div>
-
-
-
-    </div>
-  </div>
-</div>
-
-
-
-
-
-         <!--/Key Events -->
-
-
-         <!-- START : TECHNICAL INFO BOX   -->
-
-
-<div class="ep_gridrow ep-o_headerpage ep-layout_greycolor lo_white">
-</div>
-<div class="ep_gridrow ep-o_product" id="technicalInformation">
-  <div class="ep_gridrow-content">
-    <!-- SECTION HEADER -->
-    <div class="ep_gridcolumn ep-m_header ep-layout_underline" data-view1200="8" data-view1020="8" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
-      <div class="ep_gridrow">
-        <div class="ep_gridrow-content">
-          <div class="ep_gridcolumn" data-view1200="4" data-view1020="4" data-view750="6" data-view640="8" data-view480="8" data-view320="4">
-            <div class="ep_gridcolumn-content">
-              <div class="ep-a_heading ep-layout_level2-large">
-                <div class="ep_title">
-                  <div class="ep-p_text">
-                    <span class="ep_name">
-                      <span class="open proc-section-switch" title="Open / Close section" data-id="technical_information-data"></span>
-                      Technical information
-                    </span>
-                    <span class="ep_icon">&nbsp;</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="ep_gridcolumn" data-view1200="4" data-view1020="4" data-view750="6" data-view640="8" data-view480="8" data-view320="4">
-            <div class="ep_gridcolumn-content">
-                            <div class="ep-a_links doc-right">
-  <ul class="ep_list">
-    <li class="ep-p_text ep-layout_pdf">
-      <a title="open this PDF in a new window" target="_blank" href="/oeil/popups/printfichetechnical.pdf?id=743156&lang=en">
-        <span class="ep_name">
-          Technical information <!-- in PDF format -->
-          <span class="ep_format">&nbsp;</span>
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-    </li>
-  </ul>
-</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- ep_gridrow-content -->
-</div>
-
-<div id="technical_information-data" class="ep_gridcolumn ep-m_product" data-view1200="8" data-view1020="8" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
-  <div class="ep_gridcolumn-content">
-    <div class="ep-table ep-table-heading">
-
-                  <div class="ep-table-row">
-        <div class="ep-table-cell ep-table-cell-s ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name">
-              <strong>
-                                  Procedure reference
-                                  </strong>
-            </span>
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-xl ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name">2023/2019(INI)</span>
-          </div>
-        </div>
-      </div>
-
-      <div class="ep-table-row">
-        <div class="ep-table-cell ep-table-cell-s ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name">
-              <strong>Procedure type</strong>
-            </span>
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-xl ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name">INI - Own-initiative procedure</span>
-          </div>
-        </div>
-      </div>
-
-                        <div class="ep-table-row">
-        <div class="ep-table-cell ep-table-cell-s ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name"><strong>Procedure subtype</strong></span>
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-xl ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name">Implementation</span>
-          </div>
-        </div>
-      </div>
-
-
-
-
-                        <div class="ep-table-row">
-        <div class="ep-table-cell ep-table-cell-s ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name"><strong>Legal basis</strong></span>
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-xl ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name">Rules of Procedure EP 54; Rules of Procedure EP 57</span>
-          </div>
-        </div>
-      </div>
-
-            <div class="ep-table-row">
-        <div class="ep-table-cell ep-table-cell-s ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name"><strong>Other legal basis</strong></span>
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-xl ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name">Rules of Procedure EP 159</span>
-          </div>
-        </div>
-      </div>
-
-
-                        <div class="ep-table-row">
-        <div class="ep-table-cell ep-table-cell-s ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name"><strong>Stage reached in procedure</strong></span>
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-xl ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name">Procedure completed</span>
-          </div>
-        </div>
-      </div>
-
-                        <div class="ep-table-row">
-        <div class="ep-table-cell ep-table-cell-s ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name"><strong>Committee dossier</strong></span>
-          </div>
-        </div>
-        <div class="ep-table-cell ep-table-cell-xl ep-table-column-head">
-          <div class="ep-p_text">
-            <span class="ep_name">IMCO/9/11285</span>
-          </div>
-        </div>
-      </div>
-
-
-
-
-    </div>
-  </div>
-</div>
-
-<!-- END : TECHNICAL INFO BOX   -->
-
-
-         <div class="ep_gridrow ep-o_headerpage ep-layout_greycolor lo_white">
-</div>
-
-<!-- START : DOCUMENTATION GATEWAY BOX   -->
-<div class="ep_gridrow ep-o_product" id="documentGateway">
-  <div class="ep_gridrow-content">
-    <!-- SECTION HEADER -->
-    <div class="ep_gridcolumn ep-m_header" data-view1200="8" data-view1020="8" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
-      <div class="ep_gridrow">
-        <div class="ep_gridrow-content">
-          <div class="ep_gridcolumn" data-view1200="4" data-view1020="4" data-view750="6" data-view640="8" data-view480="8" data-view320="4">
-            <div class="ep_gridcolumn-content">
-              <div class="ep-a_heading ep-layout_level2-large">
-                <div class="ep_title">
-                  <div class="ep-p_text">
-                    <span class="ep_name">
-                      <span class="open proc-section-switch" title="Open / Close section" data-id="document_gateway-data"></span>
-                      Documentation gateway
-                    </span>
-                    <span class="ep_icon">&nbsp;</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="ep_gridcolumn" data-view1200="4" data-view1020="4" data-view750="6" data-view640="8" data-view480="8" data-view320="4">
-            <div class="ep_gridcolumn-content">
-                            <div class="ep-a_links doc-right">
-  <ul class="ep_list">
-    <li class="ep-p_text ep-layout_pdf">
-      <a title="open this PDF in a new window" target="_blank" href="/oeil/popups/printfichedocumentation.pdf?id=743156&lang=en">
-        <span class="ep_name">
-          Documentation gateway <!-- in PDF format -->
-          <span class="ep_format">&nbsp;</span>
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-    </li>
-  </ul>
-</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- ep_gridrow-content -->
-</div>
-
-
-
-
-
-<div id="document_gateway-data" class="ep_gridrow ep-o_product">
-  <div class="ep_gridrow-content">
-    <div class="ep_gridcolumn ep-m_product ep-layout_accordion" data-view1200="8" data-view1020="8" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
-      <div class="ep_gridcolumn-content">
-        <ul class="ep_accordion">
-
-                    <li class="ep_accordion-item" id="keyplayers_section2" data-selected="false">
-            <div class="ep_accordion-title" id="keyplayers_section2-title">
-              <span><span class="ep_name">European Parliament</span><span class="ep_icon">&nbsp;</span></span>
-            </div>
-            <div class="ep_accordion-content" id="keyplayers_section2-content">
-              <div class="ep-table keyplayers-table">
-
-<div class="ep-table-row">
-
-  <!-- 1. text -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                  Committee draft report
-              </span>
-    </div>
-  </div>
-
-  <!-- 2. code -->
-  <div class="ep-table-cell ep-table-cell-xss">
-          <div class="ep-p_text">
-        <span class="ep_name" title="European Parliament">
-                      &nbsp;
-                  </span>
-        <span class="ep_icon">&nbsp;</span>
-      </div>
-      </div>
-
-  <!-- 3. URL -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-          <a href="https://www.europarl.europa.eu/doceo/document/IMCO-PR-749206_EN.html" target="_blank">
-        <span class="ep_name">
-          PE749.206
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">15/06/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. institutional code -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                              <span class="ep_name"  title="European Parliament">EP</span>
-                        </span>
-    </div>
-  </div>
-
-  <!-- 6. summary button -->
-  <div class="ep-table-cell">
-    <div class="ep-a_button ep-layout_neutral">
-      <div class="ep-p_button ep-p_smallbutton">
-              <div class="ep-p_text">
-          <span class="ep_name">&nbsp;</span>
-        </div>
-            </div>
-    </div>
-  </div>
-</div>
-
-<div class="ep-table-row">
-
-  <!-- 1. text -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                  Amendments tabled in committee
-              </span>
-    </div>
-  </div>
-
-  <!-- 2. code -->
-  <div class="ep-table-cell ep-table-cell-xss">
-          <div class="ep-p_text">
-        <span class="ep_name" title="European Parliament">
-                      &nbsp;
-                  </span>
-        <span class="ep_icon">&nbsp;</span>
-      </div>
-      </div>
-
-  <!-- 3. URL -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-          <a href="https://www.europarl.europa.eu/doceo/document/IMCO-AM-750251_EN.html" target="_blank">
-        <span class="ep_name">
-          PE750.251
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">13/07/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. institutional code -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                              <span class="ep_name"  title="European Parliament">EP</span>
-                        </span>
-    </div>
-  </div>
-
-  <!-- 6. summary button -->
-  <div class="ep-table-cell">
-    <div class="ep-a_button ep-layout_neutral">
-      <div class="ep-p_button ep-p_smallbutton">
-              <div class="ep-p_text">
-          <span class="ep_name">&nbsp;</span>
-        </div>
-            </div>
-    </div>
-  </div>
-</div>
-
-<div class="ep-table-row">
-
-  <!-- 1. text -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                  Committee opinion
-              </span>
-    </div>
-  </div>
-
-  <!-- 2. code -->
-  <div class="ep-table-cell ep-table-cell-xss">
-        <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
-      <span class="ep_name" title="Culture and Education
-
-">
-        <abbr title="Culture and Education
-
-">CULT</abbr>
-      </span>
-      <span class="ep_icon">&nbsp;</span>
-    </div>
-      </div>
-
-  <!-- 3. URL -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-          <a href="https://www.europarl.europa.eu/doceo/document/CULT-AD-746896_EN.html" target="_blank">
-        <span class="ep_name">
-          PE746.896
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">18/07/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. institutional code -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                              <span class="ep_name"  title="European Parliament">EP</span>
-                        </span>
-    </div>
-  </div>
-
-  <!-- 6. summary button -->
-  <div class="ep-table-cell">
-    <div class="ep-a_button ep-layout_neutral">
-      <div class="ep-p_button ep-p_smallbutton">
-              <div class="ep-p_text">
-          <span class="ep_name">&nbsp;</span>
-        </div>
-            </div>
-    </div>
-  </div>
-</div>
-
-<div class="ep-table-row">
-
-  <!-- 1. text -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                  Committee opinion
-              </span>
-    </div>
-  </div>
-
-  <!-- 2. code -->
-  <div class="ep-table-cell ep-table-cell-xss">
-        <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
-      <span class="ep_name" title="Legal Affairs
-
-">
-        <abbr title="Legal Affairs
-
-">JURI</abbr>
-      </span>
-      <span class="ep_icon">&nbsp;</span>
-    </div>
-      </div>
-
-  <!-- 3. URL -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-          <a href="https://www.europarl.europa.eu/doceo/document/JURI-AD-749286_EN.html" target="_blank">
-        <span class="ep_name">
-          PE749.286
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">24/10/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. institutional code -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                              <span class="ep_name"  title="European Parliament">EP</span>
-                        </span>
-    </div>
-  </div>
-
-  <!-- 6. summary button -->
-  <div class="ep-table-cell">
-    <div class="ep-a_button ep-layout_neutral">
-      <div class="ep-p_button ep-p_smallbutton">
-              <div class="ep-p_text">
-          <span class="ep_name">&nbsp;</span>
-        </div>
-            </div>
-    </div>
-  </div>
-</div>
-
-<div class="ep-table-row">
-
-  <!-- 1. text -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                  Committee report tabled for plenary, single reading
-              </span>
-    </div>
-  </div>
-
-  <!-- 2. code -->
-  <div class="ep-table-cell ep-table-cell-xss">
-          <div class="ep-p_text">
-        <span class="ep_name" title="European Parliament">
-                      &nbsp;
-                  </span>
-        <span class="ep_icon">&nbsp;</span>
-      </div>
-      </div>
-
-  <!-- 3. URL -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-          <a href="https://www.europarl.europa.eu/doceo/document/A-9-2023-0335_EN.html" target="_blank">
-        <span class="ep_name">
-          A9-0335/2023
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">07/11/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. institutional code -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                              <span class="ep_name"  title="European Parliament">EP</span>
-                        </span>
-    </div>
-  </div>
-
-  <!-- 6. summary button -->
-  <div class="ep-table-cell">
-    <div class="ep-a_button ep-layout_neutral">
-      <div class="ep-p_button ep-p_smallbutton">
-            <button id="summary" type="button" onclick="location.href='/oeil/popups/summary.do?id=1764550&t=d&l=en'" title="Summary for Committee report tabled for plenary, single reading" target="_blank">
-        <span class="ep_name">Summary</span>
-      </button>
-            </div>
-    </div>
-  </div>
-</div>
-
-<div class="ep-table-row">
-
-  <!-- 1. text -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                  Text adopted by Parliament, single reading
-              </span>
-    </div>
-  </div>
-
-  <!-- 2. code -->
-  <div class="ep-table-cell ep-table-cell-xss">
-          <div class="ep-p_text">
-        <span class="ep_name" title="European Parliament">
-                      &nbsp;
-                  </span>
-        <span class="ep_icon">&nbsp;</span>
-      </div>
-      </div>
-
-  <!-- 3. URL -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-          <a href="https://www.europarl.europa.eu/doceo/document/TA-9-2023-0473_EN.html" target="_blank">
-        <span class="ep_name">
-          T9-0473/2023
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">13/12/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. institutional code -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                              <span class="ep_name"  title="European Parliament">EP</span>
-                        </span>
-    </div>
-  </div>
-
-  <!-- 6. summary button -->
-  <div class="ep-table-cell">
-    <div class="ep-a_button ep-layout_neutral">
-      <div class="ep-p_button ep-p_smallbutton">
-              <div class="ep-p_text">
-          <span class="ep_name">&nbsp;</span>
-        </div>
-            </div>
-    </div>
-  </div>
-</div>
-                              </div>
-            </div>
-          </li>
-
-
-
-
-
-
-
-
-
-
-
-                    <li class="ep_accordion-item" id="keyplayers_section2" data-selected="false">
-            <div class="ep_accordion-title" id="keyplayers_section2-title">
-              <span><span class="ep_name">All</span><span class="ep_icon">&nbsp;</span></span>
-            </div>
-            <div class="ep_accordion-content" id="keyplayers_section2-content">
-              <div class="ep-table keyplayers-table">
-
-<div class="ep-table-row">
-
-  <!-- 1. text -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                  Committee draft report
-              </span>
-    </div>
-  </div>
-
-  <!-- 2. code -->
-  <div class="ep-table-cell ep-table-cell-xss">
-          <div class="ep-p_text">
-        <span class="ep_name" title="European Parliament">
-                      &nbsp;
-                  </span>
-        <span class="ep_icon">&nbsp;</span>
-      </div>
-      </div>
-
-  <!-- 3. URL -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-          <a href="https://www.europarl.europa.eu/doceo/document/IMCO-PR-749206_EN.html" target="_blank">
-        <span class="ep_name">
-          PE749.206
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">15/06/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. institutional code -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                              <span class="ep_name"  title="European Parliament">EP</span>
-                        </span>
-    </div>
-  </div>
-
-  <!-- 6. summary button -->
-  <div class="ep-table-cell">
-    <div class="ep-a_button ep-layout_neutral">
-      <div class="ep-p_button ep-p_smallbutton">
-              <div class="ep-p_text">
-          <span class="ep_name">&nbsp;</span>
-        </div>
-            </div>
-    </div>
-  </div>
-</div>
-
-<div class="ep-table-row">
-
-  <!-- 1. text -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                  Amendments tabled in committee
-              </span>
-    </div>
-  </div>
-
-  <!-- 2. code -->
-  <div class="ep-table-cell ep-table-cell-xss">
-          <div class="ep-p_text">
-        <span class="ep_name" title="European Parliament">
-                      &nbsp;
-                  </span>
-        <span class="ep_icon">&nbsp;</span>
-      </div>
-      </div>
-
-  <!-- 3. URL -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-          <a href="https://www.europarl.europa.eu/doceo/document/IMCO-AM-750251_EN.html" target="_blank">
-        <span class="ep_name">
-          PE750.251
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">13/07/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. institutional code -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                              <span class="ep_name"  title="European Parliament">EP</span>
-                        </span>
-    </div>
-  </div>
-
-  <!-- 6. summary button -->
-  <div class="ep-table-cell">
-    <div class="ep-a_button ep-layout_neutral">
-      <div class="ep-p_button ep-p_smallbutton">
-              <div class="ep-p_text">
-          <span class="ep_name">&nbsp;</span>
-        </div>
-            </div>
-    </div>
-  </div>
-</div>
-
-<div class="ep-table-row">
-
-  <!-- 1. text -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                  Committee opinion
-              </span>
-    </div>
-  </div>
-
-  <!-- 2. code -->
-  <div class="ep-table-cell ep-table-cell-xss">
-        <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
-      <span class="ep_name" title="Culture and Education
-
-">
-        <abbr title="Culture and Education
-
-">CULT</abbr>
-      </span>
-      <span class="ep_icon">&nbsp;</span>
-    </div>
-      </div>
-
-  <!-- 3. URL -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-          <a href="https://www.europarl.europa.eu/doceo/document/CULT-AD-746896_EN.html" target="_blank">
-        <span class="ep_name">
-          PE746.896
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">18/07/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. institutional code -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                              <span class="ep_name"  title="European Parliament">EP</span>
-                        </span>
-    </div>
-  </div>
-
-  <!-- 6. summary button -->
-  <div class="ep-table-cell">
-    <div class="ep-a_button ep-layout_neutral">
-      <div class="ep-p_button ep-p_smallbutton">
-              <div class="ep-p_text">
-          <span class="ep_name">&nbsp;</span>
-        </div>
-            </div>
-    </div>
-  </div>
-</div>
-
-<div class="ep-table-row">
-
-  <!-- 1. text -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                  Committee opinion
-              </span>
-    </div>
-  </div>
-
-  <!-- 2. code -->
-  <div class="ep-table-cell ep-table-cell-xss">
-        <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
-      <span class="ep_name" title="Legal Affairs
-
-">
-        <abbr title="Legal Affairs
-
-">JURI</abbr>
-      </span>
-      <span class="ep_icon">&nbsp;</span>
-    </div>
-      </div>
-
-  <!-- 3. URL -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-          <a href="https://www.europarl.europa.eu/doceo/document/JURI-AD-749286_EN.html" target="_blank">
-        <span class="ep_name">
-          PE749.286
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">24/10/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. institutional code -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                              <span class="ep_name"  title="European Parliament">EP</span>
-                        </span>
-    </div>
-  </div>
-
-  <!-- 6. summary button -->
-  <div class="ep-table-cell">
-    <div class="ep-a_button ep-layout_neutral">
-      <div class="ep-p_button ep-p_smallbutton">
-              <div class="ep-p_text">
-          <span class="ep_name">&nbsp;</span>
-        </div>
-            </div>
-    </div>
-  </div>
-</div>
-
-<div class="ep-table-row">
-
-  <!-- 1. text -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                  Committee report tabled for plenary, single reading
-              </span>
-    </div>
-  </div>
-
-  <!-- 2. code -->
-  <div class="ep-table-cell ep-table-cell-xss">
-          <div class="ep-p_text">
-        <span class="ep_name" title="European Parliament">
-                      &nbsp;
-                  </span>
-        <span class="ep_icon">&nbsp;</span>
-      </div>
-      </div>
-
-  <!-- 3. URL -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-          <a href="https://www.europarl.europa.eu/doceo/document/A-9-2023-0335_EN.html" target="_blank">
-        <span class="ep_name">
-          A9-0335/2023
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">07/11/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. institutional code -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                              <span class="ep_name"  title="European Parliament">EP</span>
-                        </span>
-    </div>
-  </div>
-
-  <!-- 6. summary button -->
-  <div class="ep-table-cell">
-    <div class="ep-a_button ep-layout_neutral">
-      <div class="ep-p_button ep-p_smallbutton">
-            <button id="summary" type="button" onclick="location.href='/oeil/popups/summary.do?id=1764550&t=d&l=en'" title="Summary for Committee report tabled for plenary, single reading" target="_blank">
-        <span class="ep_name">Summary</span>
-      </button>
-            </div>
-    </div>
-  </div>
-</div>
-
-<div class="ep-table-row">
-
-  <!-- 1. text -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                  Text adopted by Parliament, single reading
-              </span>
-    </div>
-  </div>
-
-  <!-- 2. code -->
-  <div class="ep-table-cell ep-table-cell-xss">
-          <div class="ep-p_text">
-        <span class="ep_name" title="European Parliament">
-                      &nbsp;
-                  </span>
-        <span class="ep_icon">&nbsp;</span>
-      </div>
-      </div>
-
-  <!-- 3. URL -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-          <a href="https://www.europarl.europa.eu/doceo/document/TA-9-2023-0473_EN.html" target="_blank">
-        <span class="ep_name">
-          T9-0473/2023
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">13/12/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. institutional code -->
-  <div class="ep-table-cell">
-    <div class="ep-p_text">
-      <span class="ep_name">
-                              <span class="ep_name"  title="European Parliament">EP</span>
-                        </span>
-    </div>
-  </div>
-
-  <!-- 6. summary button -->
-  <div class="ep-table-cell">
-    <div class="ep-a_button ep-layout_neutral">
-      <div class="ep-p_button ep-p_smallbutton">
-              <div class="ep-p_text">
-          <span class="ep_name">&nbsp;</span>
-        </div>
-            </div>
-    </div>
-  </div>
-</div>
-                                                          </div>
-            </div>
-          </li>
-
-        </ul>
-      </div>
-    </div>
-  </div>
-</div>
-<!-- END : DOCUMENTATION GATEWAY BOX   -->
-
-
-
-         <!-- START : FINAL ACT BOX   -->
-<!-- END : FINAL ACT BOX   -->
-
-
-
-<div class="ep_gridrow ep-o_headerpage ep-layout_greycolor lo_white">
-</div>
-<!-- START : TRANSPARENCY SECTION -->
-<div class="ep_gridrow ep-o_product" id="transparency">
-  <div class="ep_gridrow-content">
-    <!-- SECTION HEADER -->
-    <div class="ep_gridcolumn ep-m_header" data-view1200="8" data-view1020="8" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
-      <div class="ep_gridrow">
-        <div class="ep_gridrow-content">
-          <div class="ep_gridcolumn" data-view1200="4" data-view1020="4" data-view750="6" data-view640="8" data-view480="8" data-view320="4">
-            <div class="ep_gridcolumn-content">
-              <div class="ep-a_heading ep-layout_level2-large">
-                <div class="ep_title">
-                  <div class="ep-p_text">
-                    <span class="ep_name">
-                      <span class="open proc-section-switch" title="Open / Close section" data-id="transparency-data"></span>
-                      Transparency
-                    </span>
-                  <span class="ep_icon">&nbsp;</span>
-                  </div>
-                </div>
-              </div>
-              </div>
-          </div>
-          <div class="ep_gridcolumn" data-view1200="4" data-view1020="4" data-view750="6" data-view640="8" data-view480="8" data-view320="4">
-            <div class="ep_gridcolumn-content">
-                            <div class="ep-a_links doc-right">
-  <ul class="ep_list">
-    <li class="ep-p_text ep-layout_pdf">
-      <a title="open this PDF in a new window" target="_blank" href="/oeil/popups/printfichetransparency.pdf?id=743156&lang=en">
-        <span class="ep_name">
-          Transparency <!-- in PDF format -->
-          <span class="ep_format">&nbsp;</span>
-        </span>
-        <span class="ep_icon">&nbsp;</span>
-      </a>
-    </li>
-  </ul>
-</div>
-            </div>
-          </div>
-        </div>
-        <div class="ep-p_text">
-        <span class="ep_name" id="subtexttrsp">
-        Meetings with interest representatives published in line with the Rules of Procedure
-        </span>
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- ep_gridrow-content -->
-</div>
-
-
-<div id="transparency-data" class="ep_gridrow ep-o_product">
-  <div class="ep_gridrow-content">
-    <div class="ep_gridcolumn ep-m_product ep-layout_accordion" data-view1200="8" data-view1020="8" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
-      <div class="ep_gridcolumn-content">
-
-        <ul class="ep_accordion">
-                <li class="ep_accordion-item" id="transparency_section1" data-selected="false">
-            <div class="ep_accordion-title" id="transparency-title">
-              <span><span class="ep_name">Rapporteurs, Shadow Rapporteurs and Committee Chairs</span><span class="ep_icon">&nbsp;</span></span>
-            </div>
-            <div class="ep_accordion-content" id="transparency-content">
-              <div class="ep-table transparency-table" id="transparency-rapporteurs-data">
-              <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/24922/ARIMONT Pascal/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">ARIMONT Pascal</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 2. Rapporteur/member-->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">
-        Shadow rapporteur for opinion
-      </span>
-    </div>
-    </div>
-
-  <!-- 3. Committee Code -->
-  <div class="ep-table-cell ep-table-cell-xs">
-    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
-    <span class="ep_name">
-            </span>
-        <span class="ep_icon">&nbsp;</span>
-  </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">30/11/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-    <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-             ARD-Verbindungsbüro Brüssel</br>
-              </span>
-    </div>
-  </div>
-
-    </div>
-  <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/24505/MAUREL Emmanuel/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">MAUREL Emmanuel</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 2. Rapporteur/member-->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">
-        Shadow rapporteur for opinion
-      </span>
-    </div>
-    </div>
-
-  <!-- 3. Committee Code -->
-  <div class="ep-table-cell ep-table-cell-xs">
-    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
-    <span class="ep_name">
-            </span>
-        <span class="ep_icon">&nbsp;</span>
-  </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">29/11/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-    <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-             Société civile des Auteurs Réalisateurs Producteurs</br>
-              </span>
-    </div>
-  </div>
-
-    </div>
-  <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/237224/ALBUQUERQUE João/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">ALBUQUERQUE João</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 2. Rapporteur/member-->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">
-        Shadow rapporteur for opinion
-      </span>
-    </div>
-    </div>
-
-  <!-- 3. Committee Code -->
-  <div class="ep-table-cell ep-table-cell-xs">
-    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
-    <span class="ep_name">
-            </span>
-        <span class="ep_icon">&nbsp;</span>
-  </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">23/11/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-    <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-             EUROCINEMA, Association de producteurs de cinéma et de télévision</br>
-                 Europa Distribution</br>
-                 Europa International</br>
-              </span>
-    </div>
-  </div>
-
-    </div>
-  <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/24922/ARIMONT Pascal/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">ARIMONT Pascal</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 2. Rapporteur/member-->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">
-        Rapporteur for opinion
-      </span>
-    </div>
-    </div>
-
-  <!-- 3. Committee Code -->
-  <div class="ep-table-cell ep-table-cell-xs">
-    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
-    <span class="ep_name">
-            </span>
-        <span class="ep_icon">&nbsp;</span>
-  </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">21/11/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-    <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-             DFL Deutsche Fußball Liga GmbH</br>
-              </span>
-    </div>
-  </div>
-
-    </div>
-  <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/24922/ARIMONT Pascal/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">ARIMONT Pascal</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 2. Rapporteur/member-->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">
-        Shadow rapporteur for opinion
-      </span>
-    </div>
-    </div>
-
-  <!-- 3. Committee Code -->
-  <div class="ep-table-cell ep-table-cell-xs">
-    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
-    <span class="ep_name">
-            </span>
-        <span class="ep_icon">&nbsp;</span>
-  </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">18/10/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-    <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-             DFL Deutsche Fußball Liga GmbH</br>
-              </span>
-    </div>
-  </div>
-
-    </div>
-  <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/202073/ANGEL Marc/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">ANGEL Marc</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 2. Rapporteur/member-->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">
-        Shadow rapporteur
-      </span>
-    </div>
-    </div>
-
-  <!-- 3. Committee Code -->
-  <div class="ep-table-cell ep-table-cell-xs">
-    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
-    <span class="ep_name">
-            </span>
-        <span class="ep_icon">&nbsp;</span>
-  </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">12/10/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-    <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-             Motion Picture Association EMEA</br>
-              </span>
-    </div>
-  </div>
-
-    </div>
-  <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/202073/ANGEL Marc/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">ANGEL Marc</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 2. Rapporteur/member-->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">
-        Shadow rapporteur
-      </span>
-    </div>
-    </div>
-
-  <!-- 3. Committee Code -->
-  <div class="ep-table-cell ep-table-cell-xs">
-    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
-    <span class="ep_name">
-            </span>
-        <span class="ep_icon">&nbsp;</span>
-  </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">12/07/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-    <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-             ACT group</br>
-              </span>
-    </div>
-  </div>
-
-    </div>
-  <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/24922/ARIMONT Pascal/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">ARIMONT Pascal</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 2. Rapporteur/member-->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">
-        Shadow rapporteur for opinion
-      </span>
-    </div>
-    </div>
-
-  <!-- 3. Committee Code -->
-  <div class="ep-table-cell ep-table-cell-xs">
-    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
-    <span class="ep_name">
-            </span>
-        <span class="ep_icon">&nbsp;</span>
-  </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">12/07/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-    <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-             Eleven Sports</br>
-              </span>
-    </div>
-  </div>
-
-    </div>
-  <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/24922/ARIMONT Pascal/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">ARIMONT Pascal</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 2. Rapporteur/member-->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">
-        Shadow rapporteur for opinion
-      </span>
-    </div>
-    </div>
-
-  <!-- 3. Committee Code -->
-  <div class="ep-table-cell ep-table-cell-xs">
-    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
-    <span class="ep_name">
-            </span>
-        <span class="ep_icon">&nbsp;</span>
-  </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">10/07/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-    <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-             EBU-UER (European Broadcasting Union)</br>
-                 ACT</br>
-              </span>
-    </div>
-  </div>
-
-    </div>
-  <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/24922/ARIMONT Pascal/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">ARIMONT Pascal</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 2. Rapporteur/member-->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">
-        Shadow rapporteur for opinion
-      </span>
-    </div>
-    </div>
-
-  <!-- 3. Committee Code -->
-  <div class="ep-table-cell ep-table-cell-xs">
-    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
-    <span class="ep_name">
-            </span>
-        <span class="ep_icon">&nbsp;</span>
-  </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">07/07/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-    <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-             EUROCINEMA, Association de producteurs de cinéma et de télévision</br>
-              </span>
-    </div>
-  </div>
-
-    </div>
-                </div>
-                              <div id="load-more-tran-rapporteurs">
-                  <div class="ep_gridcolumn-content">
-                    <div class="ep-a_loadmore" id="loadmore-rapporteurs">
-                      <div class="ep_button">
-                        <a href="#" onclick="OEIL6_RWD_Lib.search.loadMoreRapporteurs(this, '2023/2019(INI)', 10, 'en',12);return false;"  class="ep-p_text" title="Load more">
-                          <span class="ep_name">Load more<span class="ep_hidden">: Load more</span></span><span class="ep_icon">&nbsp;</span>
-                        </a>
-                      </div>
+                <div class="col-12 col-lg-4">
+                    <div class="erpl_links-list text-lg-right my-1">
+                        <ul>
+                            <li>
+                                <a href="/oeil/en/procedure-file/pdf?reference=2023/2019(INI)">
+                                    <svg class="es_icon es_icon-pdf mr-1">
+                                        <title>pdf</title>
+                                        <use xlink:href="#es_icon-pdf"></use>
+                                    </svg>
+                                    <span class="t-x">Full procedure</span>
+                                </a>
+                            </li>
+                        </ul>
                     </div>
-                  </div>
                 </div>
-                            </div>
-          </li>
-                              <li class="ep_accordion-item" id="transparency_section2" data-selected="false">
-            <div class="ep_accordion-title" id="transparency-title">
-              <span><span class="ep_name">Other Members</span><span class="ep_icon">&nbsp;</span></span>
             </div>
-            <div class="ep_accordion-content" id=transparency-content">
-              <div class="ep-table transparency-table" id="transparency-otherrap-data">
-              <div class="ep-table-row">
+            
+            <h2 class="erpl_title-h2 mb-3">Implementation of the 2018 Geoblocking Regulation in the Digital Single Market</h2>
+            <div class="separator border-dark my-3"></div>
 
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/197791/SMERIGLIO Massimiliano/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">SMERIGLIO Massimiliano</a>
-            </span>
-    </div>
-  </div>
+            
+            <div id="sectionsNavPositionRwd" class="mb-1"></div>
 
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">12/12/2023</span>
-    </div>
-  </div>
 
-  <!-- 5. Meeting Attendees -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-                 EUROCINEMA, Association de producteurs de cinéma et de télévision</br>
-                      </span>
-    </div>
-  </div>
-  </div>
-  <div class="ep-table-row">
+            
+            <div class="erpl_product">
+                <div class="row">
+                    <div class="col">
+                        <div class="mb-3">
+                            <div class="erpl_product-body">
+                                
+                                <html lang="en">
 
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/96653/ROTH NEVEĎALOVÁ Katarína/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">ROTH NEVEĎALOVÁ Katarína</a>
-            </span>
-    </div>
-  </div>
 
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">11/12/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-                 Association of Commercial Television and Video on Demand Services in Europe</br>
-                      </span>
-    </div>
-  </div>
-  </div>
-  <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/197417/SOKOL Tomislav/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">SOKOL Tomislav</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">08/12/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-                 the Association of Commercial Television and Video on Demand Services in Europe (ACT)</br>
-                      </span>
-    </div>
-  </div>
-  </div>
-  <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/96922/BILBAO BARANDICA Izaskun/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">BILBAO BARANDICA Izaskun</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">07/12/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-                 La Liga española de fútbol</br>
-                      </span>
-    </div>
-  </div>
-  </div>
-  <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/197536/COLIN-OESTERLÉ Nathalie/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">COLIN-OESTERLÉ Nathalie</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">16/11/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-                 EUROCINEMA, Association de producteurs de cinéma et de télévision</br>
-                 Syndicat des producteurs indépendants</br>
-                      </span>
-    </div>
-  </div>
-  </div>
-  <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/96775/COMI Lara/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">COMI Lara</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">15/11/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-                 European Leagues</br>
-                      </span>
-    </div>
-  </div>
-  </div>
-  <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/96775/COMI Lara/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">COMI Lara</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">15/11/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-                 Anica - Associazione Nazionale Industrie Cinematografiche Audiovisive Digitali</br>
-                      </span>
-    </div>
-  </div>
-  </div>
-  <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/197606/ZARZALEJOS Javier/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">ZARZALEJOS Javier</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">08/11/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-                 LaLiga</br>
-                      </span>
-    </div>
-  </div>
-  </div>
-  <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/204400/VÁZQUEZ LÁZARA Adrián/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">VÁZQUEZ LÁZARA Adrián</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">08/11/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-                 La Liga</br>
-                      </span>
-    </div>
-  </div>
-  </div>
-  <div class="ep-table-row">
-
-  <!-- 1. Person Name -->
-  <div class="ep-table-cell ep-table-cell-l">
-    <div class="ep-p_text">
-      <span class="ep_name">
-              <a href="https://www.europarl.europa.eu/meps/en/197832/RIBA I GINER Diana/meetings/past#detailedcardmep" title="Link to Meetings Page" target="_blank">RIBA I GINER Diana</a>
-            </span>
-    </div>
-  </div>
-
-  <!-- 4. Date -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-      <span class="ep_name">08/11/2023</span>
-    </div>
-  </div>
-
-  <!-- 5. Meeting Attendees -->
-  <div class="ep-table-cell ep-table-cell-s">
-    <div class="ep-p_text">
-    <span class="ep_name">
-                 La Liga</br>
-                      </span>
-    </div>
-  </div>
-  </div>
-                </div>
-                              <div id="load-more-tran-other">
-                  <div class="ep_gridcolumn-content">
-                    <div class="ep-a_loadmore" id="loadmore-other">
-                      <div class="ep_button">
-                        <a href="#" onclick="OEIL6_RWD_Lib.search.loadMoreOther(this, '2023/2019(INI)', 10, 'en',18);return false;" class="ep-p_text" title="Load more">
-                          <span class="ep_name">Load more<span class="ep_hidden">: Load more</span></span><span class="ep_icon">&nbsp;</span>
-                        </a>
-                      </div>
+<div class="erpl_product-section">
+    <div id="section1" class="erpl-product-content oeil-spy-section mb-2">
+        <div class="row">
+            <div class="col-12 col-lg">
+                <h2 class="erpl_title-h2 mb-2">Basic information</h2></div>
+                <div class="col-12 col-lg-4">
+                    <div class="erpl_links-list text-lg-right my-1">
+                        <ul>
+                            <li>
+                                <a href="/oeil/en/procedure-file/pdf?reference=2023/2019(INI)&amp;section=BASIC_INFO">
+                                    <svg class="es_icon es_icon-pdf mr-1">
+                                        <title>pdf</title>
+                                        <use xlink:href="#es_icon-pdf"></use>
+                                    </svg>
+                                    <span class="t-x">Basic information</span>
+                                </a>
+                            </li>
+                        </ul>
                     </div>
-                  </div>
                 </div>
-                          </div>
-          </li>
+        </div>
+        <div class="row">
+            <div class="col-6">
+                <p class="font-weight-bold mb-1">2023/2019(INI)</p>
+
+                <p>INI - Own-initiative procedure</p>
+                
+
+                
+                
+
+
+                
+                    <p class="font-weight-bold mb-1">Subject</p>
+                    <p>
+                        
+                            2 Internal market, single market
+                            <br/>
+                        
+                            3.30.25 International information networks and society, internet
+                            <br/>
+                        
+                            3.45.05 Business policy, e-commerce, after-sales service, commercial distribution
+                            <br/>
+                        
+                            3.50.15 Intellectual property, copyright 
+                            <br/>
+                        
+                            4.60.06 Consumers&#39; economic and legal interests
+                            
+                        
+                    </p>
+                
+
+                
+
+                
+            </div>
+
+            <div class="col-6">
+                
+                    <p class="font-weight-bold mb-1">Status</p>
+                    <p class="text-danger">Procedure completed</p>
+                
+
+                
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-12">
+                <div class="separator separator-dotted separator-2x mt-5 mb-3">
+                    <a class="erpl_smooth-scroll btn btn-default" href="#gateway">Please go to Documentation gateway for any follow-up documents.</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</html>
+
+                                
+                                <div class="erpl_product-section">
+    <div class="separator border-dark my-3"></div>
+    <div id="section2" class="erpl-product-content oeil-spy-section mb-2">
+        <div class="row">
+            <div class="col-12 col-lg"><h2 class="erpl_title-h2 mb-2">Key players</h2>
+            </div>
+            <div class="col-12 col-lg-4">
+                <div class="erpl_links-list text-lg-right my-1">
+                    <ul>
+                        <li>
+                            <a href="/oeil/en/procedure-file/pdf?reference=2023/2019(INI)&amp;section=KEY_PLAYERS">
+                                <svg class="es_icon es_icon-pdf mr-1">
+                                    <title>pdf</title>
+                                    <use xlink:href="#es_icon-pdf"></use>
+                                </svg>
+                                <span class="t-x">Key players</span>
+                            </a>
+                        </li>
                     </ul>
-      </div>
+                </div>
+            </div>
+        </div>
+        <div class="erpl_accordion mb-5" id="erplAccordionKeyPlayers">
+            <ul class="a-i">
+                
+    <li class="erpl_accordion-item" data-selected="false">
+        <button id="erpl_accordion-committee-title" type="button" class="erpl_accordion-item-title" data-toggle="collapse" data-target="#erpl_accordion-committee" aria-expanded="true" aria-controls="erpl_accordion-committee">
+            <span class="t-x">European Parliament</span>
+            <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
+                <use xlink:href="#es_icon-more"></use>
+            </svg>
+            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
+                <use xlink:href="#es_icon-less"></use>
+            </svg>
+        </span>
+        </button>
+        <div id="erpl_accordion-committee" class="erpl_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="erpl_accordion-committee-title">
+            <div>
+                <a href="http://www.europarl.europa.eu/" target="_blank">
+                    <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1">
+                        <use xlink:href="#es_icon-arrow"></use>
+                    </svg>
+                    <span class="t-x">European Parliament</span>
+                </a>
+
+                <div class="table-responsive mt-2">
+                    
+
+                        <table class="table table-bordered table-striped">
+                            <thead>
+                            <tr>
+                                <th class="w-50" scope="col">Committee responsible</th>
+                                <th class="w-25" scope="col">Rapporteur</th>
+                                <th class="w-25" scope="col">Appointed</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+
+                            
+
+                            
+                                
+                                    
+    <tr>
+        <th scope="row">
+            <div class="d-flex align-items-center">
+    <span class="erpl_badge erpl_badge-committee mr-1">IMCO</span>
+    <div>
+        <a href="http://www.europarl.europa.eu/committees/EN/imco/home.html" target="_blank">
+                <span class="font-weight-normal">Internal Market and Consumer Protection</span>
+        </a>
+        
+        <br/>
+        
     </div>
-  </div>
 </div>
-<!-- END : TRANSPARENCY   -->
+        </th>
+        <td>
+            
+    
+    
+        
 
+        <a class="rapporteur mb-25"
+           data-toggle="tooltip-rapporteur"
+           data-placement="bottom"
+           href="https://www.europarl.europa.eu/meps/en/197538" target="_blank"
+           title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/197538.jpg&quot; alt=&quot;Photo MAZUREK Beata &quot;&gt;">
+            <span>MAZUREK Beata (ECR)</span>
+        </a>
+        <br/>
+    
 
-      </div>
-      <!-- /procedure file content-->
+        </td>
 
-      </div>
+        <td>
+            
+                <span>01/03/2023</span>
+                <br/>
+            
+        </td>
 
-              </div>
-        <!-- SHARE LINK ON THE FOOTER OF THE PAGE -->
-<footer class="ep_gridrow ep-o_footerpage">
-    <div class="ep_gridrow-content">
-        <div class="ep_gridcolumn ep-m_product" data-view1200="12" data-view1020="12" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
-            <div class="ep_gridcolumn-content">
-                <div class="ep-a_share">
-                   <div>
-                        <div class="ep_share">
-                            <h2 class="ep_title">
-                                <div class="ep-p_text"><span class="ep_name">Share this page:</span><span class="ep_icon">&nbsp;</span></div>
-                            </h2>
-                            <ul>
-                                <li>
-                                    <div class="ep-p_text ep-layout_facebook">
-                  <a href="#" onclick="OEIL6_RWD_Lib.social.share('http://www.facebook.com/share.php?u='); return false;" title="Share this page on Facebook"><span class="ep_name">Facebook</span><span class="ep_icon">&nbsp;</span></a>
-                  </div>
-                                </li>
-                                <li>
-                                    <div class="ep-p_text ep-layout_twitter">
-                    <a href="#" onclick="OEIL6_RWD_Lib.social.share('https://twitter.com/intent/tweet?via=Europarl_EN&amp;url='); return false;" title="Share on Twitter"><span class="ep_name">Twitter</span><span class="ep_icon">&nbsp;</span></a>
-                  </div>
-                                </li>
-                                <li>
-                                    <div class="ep-p_text ep-layout_linkedin">
-                  <a href="#" href="#" onclick="OEIL6_RWD_Lib.social.share('https://www.linkedin.com/shareArticle?mini=true&amp;url='); return false;" title="Share on LinkedIn"><span class="ep_name">LinkedIn</span><span class="ep_icon">&nbsp;</span></a></div>
-                                </li>
-                                <li>
-                                    <div class="ep-p_text ep-layout_mail">
-                    <a href="#" onclick="OEIL6_RWD_Lib.social.share('mailto:?subject=Procedure File: 2023/2019(INI) | Legislative Observatory | European Parliament&body=', true); return false;" title="Send by mail">
-                      <span class="ep_name">Mail</span><span class="ep_icon">&nbsp;</span>
-                    </a>
-                  </div>
-                                </li>
-                            </ul>
-                        </div>
+    </tr>
+    <tr class="bg-none border">
+        <th scope="row" class="border-0"></th>
+        <td class="border-0">
+            
+    <button class="btn btn-primary my-1" type="button" data-toggle="collapse"
+            data-target="#collapseShadowRapporteur" aria-expanded="false"
+            aria-controls="collapseShadowRapporteur">Shadow rapporteur</button>
 
-
-
-                                  <div class="ep_links">
-                        <div class="ep-p_text"><a href="https://cst4epc.europarl.europa.eu/cst4ep/questionnaire/sq/23NclbPqghs9iBLwQYDy6w" target="_blank" title="User satisfaction survey">
-            <span class="ep_name">Tell us what you think</span><span class="ep_icon">&nbsp;</span></a>
-            </div>
-            </div>
-                        </div>
-          </div>
-            </div>
-        </div>
-    </div>
-</footer> </div>
-
-
-<footer id="website-footer" role="contentinfo">
-   <button onclick="OEIL6_RWD_Lib.core.goTop()" id="scroll-top" title="Go to top">&#8679;</button>
-
-  <h2 class="ep_hidden"><span class="ep_name">Footer</span><span class="ep_icon">&nbsp;</span></h2>
-  <!-- COMPOSANT "FOOTER LINKS" -->
-  <div class="ep_footer-relatedlinks">
-    <div class="ep_websitelinks" id="website-links">
-      <h3 class="ep_title" id="website-links-title"><span class="ep_name">Legislative Observatory</span><span class="ep_icon">&nbsp;</span></h3>
-      <div class="ep_menu-access ep_openaccess" id="website-links-access" aria-controls="website-links-content" role="tab">
-        <a href="#website-links" title="View menu"><span class="ep_name"> Legislative Observatory</span><span class="ep_icon">&nbsp;</span></a>
-      </div>
-      <div class="ep_list ep-layout_category" id="website-links-content">
-        <div>
-          <div class="ep_category">
-            <h4 class="ep_subtitle" id="website-links-category2-title"><span class="ep_name">Tools</span><span class="ep_icon">&nbsp;</span></h4>
-            <ul role="tabpanel" aria-labelledby="website-links-category2-title">
-
-              <li class="ep_item">
-                <a href="http://www.europarl.europa.eu/news/en/press-room" title="Go to the page" class="ep_button">
-                  <span class="ep_name">Press Service</span><span class="ep_icon">&nbsp;</span>
-                </a>
-              </li>
-
-              <li class="ep_item">
-                <a href="https://www.europarl.europa.eu/olp/en/home" title="Go to the page" class="ep_button">
-                  <span class="ep_name">Ordinary legislative procedure</span><span class="ep_icon">&nbsp;</span>
-                </a>
-              </li>
-
-              <li class="ep_item">
-                <a href="http://www.europarl.europa.eu/RegistreWeb/search/simple.htm?language=EN" title="Go to the page" class="ep_button">
-                  <span class="ep_name">Parliament register</span><span class="ep_icon">&nbsp;</span>
-                </a>
-              </li>
-
-              <li class="ep_item">
-                <a href="http://eur-lex.europa.eu/en/index.htm" title="Open in a new page" class="ep_button">
-                  <span class="ep_name">EUR-Lex</span><span class="ep_icon">&nbsp;</span>
-                </a>
-              </li>
-
-              <li class="ep_item">
-                <a href="https://www.consilium.europa.eu/EN/documents-publications/public-register/" title="Open in a new page" class="ep_button">
-                  <span class="ep_name">Council register</span><span class="ep_icon">&nbsp;</span>
-                </a>
-              </li>
-
-              <li class="ep_item">
-                <a href="https://webgate.ec.europa.eu/regdel/#/home" title="Open in a new page" class="ep_button">
-                  <span class="ep_name">Delegated acts register</span><span class="ep_icon">&nbsp;</span>
-                </a>
-              </li>
-
-              <li class="ep_item">
-                <a href="/oeil/info/contact2.do" title="Open in a new page" class="ep_button">
-                  <span class="ep_name">Contacts</span><span class="ep_icon">&nbsp;</span>
-                </a>
-              </li>
-            </ul>
-          </div>
-
-          <div class="ep_category">
-            <h4 class="ep_subtitle" id="website-links-category1-title">
-              <span class="ep_name">Committees</span><span class="ep_icon">&nbsp;</span>
-            </h4>
-            <ul role="tabpanel" aria-labelledby="website-links-category1-title">
-              <li class="ep_item">
-                <a href="http://www.europarl.europa.eu/committees/en/" title="Open in a new page" class="ep_button">
-                  <span class="ep_name">Home</span><span class="ep_icon">&nbsp;</span>
-                </a>
-              </li>
-              <li class="ep_item">
-                <a href="http://www.europarl.europa.eu/committees/en/draft-agendas.html" title="Open in a new page" class="ep_button">
-                  <span class="ep_name">Meetings</span><span class="ep_icon">&nbsp;</span>
-                </a>
-              </li>
-              <li class="ep_item">
-                <a href="http://www.europarl.europa.eu/committees/en/search-in-documents.html" title="Open in a new page" class="ep_button">
-                  <span class="ep_name">Documents</span><span class="ep_icon">&nbsp;</span>
-                </a>
-              </li>
-              <li class="ep_item">
-                <a href="http://www.europarl.europa.eu/committees/en/events.html" title="Open in a new page" class="ep_button">
-                  <span class="ep_name">Events</span><span class="ep_icon">&nbsp;</span>
-                </a>
-              </li>
-              <li class="ep_item">
-                <a href="http://www.europarl.europa.eu/committees/en/supporting-analyses.html" title="Open in a new page" class="ep_button">
-                  <span class="ep_name">Supporting analyses</span><span class="ep_icon">&nbsp;</span>
-                </a>
-              </li>
-            </ul>
-
-            <h4 class="ep_subtitle" id="website-links-category1-title"><span class="ep_name">Plenary</span><span class="ep_icon">&nbsp;</span></h4>
-            <ul role="tabpanel" aria-labelledby="website-links-category1-title">
-              <li class="ep_item"><a href="http://www.europarl.europa.eu/plenary/en/" title="Open in a new page" class="ep_button"><span class="ep_name">Plenary sitting</span><span class="ep_icon">&nbsp;</span></a></li>
-              <li class="ep_item"><a href="http://www.europarl.europa.eu/plenary/en/guide-plenary.html" title="Open in a new page" class="ep_button"><span class="ep_name">Around plenary</span><span class="ep_icon">&nbsp;</span></a></li>
-              <li class="ep_item"><a href="http://www.europarl.europa.eu/plenary/en/parliamentary-questions.html" title="Open in a new page" class="ep_button"><span class="ep_name">Questions and declarations</span><span class="ep_icon">&nbsp;</span></a></li>
-              <li class="ep_item"><a href="http://www.europarl.europa.eu/plenary/en/parliament-positions.html" title="Open in a new page" class="ep_button"><span class="ep_name">Legislative texts adopted</span><span class="ep_icon">&nbsp;</span></a></li>
-              <li class="ep_item"><a href="http://www.europarl.europa.eu/plenary/en/meetings-search.html" title="Open in a new page" class="ep_button"><span class="ep_name">Calendar</span><span class="ep_icon">&nbsp;</span></a></li>
-            </ul>
-          </div>
-
-
-          <div class="ep_category">
-            <h4 class="ep_subtitle" id="website-links-category3-title">
-              <span class="ep_name">Delegations</span><span class="ep_icon">&nbsp;</span>
-            </h4>
-            <ul role="tabpanel" aria-labelledby="website-links-category3-title">
-              <li class="ep_item">
-                <a href="http://www.europarl.europa.eu/delegations/en/" title="Open in a new page" class="ep_button">
-                  <span class="ep_name">Home</span><span class="ep_icon">&nbsp;</span>
-                </a>
-              </li>
-              <li class="ep_item">
-                <a href="http://www.europarl.europa.eu/delegations/en/meetings-search.html" title="Open in a new page" class="ep_button">
-                  <span class="ep_name">Calendar</span><span class="ep_icon">&nbsp;</span>
-                </a>
-              </li>
-            </ul>
-
-
-            <h4 class="ep_subtitle" id="website-links-category3-title">
-              <span class="ep_name">MEPs</span><span class="ep_icon">&nbsp;</span>
-            </h4>
-            <ul role="tabpanel" aria-labelledby="website-links-category3-title">
-              <li class="ep_item">
-                <a href="http://www.europarl.europa.eu/meps/en/map.html" title="Open in a new page" class="ep_button">
-                  <span class="ep_name">Search</span><span class="ep_icon">&nbsp;</span>
-                </a>
-              </li>
-            </ul>
-
-            <h4 class="ep_subtitle" id="website-links-category3-title">
-              <span class="ep_name">At your service</span><span class="ep_icon">&nbsp;</span>
-            </h4>
-            <ul role="tabpanel" aria-labelledby="website-links-category3-title">
-              <li class="ep_item">
-                <a href="http://www.europarl.europa.eu/atyourservice/en/" title="Open in a new page" class="ep_button">
-                  <span class="ep_name">Home</span><span class="ep_icon">&nbsp;</span>
-                </a>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
-      <div class="ep_menu-access ep_closeaccess"><a href="#website-links-access" title="Hide menu"><span class="ep_name">News</span><span class="ep_icon">&nbsp;</span></a></div>
-    </div>
-    <div class="ep_europarllinks" id="europarl-links">
-      <h3 class="ep_title" id="europarl-links-title"><span class="ep_name">About Parliament</span><span class="ep_icon">&nbsp;</span></h3>
-      <div class="ep_menu-access ep_openaccess" id="europarl-links-access" aria-controls="europarl-links-content" role="tab">
-        <a href="#europarl-links" title="View menu"><span class="ep_name">About Parliament</span><span class="ep_icon">&nbsp;</span></a>
-      </div>
-      <div class="ep_list">
-        <ul role="tabpanel" id="europarl-links-content" aria-labelledby="europarl-links-title">
-          <li class="ep_item"><a href="http://www.europarl.europa.eu/aboutparliament/en" title="Go to the page" class="ep_button"><span class="ep_name">Home</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="http://www.europarl.europa.eu/aboutparliament/en/20150201PVL00003/powers-and-procedures" title="Go to the page" class="ep_button"><span class="ep_name">Powers and procedures</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="http://www.europarl.europa.eu/aboutparliament/en/20150201PVL00009/organisation-and-rules" title="Go to the page" class="ep_button"><span class="ep_name">Organisation and rules</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="http://www.europarl.europa.eu/aboutparliament/en/20150201PVL00015/human-rights" title="Go to the page" class="ep_button"><span class="ep_name">Human rights</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="http://www.europarl.europa.eu/aboutparliament/en/20150201PVL00020/in-the-past" title="Go to the page" class="ep_button"><span class="ep_name">In the past</span><span class="ep_icon">&nbsp;</span></a></li>
-        </ul>
-      </div>
-      <div class="ep_menu-access ep_closeaccess"><a href="#europarl-links-access" title="Hide menu"><span class="ep_name">About Parliament</span><span class="ep_icon">&nbsp;</span></a></div>
-    </div>
-  </div>
-  <span class="ep_footer-separator">&nbsp;</span>
-  <div class="ep_footer-otherlinks">
-    <!-- COMPOSANT "SOCIAL LINKS" -->
-    <div class="ep_sociallinks" id="socialmedia">
-      <h3 class="ep_hidden" id="socialmedia-title"><span class="ep_name">Parliament on social media</span><span class="ep_icon">&nbsp;</span></h3>
-      <div class="ep_list">
-        <ul role="listbox" aria-labelledby="socialmedia-title">
-          <li class="ep_item"><a href="http://www.facebook.com/europeanparliament" title="Check out Parliament on Facebook"   class="ep_button ep_facebook" ><span class="ep_name">Facebook</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="http://twitter.com/Europarl_en" title="Check out Parliament on Twitter"    class="ep_button ep_twitter"  ><span class="ep_name">Twitter</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="http://www.flickr.com/photos/european_parliament/" title="Check out Parliament on Flickr"    class="ep_button ep_flickr"   ><span class="ep_name">Flickr</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="https://www.linkedin.com/company/european-parliament" title="Check out Parliament on LinkedIn"   class="ep_button ep_linkedin" ><span class="ep_name">LinkedIn</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="http://www.youtube.com/user/EuropeanParliament" title="Check out Parliament on YouTube"    class="ep_button ep_youtube"  ><span class="ep_name">YouTube</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="http://instagram.com/europeanparliament" title="Check out Parliament on Instagram"   class="ep_button ep_instagram"  ><span class="ep_name">Instagram</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="http://www.pinterest.com/epinfographics/" title="Check out Parliament on Pinterest"  class="ep_button ep_pinterest"  ><span class="ep_name">Pinterest</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="https://www.snapchat.com/add/europarl" title="Check out Parliament on Snapchat"  class="ep_button ep_snapchat" ><span class="ep_name">Snapchat</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="https://www.reddit.com/r/europeanparliament/" title="Check out Parliament on Reddit"     class="ep_button ep_reddit"   ><span class="ep_name">Reddit</span><span class="ep_icon">&nbsp;</span></a></li>
-
-        </ul>
-      </div>
-    </div>
-    <!-- COMPOSANT "MANDATORY LINKS" -->
-    <div class="ep_mandatorylinks" id="informationlinks">
-      <h3 class="ep_hidden" id="informationlinks-title"><span class="ep_name">Information links</span><span class="ep_icon">&nbsp;</span></h3>
-      <div class="ep_list">
-        <ul role="listbox" aria-labelledby="informationlinks-title">
-          <li class="ep_item"><a href="http://www.europarl.europa.eu/portal/en/contact/" title="Go to the page" class="ep_button"><span class="ep_name">Contact</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="http://www.europarl.europa.eu/tools/rss/default_en.htm" title="Go to the page" class="ep_button"><span class="ep_name">RSS</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="https://www.europarl.europa.eu/portal/en/sitemap" title="Go to the page" class="ep_button"><span class="ep_name">Sitemap</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="https://europarl.europa.eu/legal-notice/en/" title="Go to the page" class="ep_button"><span class="ep_name">Legal Notice</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="https://europarl.europa.eu/privacy-policy/en/" title="Go to the page" class="ep_button"><span class="ep_name">Privacy Policy</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="http://www.europarl.europa.eu/portal/en/accessibility" title="Go to the page" class="ep_button"><span class="ep_name">WAI AA-WCAG 2.0</span><span class="ep_icon">&nbsp;</span></a></li>
-          <li class="ep_item"><a href="http://www.europarl.europa.eu/portal/en/cookie-policy" title="Go to the page" class="ep_button"><span class="ep_name">Cookies</span><span class="ep_icon">&nbsp;</span></a></li>
-        </ul>
-      </div>
-    </div>
-
-
-  </div>
-  <div id="version">
-      <div class="ep_list">
-        <ul role="listbox" aria-label="version-title" title="version">
-          <li class="ep_item" role="option" aria-labelledby="version"  aria-checked="true">
-            <a href="#" title="Go to the page" class="ep_button" onclick='return false;'>
-              <span class="ep_name">Version 9.4.3</span>
-              <span class="ep_icon">&nbsp;</span>
+    <div class="collapse" id="collapseShadowRapporteur">
+        <div class="card card-body border-0 p-0">
+            <a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/124988" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/124988.jpg&quot; alt=&quot;Photo CLUNE Deirdre &quot;&gt;">
+                <span>CLUNE Deirdre (EPP)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/202073" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/202073.jpg&quot; alt=&quot;Photo ANGEL Marc &quot;&gt;">
+                <span>ANGEL Marc (S&amp;D)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/96776" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/96776.jpg&quot; alt=&quot;Photo THUN UND HOHENSTEIN Róża &quot;&gt;">
+                <span>THUN UND HOHENSTEIN Róża (Renew)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/197870" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/197870.jpg&quot; alt=&quot;Photo VAN SPARRENTAK Kim &quot;&gt;">
+                <span>VAN SPARRENTAK Kim (Greens/EFA)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/128483" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/128483.jpg&quot; alt=&quot;Photo BUCHHEIT Markus &quot;&gt;">
+                <span>BUCHHEIT Markus (ID)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/130833" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/130833.jpg&quot; alt=&quot;Photo KOULOGLOU Stelios &quot;&gt;">
+                <span>KOULOGLOU Stelios (The Left)</span>
             </a>
-          </li>
-        </ul>
-      </div>
+        </div>
+    </div>
+
+        </td>
+        <td class="border-0"></td>
+    </tr>
+
+                                
+
+                                
+                            
+
+                            </tbody>
+                        </table>
+
+                        
+                    
+
+                        <table class="table table-bordered table-striped">
+                            <thead>
+                            <tr>
+                                <th class="w-50" scope="col">Committee for opinion</th>
+                                <th class="w-25" scope="col">Rapporteur for opinion</th>
+                                <th class="w-25" scope="col">Appointed</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+
+                            
+
+                            
+                                
+                                    
+    <tr>
+        <th scope="row">
+            <div class="d-flex align-items-center">
+    <span class="erpl_badge erpl_badge-committee mr-1">CULT</span>
+    <div>
+        <a href="http://www.europarl.europa.eu/committees/EN/cult/home.html" target="_blank">
+                <span class="font-weight-normal">Culture and Education
+
+</span>
+        </a>
+        
+        <br/>
+        <span class="font-weight-normal">(Associated committee)</span>
+    </div>
+</div>
+        </th>
+        <td>
+            
+    
+    
+        
+
+        <a class="rapporteur mb-25"
+           data-toggle="tooltip-rapporteur"
+           data-placement="bottom"
+           href="https://www.europarl.europa.eu/meps/en/96756" target="_blank"
+           title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/96756.jpg&quot; alt=&quot;Photo VERHEYEN Sabine &quot;&gt;">
+            <span>VERHEYEN Sabine (EPP)</span>
+        </a>
+        <br/>
+    
+
+        </td>
+
+        <td>
+            
+                <span>09/02/2023</span>
+                <br/>
+            
+        </td>
+
+    </tr>
+    <tr>
+        <th scope="row">
+            <div class="d-flex align-items-center">
+    <span class="erpl_badge erpl_badge-committee mr-1">JURI</span>
+    <div>
+        <a href="http://www.europarl.europa.eu/committees/EN/juri/home.html" target="_blank">
+                <span class="font-weight-normal">Legal Affairs
+
+</span>
+        </a>
+        
+        <br/>
+        <span class="font-weight-normal">(Associated committee)</span>
+    </div>
+</div>
+        </th>
+        <td>
+            
+    
+    
+        
+
+        <a class="rapporteur mb-25"
+           data-toggle="tooltip-rapporteur"
+           data-placement="bottom"
+           href="https://www.europarl.europa.eu/meps/en/197567" target="_blank"
+           title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/197567.jpg&quot; alt=&quot;Photo MELCHIOR Karen &quot;&gt;">
+            <span>MELCHIOR Karen (Renew)</span>
+        </a>
+        <br/>
+    
+
+        </td>
+
+        <td>
+            
+                <span>28/02/2023</span>
+                <br/>
+            
+        </td>
+
+    </tr>
+    
+    
+
+                                
+
+                                
+                            
+
+                            </tbody>
+                        </table>
+
+                        
+                    
+                </div>
+            </div>
+        </div>
+    </li>
+
+
+                
+
+                
+    <li class="erpl_accordion-item" data-selected="false">
+        <button id="erpl_accordion-item3-title" type="button" class="erpl_accordion-item-title collapsed" data-toggle="collapse" data-target="#erpl_accordion-item3" aria-expanded="false" aria-controls="erpl_accordion-item3">
+            <span class="t-x">European Commission</span>
+            <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
+                <use xlink:href="#es_icon-more"></use>
+            </svg>
+            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
+                <use xlink:href="#es_icon-less"></use>
+            </svg>
+        </span>
+        </button>
+        <div id="erpl_accordion-item3" class="collapse erpl_accordion-item-content a-i-none" aria-labelledby="erpl_accordion-item3-title">
+            <div>
+                <a href="http://ec.europa.eu/" target="_blank">
+                    <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1">
+                        <use xlink:href="#es_icon-arrow"></use>
+                    </svg>
+                    <span class="t-x">European Commission</span>
+                </a>
+                <div class="table-responsive mt-2">
+                    <table class="table table-striped table-bordered">
+                        <thead>
+                        <tr>
+                            <th class="align-middle" scope="col">Commission DG</th>
+                            <th class="align-middle" scope="col">Commissioner</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <th class="align-middle" scope="row">
+                                <a href="http://ec.europa.eu/info/departments/internal-market-industry-entrepreneurship-and-smes_en" target="_blank"
+                                   class="font-weight-normal">
+                                    <span>Internal Market, Industry, Entrepreneurship and SMEs</span>
+                                </a>
+                            </th>
+                            <td class="align-middle">
+                                <span>BRETON Thierry</span>
+                                
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+
+                </div>
+            </div>
+        </div>
+    </li>
+
+
+                
+    
+
+            </ul>
+        </div>
+    </div>
+
+</div>
+
+                                
+                                <html lang="en">
+
+
+
+
+<div class="erpl_product-section">
+    <div class="separator border-dark my-3"></div>
+    <div id="section3" class="erpl-product-content oeil-spy-section mb-2">
+        <div class="row">
+            <div class="col-12 col-lg">
+                <h2 class="erpl_title-h2 mb-2">Key events</h2>
+            </div>
+            <div class="col-12 col-lg-4">
+                <div class="erpl_links-list text-lg-right my-1">
+                    <ul>
+                        <li>
+                            <a href="/oeil/en/procedure-file/pdf?reference=2023/2019(INI)&amp;section=KEY_EVENTS" target="_blank">
+                                <svg class="es_icon es_icon-pdf mr-1">
+                                    <title>pdf</title>
+                                    <use xlink:href="#es_icon-pdf"></use>
+                                </svg>
+                                <span class="t-x">Key events</span>
+                            </a>
+                        </li>
+                    </ul>
+
+                </div>
+            </div>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-striped table-bordered">
+                <thead>
+                <tr>
+                    <th class="align-middle" scope="col">Date</th>
+                    <th class="align-middle" scope="col">Event</th>
+                    <th class="align-middle" scope="col">Reference</th>
+                    <th class="align-middle" scope="col">Summary</th>
+                </tr>
+                </thead>
+
+                <tbody>
+                <tr>
+                    
+                        <td class="align-middle" >16/02/2023</td>
+                        <td class="align-middle">Committee referral announced in Parliament</td>
+                        <td class="align-middle text-center">
+                            
+                                
+                                <span></span>
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >16/02/2023</td>
+                        <td class="align-middle">Referral to associated committees announced in Parliament</td>
+                        <td class="align-middle text-center">
+                            
+                                
+                                <span></span>
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >25/10/2023</td>
+                        <td class="align-middle">Vote in committee</td>
+                        <td class="align-middle text-center">
+                            
+                                
+                                <span></span>
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >07/11/2023</td>
+                        <td class="align-middle">Committee report tabled for plenary</td>
+                        <td class="align-middle text-center">
+                            
+                                <a href="https://www.europarl.europa.eu/doceo/document/A-9-2023-0335_EN.html" target="_blank">A9-0335/2023</a>
+                                
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            <a href="/oeil/en/document-summary?id=1764550" target="_blank">
+                                <button class="btn btn-success btn-sm" type="button">Summary</button>
+                            </a>
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >13/12/2023</td>
+                        <td class="align-middle">Decision by Parliament</td>
+                        <td class="align-middle text-center">
+                            
+                                <a href="https://www.europarl.europa.eu/doceo/document/TA-9-2023-0473_EN.html" target="_blank">T9-0473/2023</a>
+                                
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            <a href="/oeil/en/document-summary?id=1770181" target="_blank">
+                                <button class="btn btn-success btn-sm" type="button">Summary</button>
+                            </a>
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >13/12/2023</td>
+                        <td class="align-middle">Results of vote in Parliament</td>
+                        <td class="align-middle text-center">
+                            
+
+                            
+
+                            
+                                <a href="/oeil/en/sda-vote-result?sdaId=60860" target="_blank">
+                                    <svg aria-hidden="true" class="es_icon es_icon-vote es_icon-24">
+                                        <use xlink:href="#es_icon-vote"></use>
+                                    </svg>
+                                </a>
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+    </div>
+</div>
+
+
+                                
+                                
+
+
+
+
+
+                                
+                                <html lang="en">
+
+
+
+
+<div class="erpl_product-section">
+    <div class="separator border-dark my-3"></div>
+    <div id="section5" class="erpl-product-content oeil-spy-section mb-2">
+        <div class="row">
+            <div class="col-12 col-lg">
+                <h2 class="erpl_title-h2 mb-2">Technical information</h2>
+            </div>
+            <div class="col-12 col-lg-4">
+                <div class="erpl_links-list text-lg-right my-1">
+                    <ul>
+                        <li>
+                            <a href="/oeil/en/procedure-file/pdf?reference=2023/2019(INI)&amp;section=TECHNICAL_INFORMATION">
+                                <svg class="es_icon es_icon-pdf mr-1">
+                                    <title>pdf</title>
+                                    <use xlink:href="#es_icon-pdf"></use>
+                                </svg>
+                                <span class="t-x">Technical information</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <div class="table-responsive">
+            <table class="table table-striped table-bordered">
+                <thead>
+                <tr>
+                    <th class="align-middle" scope="col">Procedure</th>
+                    <th class="align-middle" scope="col">Information</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <th class="align-middle" scope="row">Procedure reference</th>
+                    <td class="align-middle">2023/2019(INI)</td>
+                </tr>
+                <tr>
+                    <th class="align-middle" scope="row">Procedure type</th>
+                    <td class="align-middle">INI - Own-initiative procedure</td>
+                </tr>
+                <tr>
+                    <th class="align-middle" scope="row">Nature of procedure</th>
+                    <td class="align-middle">Implementation</td>
+                </tr>
+                
+                
+                <tr>
+                    <th class="align-middle" scope="row">Legal basis</th>
+                    <td class="align-middle">
+                        
+                            <span class="d-block">Rules of Procedure EP 55  </span>
+                        
+                            <span class="d-block">Rules of Procedure EP 57_o  </span>
+                        
+                    </td>
+                </tr>
+                <tr>
+                    <th class="align-middle" scope="row">Other legal basis</th>
+                    <td class="align-middle">
+                        
+                            <span class="d-block">Rules of Procedure EP 165  </span>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <th class="align-middle" scope="row">Stage reached in procedure</th>
+                    <td class="align-middle">Procedure completed</td>
+                </tr>
+                <tr>
+                    <th class="align-middle" scope="row">Committee dossier</th>
+                    <td class="align-middle">
+                    
+                        <span>IMCO/9/11285</span>
+                        <br/>
+                    
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+                                
+                                <html lang="en">
+
+
+
+
+<div class="erpl_product-section">
+    <div class="separator border-dark my-3"></div>
+    <div id="section6" class="erpl-product-content oeil-spy-section mb-2">
+        <div class="row">
+            <div class="col-12 col-lg">
+                <h2 id="gateway" class="erpl_title-h2 mb-2">Documentation gateway</h2>
+            </div>
+            <div class="col-12 col-lg-4">
+                <div class="erpl_links-list text-lg-right my-1">
+                    <ul>
+                        <li>
+                            <a href="/oeil/en/procedure-file/pdf?reference=2023/2019(INI)&amp;section=DOCUMENTATION_GATEWAY" target="_blank">
+                                <svg class="es_icon es_icon-pdf mr-1">
+                                    <title>pdf</title>
+                                    <use xlink:href="#es_icon-pdf"></use>
+                                </svg>
+                                <span class="t-x">Documentation gateway</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="erpl_accordion mb-5" id="erplAccordionDocGateway">
+            <ul class="a-i">
+                
+                    <li class="erpl_accordion-item" data-selected="false">
+    <button
+            id="erpl_accordion-item-doc-gateway-EP-title"
+            type="button"
+            class="erpl_accordion-item-title collapsed"
+            data-toggle="collapse"
+            aria-expanded="true" data-target="#erpl_accordion-item-doc-gateway-EP" aria-controls="erpl_accordion-item-doc-gateway-EP"
+    >
+        <span class="t-x">European Parliament</span>
+        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
+                <use xlink:href="#es_icon-more"></use>
+            </svg>
+            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
+                <use xlink:href="#es_icon-less"></use>
+            </svg>
+        </span>
+    </button>
+    <div id="erpl_accordion-item-doc-gateway-EP" class="collapse erpl_accordion-item-content a-i-none collapse show" aria-labelledby="erpl_accordion-item-doc-gateway-EP-title">
+        <div>
+            <div class="table-responsive">
+                <table class="table table-striped table-bordered">
+                    <thead>
+                    <tr>
+                        
+
+                        <th class="align-middle" scope="col">Document type</th>
+                        <th class="align-middle" scope="col">Committee</th>
+                        <th class="align-middle w-25" scope="col">Reference</th>
+                        <th class="align-middle" scope="col">Date</th>
+                        <th class="align-middle" scope="col">Summary</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Amendments tabled in committee</span>
+                        </th>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/CULT-AM-749201_EN.html" target="_blank">PE749.201</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >30/05/2023</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Committee draft report</span>
+                        </th>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/IMCO-PR-749206_EN.html" target="_blank">PE749.206</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >15/06/2023</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Amendments tabled in committee</span>
+                        </th>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/JURI-AM-751728_EN.html" target="_blank">PE751.728</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >11/07/2023</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Amendments tabled in committee</span>
+                        </th>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/IMCO-AM-750251_EN.html" target="_blank">PE750.251</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >13/07/2023</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Committee opinion</span>
+                        </th>
+
+                        <td class="align-middle">
+                            <span class="erpl_badge erpl_badge-committee mr-25">CULT</span>
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/CULT-AD-746896_EN.html" target="_blank">PE746.896</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >18/07/2023</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Committee opinion</span>
+                        </th>
+
+                        <td class="align-middle">
+                            <span class="erpl_badge erpl_badge-committee mr-25">JURI</span>
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/JURI-AD-749286_EN.html" target="_blank">PE749.286</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >24/10/2023</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Committee report tabled for plenary, single reading</span>
+                        </th>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/A-9-2023-0335_EN.html" target="_blank">A9-0335/2023</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >07/11/2023</td>
+
+                        <td class="align-middle">
+                            <a href="/oeil/en/document-summary?id=1764550" target="_blank">
+                                <button class="btn btn-success btn-sm" type="button">Summary</button>
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Text adopted by Parliament, single reading</span>
+                        </th>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/TA-9-2023-0473_EN.html" target="_blank">T9-0473/2023</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >13/12/2023</td>
+
+                        <td class="align-middle">
+                            <a href="/oeil/en/document-summary?id=1770181" target="_blank">
+                                <button class="btn btn-success btn-sm" type="button">Summary</button>
+                            </a>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</li>
+                
+                    <li class="erpl_accordion-item" data-selected="false">
+    <button
+            id="erpl_accordion-item-doc-gateway-EC-title"
+            type="button"
+            class="erpl_accordion-item-title collapsed"
+            data-toggle="collapse"
+            aria-expanded="true" data-target="#erpl_accordion-item-doc-gateway-EC" aria-controls="erpl_accordion-item-doc-gateway-EC"
+    >
+        <span class="t-x">European Commission</span>
+        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
+                <use xlink:href="#es_icon-more"></use>
+            </svg>
+            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
+                <use xlink:href="#es_icon-less"></use>
+            </svg>
+        </span>
+    </button>
+    <div id="erpl_accordion-item-doc-gateway-EC" class="collapse erpl_accordion-item-content a-i-none collapse show" aria-labelledby="erpl_accordion-item-doc-gateway-EC-title">
+        <div>
+            <div class="table-responsive">
+                <table class="table table-striped table-bordered">
+                    <thead>
+                    <tr>
+                        
+
+                        <th class="align-middle" scope="col">Document type</th>
+                        
+                        <th class="align-middle w-25" scope="col">Reference</th>
+                        <th class="align-middle" scope="col">Date</th>
+                        <th class="align-middle" scope="col">Summary</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Commission response to text adopted in plenary</span>
+                        </th>
+
+                        
+                        <td class="align-middle w-25">
+                            <a href="https://data.europarl.europa.eu/distribution/doc/SP-2024-220-TA-9-2023-0473_en.docx" target="_blank">SP(2024)220</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >24/06/2024</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</li>
+                
+            </ul>
+        </div>
+    </div>
+</div>
+
+                                
+                                <html lang="en">
+
+
+
+
+
+
+                                
+                                
+<div class="erpl_product-section">
+    <div id="section8" class="separator border-dark my-3"></div>
+    <div class="erpl-product-content mb-2">
+        <div class="row">
+            <div class="col-12 col-lg"><h2 class="erpl_title-h2 mb-2">Transparency</h2>
+            </div>
+            <div class="col-12 col-lg-4">
+                <div class="erpl_links-list text-lg-right my-1">
+                    <ul>
+                        <li>
+                            <a href="/oeil/en/procedure-file/pdf?reference=2023/2019(INI)&amp;section=TRANSPARENCY">
+                                <svg class="es_icon es_icon-pdf mr-1">
+                                    <title>pdf</title>
+                                    <use xlink:href="#es_icon-pdf"></use>
+                                </svg>
+                                <span class="t-x">Transparency</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <p>Meetings with interest representatives published in line with the Rules of Procedure</p>
+        <div class="erpl_accordion mb-5" id="erplAccordionTransparency">
+            <ul class="a-i">
+                <li class="erpl_accordion-item" data-selected="false">
+                    <button id="meetingGroup0-content-title"
+                            type="button"
+                            class="erpl_accordion-item-title collapsed"
+                            data-toggle="collapse"
+                            aria-expanded="false"
+                            data-target="#meetingGroup0-content"
+                            aria-controls="meetingGroup0-content">
+                        <span class="t-x">Rapporteurs, Shadow Rapporteurs and Committee Chairs</span>
+                        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+                            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
+                                <use xlink:href="#es_icon-more"></use>
+                            </svg>
+                            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
+                                <use xlink:href="#es_icon-less"></use>
+                            </svg>
+                        </span>
+                    </button>
+                    <div id="meetingGroup0-content"
+                         class="collapse erpl_accordion-item-content a-i-none"
+                         aria-labelledby="meetingGroup0-content-title">
+                        <div class="oeil-meetings-list-container">
+                            <div class="table-responsive">
+                                <table class="table table-striped table-bordered">
+                                    <thead>
+                                    <tr>
+                                        <th class="align-middle" scope="col">Name</th>
+                                        <th class="align-middle" scope="col">Role</th>
+                                        <th class="align-middle" scope="col">Committee</th>
+                                        <th class="align-middle" scope="col">Date</th>
+                                        <th class="align-middle" scope="col">Interest representatives</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/24922"
+                                               class="font-weight-normal">ARIMONT Pascal</a>
+                                        </th>
+                                        <td class="align-middle">Shadow rapporteur for opinion</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/JURI"
+                                               title="Committee on Legal Affairs">JURI</a>
+                                        </td>
+                                        <td class="align-middle">30/11/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                ARD-Verbindungsbüro Brüssel
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/24505"
+                                               class="font-weight-normal">MAUREL Emmanuel</a>
+                                        </th>
+                                        <td class="align-middle">Shadow rapporteur for opinion</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/CULT"
+                                               title="Committee on Culture and Education">CULT</a>
+                                        </td>
+                                        <td class="align-middle">29/11/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                Société civile des Auteurs Réalisateurs Producteurs
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/237224"
+                                               class="font-weight-normal">ALBUQUERQUE João</a>
+                                        </th>
+                                        <td class="align-middle">Shadow rapporteur for opinion</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/CULT"
+                                               title="Committee on Culture and Education">CULT</a>
+                                        </td>
+                                        <td class="align-middle">23/11/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                EUROCINEMA, Association de producteurs de cinéma et de télévision
+                                                <br/>
+                                            
+                                                Europa Distribution
+                                                <br/>
+                                            
+                                                Europa International
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/24922"
+                                               class="font-weight-normal">ARIMONT Pascal</a>
+                                        </th>
+                                        <td class="align-middle">Rapporteur for opinion</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/JURI"
+                                               title="Committee on Legal Affairs">JURI</a>
+                                        </td>
+                                        <td class="align-middle">21/11/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                DFL Deutsche Fußball Liga GmbH
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/24922"
+                                               class="font-weight-normal">ARIMONT Pascal</a>
+                                        </th>
+                                        <td class="align-middle">Shadow rapporteur for opinion</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/JURI"
+                                               title="Committee on Legal Affairs">JURI</a>
+                                        </td>
+                                        <td class="align-middle">18/10/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                DFL Deutsche Fußball Liga GmbH
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/202073"
+                                               class="font-weight-normal">ANGEL Marc</a>
+                                        </th>
+                                        <td class="align-middle">Shadow rapporteur</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/IMCO"
+                                               title="Committee on the Internal Market and Consumer Protection">IMCO</a>
+                                        </td>
+                                        <td class="align-middle">12/10/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                Motion Picture Association EMEA
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/202073"
+                                               class="font-weight-normal">ANGEL Marc</a>
+                                        </th>
+                                        <td class="align-middle">Shadow rapporteur</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/IMCO"
+                                               title="Committee on the Internal Market and Consumer Protection">IMCO</a>
+                                        </td>
+                                        <td class="align-middle">12/07/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                ACT group
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/24922"
+                                               class="font-weight-normal">ARIMONT Pascal</a>
+                                        </th>
+                                        <td class="align-middle">Shadow rapporteur for opinion</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/JURI"
+                                               title="Committee on Legal Affairs">JURI</a>
+                                        </td>
+                                        <td class="align-middle">12/07/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                Eleven Sports
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/24922"
+                                               class="font-weight-normal">ARIMONT Pascal</a>
+                                        </th>
+                                        <td class="align-middle">Shadow rapporteur for opinion</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/JURI"
+                                               title="Committee on Legal Affairs">JURI</a>
+                                        </td>
+                                        <td class="align-middle">10/07/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                EBU-UER (European Broadcasting Union)
+                                                <br/>
+                                            
+                                                ACT
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/24922"
+                                               class="font-weight-normal">ARIMONT Pascal</a>
+                                        </th>
+                                        <td class="align-middle">Shadow rapporteur for opinion</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/JURI"
+                                               title="Committee on Legal Affairs">JURI</a>
+                                        </td>
+                                        <td class="align-middle">07/07/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                EUROCINEMA, Association de producteurs de cinéma et de télévision
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="separator separator-dotted separator-2x my-5">
+                                <button data-next-page-url="/oeil/en/procedure-meetings/?reference=2023/2019(INI)&amp;type=SPECIAL_ROLES&amp;page=1"
+                                        class="btn btn-default oei-loadmore-button"
+                                        title="Load more">Load more</button>
+                            </div>
+                        </div>
+                    </div>
+                </li>
+            </ul>
+            <ul class="a-i">
+                <li class="erpl_accordion-item" data-selected="false">
+                    <button id="meetingGroup1-content-title"
+                            type="button"
+                            class="erpl_accordion-item-title collapsed"
+                            data-toggle="collapse"
+                            aria-expanded="false"
+                            data-target="#meetingGroup1-content"
+                            aria-controls="meetingGroup1-content">
+                        <span class="t-x">Other Members</span>
+                        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+                            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
+                                <use xlink:href="#es_icon-more"></use>
+                            </svg>
+                            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
+                                <use xlink:href="#es_icon-less"></use>
+                            </svg>
+                        </span>
+                    </button>
+                    <div id="meetingGroup1-content"
+                         class="collapse erpl_accordion-item-content a-i-none"
+                         aria-labelledby="meetingGroup1-content-title">
+                        <div class="oeil-meetings-list-container">
+                            <div class="table-responsive">
+                                <table class="table table-striped table-bordered">
+                                    <thead>
+                                    <tr>
+                                        <th class="align-middle" scope="col">Name</th>
+                                        
+                                        
+                                        <th class="align-middle" scope="col">Date</th>
+                                        <th class="align-middle" scope="col">Interest representatives</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/197791"
+                                               class="font-weight-normal">SMERIGLIO Massimiliano</a>
+                                        </th>
+                                        
+                                        
+                                        <td class="align-middle">12/12/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                EUROCINEMA, Association de producteurs de cinéma et de télévision
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/96653"
+                                               class="font-weight-normal">ROTH NEVEĎALOVÁ Katarína</a>
+                                        </th>
+                                        
+                                        
+                                        <td class="align-middle">11/12/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                Association of Commercial Television and Video on Demand Services in Europe
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/197417"
+                                               class="font-weight-normal">SOKOL Tomislav</a>
+                                        </th>
+                                        
+                                        
+                                        <td class="align-middle">08/12/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                the Association of Commercial Television and Video on Demand Services in Europe (ACT)
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/96922"
+                                               class="font-weight-normal">BILBAO BARANDICA Izaskun</a>
+                                        </th>
+                                        
+                                        
+                                        <td class="align-middle">07/12/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                La Liga española de fútbol
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/197536"
+                                               class="font-weight-normal">COLIN-OESTERLÉ Nathalie</a>
+                                        </th>
+                                        
+                                        
+                                        <td class="align-middle">16/11/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                EUROCINEMA, Association de producteurs de cinéma et de télévision
+                                                <br/>
+                                            
+                                                Syndicat des producteurs indépendants
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/96775"
+                                               class="font-weight-normal">COMI Lara</a>
+                                        </th>
+                                        
+                                        
+                                        <td class="align-middle">15/11/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                Anica - Associazione Nazionale Industrie Cinematografiche Audiovisive Digitali
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/96775"
+                                               class="font-weight-normal">COMI Lara</a>
+                                        </th>
+                                        
+                                        
+                                        <td class="align-middle">15/11/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                European Leagues
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/247735"
+                                               class="font-weight-normal">BALLARÍN CEREZA Laura</a>
+                                        </th>
+                                        
+                                        
+                                        <td class="align-middle">08/11/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                Filmin
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/197832"
+                                               class="font-weight-normal">RIBA I GINER Diana</a>
+                                        </th>
+                                        
+                                        
+                                        <td class="align-middle">08/11/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                La Liga
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/247735"
+                                               class="font-weight-normal">BALLARÍN CEREZA Laura</a>
+                                        </th>
+                                        
+                                        
+                                        <td class="align-middle">08/11/2023</td>
+                                        <td class="align-middle">
+                                            
+                                                Laliga
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="separator separator-dotted separator-2x my-5">
+                                <button data-next-page-url="/oeil/en/procedure-meetings/?reference=2023/2019(INI)&amp;type=REGULAR_MEMBERS&amp;page=1"
+                                        class="btn btn-default oei-loadmore-button"
+                                        title="Load more">Load more</button>
+                            </div>
+                        </div>
+                    </div>
+                </li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+                                
+                                <html lang="en">
+
+
+
+
+
+
+</html>
+
+                                
+                                <html lang="en">
+
+
+
+
+
+
+</html>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+
+        <div class="col-12 col-xl-3 offset-xl-1">
+            
+            <div class="position-sticky" id="sectionsNavPositionInitial">
+                
+                
+
+
+
+
+<div class="card erpl_move"
+     data-move-lg="#sectionsNavPositionRwd"
+     data-move-md="#sectionsNavPositionRwd"
+     data-move-sm="#sectionsNavPositionRwd"
+     data-move-xl="#sectionsNavPositionInitial"
+     data-move-xs="#sectionsNavPositionRwd"
+     data-move-xxl="#sectionsNavPositionInitial">
+    <div class="card-body py-0">
+        <nav class="erpl_side-navigation">
+            <h3 class="erpl_title-h3 mb-0 py-2">
+                <a class="text-primary" href="#">
+                    <span class="t-x">Procedure file</span>
+                </a>
+            </h3>
+            <div class="erpl_links-list erpl_links-list-nav">
+                <ul>
+                    <li data-selected="true">
+                        <a class="erpl_smooth-scroll" href="#section1">
+                            <span class="t-x">Basic information</span>
+                        </a>
+                    </li>
+                    <li data-selected="false">
+                        <a class="erpl_smooth-scroll" href="#section2">
+                            <span class="t-x">Key players</span>
+                        </a>
+                    </li>
+                    <li data-selected="false">
+                        <a class="erpl_smooth-scroll" href="#section3">
+                            <span class="t-x">Key events</span>
+                        </a>
+                    </li>
+                    
+                    <li data-selected="false">
+                        <a class="erpl_smooth-scroll" href="#section5">
+                            <span class="t-x">Technical information</span>
+                        </a>
+                    </li>
+                    <li data-selected="false">
+                        <a class="erpl_smooth-scroll" href="#section6">
+                            <span class="t-x">Documentation gateway</span>
+                        </a>
+                    </li>
+                    
+                    <li data-selected="false">
+                        <a class="erpl_smooth-scroll" href="#section8">
+                            <span class="t-x">Transparency</span>
+                        </a>
+                    </li>
+                    
+                    
+                </ul>
+            </div>
+        </nav>
+    </div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+</main>
+
+    
+    <button id="scrollToTopButton" type="button" class="btn btn-primary rounded-circle" data-duration="250" data-min-scroll-to-show="200" aria-label="Scroll to top">
+        <svg aria-hidden="true" class="es_icon es_icon-chevron es_icon-rotate-270">
+            <use xlink:href="#es_icon-chevron"></use>
+        </svg>
+    </button>
+
+    
+    <footer class="erpl_footer">
+    <div class="erpl_footer-top mt-8">
+        <div class="container">
+            <div class="erpl_footer-top-content border-top-lg border-secondary text-center d-md-flex justify-content-between pt-md-3 mb-5 a-i">
+                <nav id="share-links" class="erpl_share-links" aria-label="Share links">
+                    <div class="d-md-flex">
+                        <h2 class="erpl_title-h5 mb-2 mb-md-0"><span class="mr-md-1">Share this page</span></h2>
+                        <ul class="erpl_share-links-list d-flex justify-content-center mb-3 mb-md-0">
+                            <li class="mr-1">
+                                <a title="Share this page on Facebook" href="https://www.facebook.com/share.php?u=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2023/2019(INI)" target="_blank">
+                                    <span class="sr-only">Facebook</span>
+                                    <svg aria-hidden="true" class="es_icon es_icon-facebook">
+                                        <use xlink:href="#es_icon-facebook"></use>
+                                    </svg>
+                                </a>
+                            </li>
+                            <li class="mr-1">
+                                <a title="Share this page on Twitter" href="https://twitter.com/intent/tweet?url=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2023/2019(INI)&amp;text=Procedure%20File:%202023/2019(INI)&amp;via=Europarl_EN" target="_blank">
+                                    <span class="sr-only">Twitter</span>
+                                    <svg aria-hidden="true" class="es_icon es_icon-twitter">
+                                        <use xlink:href="#es_icon-twitter"></use>
+                                    </svg>
+                                </a>
+                            </li>
+                            <li class="mr-1">
+                                <a title="Share this page on LinkedIn" href="https://www.linkedin.com/sharing/share-offsite?url=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2023/2019(INI)" target="_blank">
+                                    <span class="sr-only">LinkedIn</span>
+                                    <svg aria-hidden="true" class="es_icon es_icon-linkedin">
+                                        <use xlink:href="#es_icon-linkedin"></use>
+                                    </svg>
+                                </a>
+                            </li>
+                            <li>
+                                <a title="Share this page on Whatsapp" href="https://api.whatsapp.com/send?text=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2023/2019(INI)" target="_blank">
+                                    <span class="sr-only">Whatsapp</span>
+                                    <svg aria-hidden="true" class="es_icon es_icon-whatsapp">
+                                        <use xlink:href="#es_icon-whatsapp"></use>
+                                    </svg>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </nav>
+                <nav class="erpl_horizontal-links" aria-label="data protection link">
+                    <div>
+                        <a href="https://oeil.secure.europarl.europa.eu/oeil/en/external-documents/download?id=2" target="_blank">
+                            <span class="t-y">Data Protection Notice</span>
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+    </div>
+    <div class="erpl_footer-bottom bg-black-footer pt-3 pb-3">
+        <div class="container">
+            <div class="row" id="footerLinks">
+                <nav class="col-12 col-xl-9 text-center text-md-left" id="website-links" aria-label="Website links">
+    <h3 class="erpl_title-h3 mb-2 text-white">Legislative Observatory</h3>
+    <div class="collapse show" id="website-links-items">
+        <div class="row">
+            <div class="col-12 col-md-6 col-xl-4">
+                <div>
+                    <div class="subtitle mb-1">Tools</div>
+                    <nav class="link-group t-x-mode" aria-label="Tools">
+                        <a href="https://www.europarl.europa.eu/news/en/press-room" class="link-group-item mb-1 d-block">
+                            <span>Press Service</span>
+                        </a><a href="https://www.europarl.europa.eu/olp/en/home" class="link-group-item mb-1 d-block">
+                            <span>Ordinary legislative procedure</span>
+                        </a><a href="https://www.europarl.europa.eu/RegistreWeb/search/simple.htm?language=en" class="link-group-item mb-1 d-block">
+                            <span>Parliament register</span>
+                        </a><a href="https://eur-lex.europa.eu/en/index.htm" class="link-group-item mb-1 d-block">
+                            <span>EUR-Lex</span>
+                        </a><a href="https://www.consilium.europa.eu/en/documents-publications/public-register/" class="link-group-item mb-1 d-block">
+                            <span>Council register</span>
+                        </a><a href="https://webgate.ec.europa.eu/regdel/#/home" class="link-group-item mb-1 d-block">
+                            <span>Delegated acts register</span>
+                        </a>
+                    </nav>
+                </div>
+            </div>
+            <div class="col-12 col-md-6 col-xl-4">
+                <div>
+                    <div class="subtitle mb-1">Committees</div>
+                    <nav class="link-group t-x-mode" aria-label="Committees">
+                        <a href="https://www.europarl.europa.eu/committees/en/home" class="link-group-item mb-1 d-block">
+                            <span>Home</span>
+                        </a><a href="https://www.europarl.europa.eu/committees/en/meetings/meeting-documents" class="link-group-item mb-1 d-block">
+                            <span>Meetings</span>
+                        </a><a href="https://www.europarl.europa.eu/committees/en/documents/search" class="link-group-item mb-1 d-block">
+                            <span>Documents</span>
+                        </a><a href="https://www.europarl.europa.eu/committees/en/events/events-hearings" class="link-group-item mb-1 d-block">
+                            <span>Events</span>
+                        </a><a href="https://www.europarl.europa.eu/committees/en/supporting-analyses/sa-highlights" class="link-group-item mb-1 d-block">
+                            <span>Supporting analyses</span>
+                        </a>
+                    </nav>
+                </div>
+                <div>
+                    <div class="subtitle mb-1">Plenary</div>
+                    <nav class="link-group t-x-mode" aria-label="Plenary">
+                        <a href="https://www.europarl.europa.eu/plenary/en/" class="link-group-item mb-1 d-block">
+                            <span>Plenary sitting</span>
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/guide-plenary.html" class="link-group-item mb-1 d-block">
+                            <span>Around plenary</span>
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliamentary-questions.html" class="link-group-item mb-1 d-block">
+                            <span>Questions and declarations</span>
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliament-positions.html" class="link-group-item mb-1 d-block">
+                            <span>Legislative texts adopted</span>
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/meetings-search.html" class="link-group-item mb-1 d-block">
+                            <span>Calendar</span>
+                        </a>
+                    </nav>
+                </div>
+            </div>
+            <div class="col-12 col-md-6 col-xl-4">
+                <div>
+                    <div class="subtitle mb-1">Delegations</div>
+                    <nav class="link-group t-x-mode" aria-label="Delegations">
+                        <a href="https://www.europarl.europa.eu/delegations/en/calendar" class="link-group-item mb-1 d-block">
+                            <span>Calendar</span>
+                        </a><a href="https://www.europarl.europa.eu/delegations/en/home" class="link-group-item mb-1 d-block">
+                            <span>Home</span>
+                        </a>
+                    </nav>
+                </div>
+                <div>
+                    <div class="subtitle mb-1">MEPs</div>
+                    <nav class="link-group t-x-mode" aria-label="MEPs">
+                        <a href="https://www.europarl.europa.eu/meps/en/search/advanced" class="link-group-item mb-1 d-block">
+                            <span>Search</span>
+                        </a>
+                    </nav>
+                </div>
+                <div>
+                    <div class="subtitle mb-1">At your service</div>
+                    <nav class="link-group t-x-mode" aria-label="At your service">
+                        <a href="https://www.europarl.europa.eu/at-your-service/en" class="link-group-item mb-1 d-block">
+                            <span>Home</span>
+                        </a>
+                    </nav>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="d-block d-md-none">
+        <div class="footerLinkToggle separator separator-dotted separator-2x mb-5 mt-5 collapsed">
+            <a class="erpl_toggle-menu" href="#website-links"
+               title="Toggle linked links"
+               role="button"
+               data-toggle="collapse"
+               data-target="#website-links-items"
+               aria-expanded="false"
+               aria-controls="website-links" aria-label="Toggle linked links">
+                <svg aria-hidden="true" class="es_icon es_icon-plus" data-show-expanded="false">
+                    <use xlink:href="#es_icon-plus"></use>
+                </svg>
+
+                <svg aria-hidden="true" class="es_icon es_icon-minus" data-show-expanded="true">
+                    <use xlink:href="#es_icon-minus"></use>
+                </svg>
+            </a>
+            <a class="erpl_nojs-close-menu" href="#website-links-close"
+               title="Untoggle linked links"
+               role="button"
+               data-toggle="collapse"
+               data-target="#website-links-items"
+               aria-expanded="false"
+               aria-controls="website-links" aria-label="Untoggle linked links">
+                <svg aria-hidden="true" class="es_icon es_icon-minus">
+                    <use xlink:href="#es_icon-minus"></use>
+                </svg>
+            </a>
+        </div>
+    </div>
+</nav>
+                <nav class="col-12 col-xl-3 text-center text-md-left" id="europarl-links" aria-label="Europarl links">
+    <div class="separator separator-dotted separator-2x mt-3 mb-4 d-none d-md-flex d-xl-none"></div>
+    <h3 class="erpl_title-h3 mb-2 text-white">European Parliament</h3>
+    <div class="collapse show" id="europarl-links-items">
+        <nav class="link-group pt-25 t-x-mode" aria-label="European Parliament">
+            <a href="https://www.europarl.europa.eu/news/en" class="link-group-item mb-1 d-block">
+                <span>News</span></a><a href="https://www.europarl.europa.eu/topics/en" class="link-group-item mb-1 d-block">
+                <span>Topics</span></a><a href="https://www.europarl.europa.eu/meps/en" class="link-group-item mb-1 d-block">
+                <span>MEPs</span></a><a href="https://www.europarl.europa.eu/about-parliament/en" class="link-group-item mb-1 d-block">
+                <span>About Parliament</span></a><a href="https://www.europarl.europa.eu/plenary/en" class="link-group-item mb-1 d-block">
+                <span>Plenary</span></a><a href="https://www.europarl.europa.eu/committees/en" class="link-group-item mb-1 d-block">
+                <span>Committees</span></a><a href="https://www.europarl.europa.eu/delegations/en" class="link-group-item mb-1 d-block">
+                <span>Delegations</span></a><a href="https://elections.europa.eu/en/" class="link-group-item mb-1 d-block">
+                <span>Elections</span></a>
+        </nav>
+    </div>
+    <div class="d-block d-md-none">
+        <div class="footerLinkToggle separator separator-dotted separator-2x mb-5 mt-5 collapsed">
+            <a href="#europarl-links"
+               title="Toggle European Parliament websites"
+               role="button"
+               data-toggle="collapse"
+               data-target="#europarl-links-items"
+               aria-expanded="false"
+               aria-controls="europarl-links" aria-label="Toggle European Parliament websites">
+                <svg aria-hidden="true" class="es_icon es_icon-plus" data-show-expanded="false">
+                    <use xlink:href="#es_icon-plus"></use>
+                </svg>
+
+                <svg aria-hidden="true" class="es_icon es_icon-minus" data-show-expanded="true">
+                    <use xlink:href="#es_icon-minus"></use>
+                </svg>
+            </a>
+            <a class="erpl_nojs-close-menu" href="#europarl-links-close"
+               title="Untoggle European Parliament websites"
+               role="button" data-toggle="collapse"
+               data-target="#europarl-links-items"
+               aria-expanded="false"
+               aria-controls="europarl-links" aria-label="Untoggle European Parliament websites">
+                <svg aria-hidden="true" class="es_icon es_icon-minus">
+                    <use xlink:href="#es_icon-minus"></use>
+                </svg>
+            </a>
+        </div>
+    </div>
+</nav>
+            </div>
+
+
+            <div class="separator separator-dotted separator-2x mt-3 mb-3 d-none d-md-flex"></div>
+            <div class="row">
+                <nav class="col-12" id="social-links" aria-label="Social links">
+                    <div class="erpl_social-links mb-2">
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on Facebook" href="https://www.facebook.com/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-facebook-color">
+                                    <use href="#es_icon-facebook-color"></use>
+                                </svg>
+                                <span class="sr-only">Facebook</span>
+                            </a>
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on Twitter" href="https://twitter.com/Europarl_en" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-twitter-color">
+                                    <use href="#es_icon-twitter-color"></use>
+                                </svg>
+                                <span class="sr-only">Twitter</span>
+                            </a>
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on Flickr" href="https://www.flickr.com/photos/european_parliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-flickr-color">
+                                    <use href="#es_icon-flickr-color"></use>
+                                </svg>
+                                <span class="sr-only">Flickr</span>
+                            </a>
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on LinkedIn" href="https://www.linkedin.com/company/european-parliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-linkedin-color">
+                                    <use href="#es_icon-linkedin-color"></use>
+                                </svg>
+                                <span class="sr-only">LinkedIn</span>
+                            </a>
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on YouTube" href="https://www.youtube.com/user/EuropeanParliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-youtube-color">
+                                    <use href="#es_icon-youtube-color"></use>
+                                </svg>
+                                <span class="sr-only">YouTube</span>
+                            </a>
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on Instagram" href="https://www.instagram.com/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-instagram-color">
+                                    <use href="#es_icon-instagram-color"></use>
+                                </svg>
+                                <span class="sr-only">Instagram</span>
+                            </a>
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on Pinterest" href="https://www.pinterest.fr/epinfographics" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-pinterest-color">
+                                    <use href="#es_icon-pinterest-color"></use>
+                                </svg>
+                                <span class="sr-only">Pinterest</span>
+                            </a>
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on Snapchat" href="https://www.snapchat.com/add/europarl" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-snapchat-color">
+                                    <use href="#es_icon-snapchat-color"></use>
+                                </svg>
+                                <span class="sr-only">Snapchat</span>
+                            </a>
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on Reddit" href="https://www.reddit.com/r/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-reddit-color">
+                                    <use href="#es_icon-reddit-color"></use>
+                                </svg>
+                                <span class="sr-only">Reddit</span>
+                            </a>
+                        
+                    </div>
+                </nav>
+            </div>
+            <div class="row">
+                <nav id="information-links" class="col-12 small text-center text-white font-weight-bold t-y-mode" aria-label="Information links">
+                    
+                        <a href="https://www.europarl.europa.eu/portal/en/contact" class="mr-2 mb-1">
+                            <span>Contact</span>
+                        </a>
+                    
+                        <a href="https://www.europarl.europa.eu/portal/en/sitemap" class="mr-2 mb-1">
+                            <span>Sitemap</span>
+                        </a>
+                    
+                        <a href="https://www.europarl.europa.eu/legal-notice/en" class="mr-2 mb-1">
+                            <span>Legal notice</span>
+                        </a>
+                    
+                        <a href="https://www.europarl.europa.eu/privacy-policy/en" class="mr-2 mb-1">
+                            <span>Privacy policy</span>
+                        </a>
+                    
+                        <a href="https://www.europarl.europa.eu/portal/en/accessibility" class="mr-2 mb-1">
+                            <span>Accessibility</span>
+                        </a>
+                    
+                </nav>
+            </div>
+        </div>
     </div>
 </footer>
-</div>
 
-    </body>
+    
+    <script src="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/lib/jquery/jquery.min.js"></script>
+    
+    <script id="evostrap" src="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/dist/js/evostrap.js"></script>
+    <script src="https://www.europarl.europa.eu/commonFrontResources/evostrap-oeil/1.0.0//dist/js/oeil.js"></script>
+
+    
+    <script src="/oeil/oeil-addons/documents-loading.js"></script>
+    <script src="/oeil/oeil-addons/session-calendar.js"></script>
+    <script src="/oeil/oeil-addons/tools.js"></script>
+    <script src="/oeil/oeil-addons/meetings-list.js"></script>
+
+    
+    <script type="text/javascript" defer data-tracker-name="ATInternet"
+            data-value="https://www.europarl.europa.eu/website/webanalytics/ati-oeil.js"
+            src="https://www.europarl.europa.eu/website/privacy-policy/privacy-policy.js">
+    </script>
+
+    
+    
+    <script src="/oeil/oeil-addons/scroll-spy.js"></script>
+
+</body>
 </html>


### PR DESCRIPTION
The markup of the OEIL has changed and the previous selector to extract the procedure title didn’t work any more. Also updated the tests fixture with the current version of the web page.