### PR TITLE
Fix last session on homepage

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -26,16 +26,16 @@ export const loader: Loader<HomePageData> = async () => {
   const { data: current } = await getSessions({
     query: {
       status: "current",
-      pageSize: 1,
-      sortOrder: "asc",
+      page_size: 1,
+      sort_order: "asc",
     },
   });
 
   const { data: past } = await getSessions({
     query: {
       status: "past",
-      pageSize: 1,
-      sortOrder: "desc",
+      page_size: 1,
+      sort_order: "desc",
     },
   });
 


### PR DESCRIPTION
I think with the recent `openapi-ts` upgrade the naming convention for parameter names changed. As a result, the parameters are ignored and currently an incorrect date is displayed on the homepage. Also checked that there are no other similar issues like this.