### PR TITLE
Do not display votes with empty titles

### DIFF
--- a/backend/howtheyvote/api/votes_api.py
+++ b/backend/howtheyvote/api/votes_api.py
@@ -6,7 +6,7 @@ from io import StringIO
 from typing import TypeVar
 
 from flask import Blueprint, Response, abort, jsonify, request
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from structlog import get_logger
 
 from ..db import Session
@@ -102,6 +102,7 @@ def index() -> Response:
     query = query.page_size(request.args.get("page_size", type=int))
     query = query.sort("timestamp", Order.DESC)
     query = query.filter("is_main", True)
+    query = query.where(or_(Vote.title != None, Vote.procedure_title != None))  # noqa: E711
 
     response = query.handle()
     results: list[BaseVoteDict] = [

--- a/backend/howtheyvote/store/index.py
+++ b/backend/howtheyvote/store/index.py
@@ -71,7 +71,11 @@ def index_search(
         return
 
     votes = cast(Iterable[Vote], records)
-    formatted_records = [_serialize_vote(vote) for vote in votes if vote.is_main]
+    formatted_records = []
+
+    for vote in votes:
+        if vote.is_main and vote.display_title:
+            formatted_records.append(_serialize_vote(vote))
 
     if not len(formatted_records):
         log.warning("Skipping indexing to search index as list of records is empty")

--- a/backend/tests/api/test_votes_api.py
+++ b/backend/tests/api/test_votes_api.py
@@ -139,6 +139,36 @@ def test_votes_api_index(db_session, api):
     assert res.json["results"][0]["display_title"] == "Vote One"
 
 
+def test_votes_api_index_empty_title(db_session, api):
+    empty_title = Vote(
+        id=1,
+        timestamp=datetime.datetime(2024, 1, 1, 0, 0, 0),
+        is_main=True,
+    )
+
+    non_empty_vote_title = Vote(
+        id=2,
+        timestamp=datetime.datetime(2024, 1, 2, 0, 0, 0),
+        title="Vote title",
+        is_main=True,
+    )
+
+    non_empty_procedure_title = Vote(
+        id=3,
+        timestamp=datetime.datetime(2024, 1, 3, 0, 0, 0),
+        title="Procedure title",
+        is_main=True,
+    )
+
+    db_session.add_all([empty_title, non_empty_vote_title, non_empty_procedure_title])
+    db_session.commit()
+
+    res = api.get("/api/votes")
+    assert len(res.json["results"]) == 2
+    assert res.json["results"][0]["display_title"] == "Procedure title"
+    assert res.json["results"][1]["display_title"] == "Vote title"
+
+
 def test_votes_api_search(db_session, search_index, api):
     one = Vote(
         id=1,


### PR DESCRIPTION
In some cases, we cannot extract any title (vote title or procedure title) for a given vote. In that case, we cannot display anything about this vote in the frontend, so we should probably just hide it.

After deployment run the following commands:

```
# Delete search index to make sure all votes (incl. those without a title) are removed
htv system delete-indexes

# Recreate the index
htv system upgrade

# Reindex all votes
htv aggregate votes
```
