### PR TITLE
Temporarily pin Poetry to <2.0

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install "poetry<2.0"
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,7 +15,7 @@ RUN apk --update add \
     sqlite \
     tmux
 
-RUN pip install poetry
+RUN pip install "poetry<2.0"
 
 WORKDIR /howtheyvote/backend
 


### PR DESCRIPTION
A new major version of Poetry has been released which includes some breaking changes related to project configuration: https://python-poetry.org/blog/announcing-poetry-2.0.0

For now, this pins to Poetry < 2.0