### PR TITLE
Update main vote analyzer to also handle special vote titles 

### DIFF
--- a/backend/howtheyvote/pipelines/rcv_list.py
+++ b/backend/howtheyvote/pipelines/rcv_list.py
@@ -234,7 +234,9 @@ class RCVListPipeline:
         writer = BulkWriter()
 
         for vote in self._votes():
-            analyzer = MainVoteAnalyzer(vote.id, vote.description)
+            analyzer = MainVoteAnalyzer(
+                vote_id=vote.id, description=vote.description, title=vote.title
+            )
             writer.add(analyzer.run())
 
         writer.flush()

--- a/backend/tests/analysis/test_votes.py
+++ b/backend/tests/analysis/test_votes.py
@@ -1,0 +1,64 @@
+from howtheyvote.analysis.votes import MainVoteAnalyzer
+from howtheyvote.models.common import Fragment
+
+from ..helpers import record_to_dict
+
+
+def test_main_vote_analyzer_description():
+    analyzer = MainVoteAnalyzer(
+        vote_id=1,
+        description="Am 123",
+        title="Lorem Ipsum",
+    )
+    assert analyzer.run() is None
+
+    analyzer = MainVoteAnalyzer(
+        vote_id=2,
+        description="Proposition de résolution",
+        title="Lorem ipsum",
+    )
+    expected = Fragment(
+        model="Vote",
+        source_id=2,
+        source_name="MainVoteAnalyzer",
+        group_key=2,
+        data={"is_main": True},
+    )
+    assert record_to_dict(analyzer.run()) == record_to_dict(expected)
+
+    analyzer = MainVoteAnalyzer(
+        vote_id=3,
+        description="Accord provisoire - Am 123",
+        title="Lorem ipsum",
+    )
+    expected = Fragment(
+        model="Vote",
+        source_id=3,
+        source_name="MainVoteAnalyzer",
+        group_key=3,
+        data={"is_main": True},
+    )
+    assert record_to_dict(analyzer.run()) == record_to_dict(expected)
+
+
+def test_main_vote_analyzer_title():
+    analyzer = MainVoteAnalyzer(
+        vote_id=1,
+        description=None,
+        title="Ordre du jour de mardi",
+    )
+    assert analyzer.run() is None
+
+    expected = Fragment(
+        model="Vote",
+        source_id=2,
+        source_name="MainVoteAnalyzer",
+        group_key=2,
+        data={"is_main": True},
+    )
+    analyzer = MainVoteAnalyzer(
+        vote_id=2,
+        description=None,
+        title="Élection de la Commission",
+    )
+    assert record_to_dict(analyzer.run()) == record_to_dict(expected)

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -1,0 +1,7 @@
+from typing import Any
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+def record_to_dict(record: DeclarativeBase) -> dict[str, Any]:
+    return {c.name: getattr(record, c.name) for c in record.__table__.columns}

--- a/backend/tests/scrapers/helpers.py
+++ b/backend/tests/scrapers/helpers.py
@@ -1,14 +1,7 @@
 from pathlib import Path
-from typing import Any
-
-from sqlalchemy.orm import DeclarativeBase
 
 FIXTURES_BASE = Path(__file__).resolve().parent / "data"
 
 
 def load_fixture(path: str) -> str:
     return FIXTURES_BASE.joinpath(path).read_text()
-
-
-def record_to_dict(record: DeclarativeBase) -> dict[str, Any]:
-    return {c.name: getattr(record, c.name) for c in record.__table__.columns}

--- a/backend/tests/scrapers/test_votes.py
+++ b/backend/tests/scrapers/test_votes.py
@@ -11,7 +11,8 @@ from howtheyvote.scrapers.votes import (
     RCVListScraper,
 )
 
-from .helpers import load_fixture, record_to_dict
+from ..helpers import record_to_dict
+from .helpers import load_fixture
 
 
 def test_rcv_list_scraper(responses):


### PR DESCRIPTION
Until now, we’ve decided whether a vote is a main vote solely based on the description of a vote. However, in rare cases a main vote may not have description and only a title (e.g. in case of the election of the Commission). I’ve updated the analyzer to handle votes based on title in addition to the existing heuristic.