### PR TITLE
Prevent line breaks within formatted date

### DIFF
--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -38,6 +38,7 @@
   border-radius: 4px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   box-shadow: 0 2px 3px rgba(0, 0, 0, 0.2);
+  text-wrap: balance;
 }
 
 .home-page__session-info strong {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -126,7 +126,8 @@ function SessionInfo({ currentSession, lastSession }: SessionInfoProps) {
       <>
         The last plenary session was held{" "}
         {locationName && `in ${locationName} `}
-        from {startDate} to {endDate}.{" "}
+        from {startDate?.replaceAll(" ", "\u00a0")} to{" "}
+        {endDate?.replace(" ", "\u00a0")}.{" "}
         <strong>
           <a href="/votes">View vote results</a>
         </strong>{" "}


### PR DESCRIPTION
This fixes a small visual issue: In some cases, line breaks were inserted in formatted dates (for example `Nov[break]28`). This PR fixes that by using non-breaking spaces in formatted dates and also improves the visual appearance by ensuring that the lines are roughly the same length (using `text-wrap: balance`).

**Before:**
<img width="606" alt="Screenshot 2024-12-08 at 11 09 45 PM" src="https://github.com/user-attachments/assets/453740d3-9310-4673-ba61-a4be912b4710">

**After:**
<img width="601" alt="Screenshot 2024-12-08 at 11 11 46 PM" src="https://github.com/user-attachments/assets/eaa1f8a6-4405-4a9d-b3c5-abf2523095b9">

