### PR TITLE
Update groups, countries, Eurovoc terms

### DIFF
--- a/backend/howtheyvote/cli/dev.py
+++ b/backend/howtheyvote/cli/dev.py
@@ -357,10 +357,9 @@ def _load_alt_labels(group_code: str) -> set[str]:
 
 
 def exec_sparql_query(endpoint: str, query: str) -> Any:
-    params = {
-        "format": "application/sparql-results+json",
-        "query": query,
-    }
-
-    response = requests.get(endpoint, params=params)
+    response = requests.post(
+        endpoint,
+        data={"query": query},
+        headers={"Accept": "application/sparql-results+json"},
+    )
     return response.json()["results"]["bindings"]

--- a/backend/howtheyvote/cli/dev.py
+++ b/backend/howtheyvote/cli/dev.py
@@ -94,7 +94,6 @@ def load_eurovoc() -> None:
       }
     }
     GROUP BY ?id ?label ?geo_area_code
-    ORDER BY ?id
     """
     log.info("Retrieving EuroVoc terms")
     results = exec_sparql_query(DATA_ENDPOINT, query)
@@ -129,9 +128,9 @@ def load_eurovoc() -> None:
             EurovocConcept(
                 id=result["id"]["value"],
                 label=result["label"]["value"],
-                alt_labels=alt_labels,
-                related_ids=related_ids,
-                broader_ids=broader_ids,
+                alt_labels=sorted(alt_labels),
+                related_ids=sorted(related_ids),
+                broader_ids=sorted(broader_ids),
                 geo_area_code=geo_area_code,
             )
         )
@@ -194,11 +193,7 @@ def load_countries() -> None:
         # The Named Authority Code assigned by the EU. In case of countries listed in ISO-3166-1, this
         # this is the 3-letter country code.
         ?country dc:identifier ?code.
-
-        # Protocol order for EU member states
-        OPTIONAL { ?country euvoc:order ?order. }
     }
-    ORDER BY (!BOUND(?order)) ?order ?code
     """  # noqa: E501
 
     log.info("Retrieving countries")
@@ -274,7 +269,6 @@ def load_groups() -> None:
             )
         }
     }
-    ORDER BY (BOUND(?end_date)) ?code
     """  # noqa: E501
 
     log.info("Retrieving groups")
@@ -330,7 +324,7 @@ def load_groups() -> None:
                 short_label=short_label,
                 start_date=start_date,
                 end_date=end_date,
-                alt_labels=list(alt_labels),
+                alt_labels=sorted(alt_labels),
             )
         )
 

--- a/backend/howtheyvote/cli/dev.py
+++ b/backend/howtheyvote/cli/dev.py
@@ -103,10 +103,10 @@ def load_eurovoc() -> None:
     )
 
     for result in results:
-        # `term` is the resource URI (e.g. `http://eurovoc.europa.eu/162`) which contains the ID.
-        # We previously used the DC Terms `identifier` property. However, this property is sometimes
-        # ambiguous. For example, the domain concept "AGRICULTURE, FORESTRY AND FISHERIES" has the
-        # DC Terms identifier `56`, but the correct ID is `100156`.
+        # `term` is the resource URI (e.g. `http://eurovoc.europa.eu/162`) which contains the
+        # ID. We previously used the DC Terms `identifier` property. However, this property is
+        # sometimes ambiguous. For example, the domain concept "AGRICULTURE, FORESTRY AND
+        # FISHERIES" has the DC Terms identifier `56`, but the correct ID is `100156`.
         if result["term"]["value"]:
             uri = result["term"]["value"]
             _, id_ = uri.rsplit("/", 1)

--- a/backend/howtheyvote/data.py
+++ b/backend/howtheyvote/data.py
@@ -38,6 +38,7 @@ class DataclassContainer(Generic[DataclassType]):
     def save(self) -> None:
         """Save data to file."""
         records = [dataclasses.asdict(r) for r in self.index.values()]  # type: ignore
+        records = sorted(records, key=lambda r: r[self.key_attr])
         text = json_dumps(records, indent=2)
         self.file_path.write_text(text)
 

--- a/backend/howtheyvote/data/countries.json
+++ b/backend/howtheyvote/data/countries.json
@@ -1,167 +1,5 @@
 [
   {
-    "code": "BEL",
-    "label": "Belgium",
-    "alt_label": "Kingdom of Belgium",
-    "iso_alpha_2": "BE"
-  },
-  {
-    "code": "BGR",
-    "label": "Bulgaria",
-    "alt_label": "Republic of Bulgaria",
-    "iso_alpha_2": "BG"
-  },
-  {
-    "code": "CZE",
-    "label": "Czechia",
-    "alt_label": "Czech Republic",
-    "iso_alpha_2": "CZ"
-  },
-  {
-    "code": "DNK",
-    "label": "Denmark",
-    "alt_label": "Kingdom of Denmark",
-    "iso_alpha_2": "DK"
-  },
-  {
-    "code": "DEU",
-    "label": "Germany",
-    "alt_label": "Federal Republic of Germany",
-    "iso_alpha_2": "DE"
-  },
-  {
-    "code": "EST",
-    "label": "Estonia",
-    "alt_label": "Republic of Estonia",
-    "iso_alpha_2": "EE"
-  },
-  {
-    "code": "IRL",
-    "label": "Ireland",
-    "alt_label": "Ireland",
-    "iso_alpha_2": "IE"
-  },
-  {
-    "code": "GRC",
-    "label": "Greece",
-    "alt_label": "Hellenic Republic",
-    "iso_alpha_2": "GR"
-  },
-  {
-    "code": "ESP",
-    "label": "Spain",
-    "alt_label": "Kingdom of Spain",
-    "iso_alpha_2": "ES"
-  },
-  {
-    "code": "FRA",
-    "label": "France",
-    "alt_label": "French Republic",
-    "iso_alpha_2": "FR"
-  },
-  {
-    "code": "HRV",
-    "label": "Croatia",
-    "alt_label": "Republic of Croatia",
-    "iso_alpha_2": "HR"
-  },
-  {
-    "code": "ITA",
-    "label": "Italy",
-    "alt_label": "Italian Republic",
-    "iso_alpha_2": "IT"
-  },
-  {
-    "code": "CYP",
-    "label": "Cyprus",
-    "alt_label": "Republic of Cyprus",
-    "iso_alpha_2": "CY"
-  },
-  {
-    "code": "LVA",
-    "label": "Latvia",
-    "alt_label": "Republic of Latvia",
-    "iso_alpha_2": "LV"
-  },
-  {
-    "code": "LTU",
-    "label": "Lithuania",
-    "alt_label": "Republic of Lithuania",
-    "iso_alpha_2": "LT"
-  },
-  {
-    "code": "LUX",
-    "label": "Luxembourg",
-    "alt_label": "Grand Duchy of Luxembourg",
-    "iso_alpha_2": "LU"
-  },
-  {
-    "code": "HUN",
-    "label": "Hungary",
-    "alt_label": "Hungary",
-    "iso_alpha_2": "HU"
-  },
-  {
-    "code": "MLT",
-    "label": "Malta",
-    "alt_label": "Republic of Malta",
-    "iso_alpha_2": "MT"
-  },
-  {
-    "code": "NLD",
-    "label": "Netherlands",
-    "alt_label": "Kingdom of the Netherlands",
-    "iso_alpha_2": "NL"
-  },
-  {
-    "code": "AUT",
-    "label": "Austria",
-    "alt_label": "Republic of Austria",
-    "iso_alpha_2": "AT"
-  },
-  {
-    "code": "POL",
-    "label": "Poland",
-    "alt_label": "Republic of Poland",
-    "iso_alpha_2": "PL"
-  },
-  {
-    "code": "PRT",
-    "label": "Portugal",
-    "alt_label": "Portuguese Republic",
-    "iso_alpha_2": "PT"
-  },
-  {
-    "code": "ROU",
-    "label": "Romania",
-    "alt_label": "Romania",
-    "iso_alpha_2": "RO"
-  },
-  {
-    "code": "SVN",
-    "label": "Slovenia",
-    "alt_label": "Republic of Slovenia",
-    "iso_alpha_2": "SI"
-  },
-  {
-    "code": "SVK",
-    "label": "Slovakia",
-    "alt_label": "Slovak Republic",
-    "iso_alpha_2": "SK"
-  },
-  {
-    "code": "FIN",
-    "label": "Finland",
-    "alt_label": "Republic of Finland",
-    "iso_alpha_2": "FI"
-  },
-  {
-    "code": "SWE",
-    "label": "Sweden",
-    "alt_label": "Kingdom of Sweden",
-    "iso_alpha_2": "SE"
-  },
-  {
     "code": "ABW",
     "label": "Aruba",
     "alt_label": "Aruba",
@@ -252,6 +90,12 @@
     "iso_alpha_2": "AU"
   },
   {
+    "code": "AUT",
+    "label": "Austria",
+    "alt_label": "Republic of Austria",
+    "iso_alpha_2": "AT"
+  },
+  {
     "code": "AZE",
     "label": "Azerbaijan",
     "alt_label": "Republic of Azerbaijan",
@@ -262,6 +106,12 @@
     "label": "Burundi",
     "alt_label": "Republic of Burundi",
     "iso_alpha_2": "BI"
+  },
+  {
+    "code": "BEL",
+    "label": "Belgium",
+    "alt_label": "Kingdom of Belgium",
+    "iso_alpha_2": "BE"
   },
   {
     "code": "BEN",
@@ -286,6 +136,12 @@
     "label": "Bangladesh",
     "alt_label": "People\u2019s Republic of Bangladesh",
     "iso_alpha_2": "BD"
+  },
+  {
+    "code": "BGR",
+    "label": "Bulgaria",
+    "alt_label": "Republic of Bulgaria",
+    "iso_alpha_2": "BG"
   },
   {
     "code": "BHR",
@@ -498,6 +354,24 @@
     "iso_alpha_2": "KY"
   },
   {
+    "code": "CYP",
+    "label": "Cyprus",
+    "alt_label": "Republic of Cyprus",
+    "iso_alpha_2": "CY"
+  },
+  {
+    "code": "CZE",
+    "label": "Czechia",
+    "alt_label": "Czech Republic",
+    "iso_alpha_2": "CZ"
+  },
+  {
+    "code": "DEU",
+    "label": "Germany",
+    "alt_label": "Federal Republic of Germany",
+    "iso_alpha_2": "DE"
+  },
+  {
     "code": "DJI",
     "label": "Djibouti",
     "alt_label": "Republic of Djibouti",
@@ -508,6 +382,12 @@
     "label": "Dominica",
     "alt_label": "Commonwealth of Dominica",
     "iso_alpha_2": "DM"
+  },
+  {
+    "code": "DNK",
+    "label": "Denmark",
+    "alt_label": "Kingdom of Denmark",
+    "iso_alpha_2": "DK"
   },
   {
     "code": "DOM",
@@ -546,6 +426,18 @@
     "iso_alpha_2": "EH"
   },
   {
+    "code": "ESP",
+    "label": "Spain",
+    "alt_label": "Kingdom of Spain",
+    "iso_alpha_2": "ES"
+  },
+  {
+    "code": "EST",
+    "label": "Estonia",
+    "alt_label": "Republic of Estonia",
+    "iso_alpha_2": "EE"
+  },
+  {
     "code": "ETH",
     "label": "Ethiopia",
     "alt_label": "Federal Democratic Republic of Ethiopia",
@@ -558,6 +450,12 @@
     "iso_alpha_2": "EU"
   },
   {
+    "code": "FIN",
+    "label": "Finland",
+    "alt_label": "Republic of Finland",
+    "iso_alpha_2": "FI"
+  },
+  {
     "code": "FJI",
     "label": "Fiji",
     "alt_label": "Republic of Fiji",
@@ -568,6 +466,12 @@
     "label": "Falkland Islands",
     "alt_label": "Falkland Islands",
     "iso_alpha_2": "FK"
+  },
+  {
+    "code": "FRA",
+    "label": "France",
+    "alt_label": "French Republic",
+    "iso_alpha_2": "FR"
   },
   {
     "code": "FRO",
@@ -648,6 +552,12 @@
     "iso_alpha_2": "GQ"
   },
   {
+    "code": "GRC",
+    "label": "Greece",
+    "alt_label": "Hellenic Republic",
+    "iso_alpha_2": "GR"
+  },
+  {
     "code": "GRD",
     "label": "Grenada",
     "alt_label": "Grenada",
@@ -702,10 +612,22 @@
     "iso_alpha_2": "HN"
   },
   {
+    "code": "HRV",
+    "label": "Croatia",
+    "alt_label": "Republic of Croatia",
+    "iso_alpha_2": "HR"
+  },
+  {
     "code": "HTI",
     "label": "Haiti",
     "alt_label": "Republic of Haiti",
     "iso_alpha_2": "HT"
+  },
+  {
+    "code": "HUN",
+    "label": "Hungary",
+    "alt_label": "Hungary",
+    "iso_alpha_2": "HU"
   },
   {
     "code": "IDN",
@@ -732,6 +654,12 @@
     "iso_alpha_2": "IO"
   },
   {
+    "code": "IRL",
+    "label": "Ireland",
+    "alt_label": "Ireland",
+    "iso_alpha_2": "IE"
+  },
+  {
     "code": "IRN",
     "label": "Iran",
     "alt_label": "Islamic Republic of Iran",
@@ -754,6 +682,12 @@
     "label": "Israel",
     "alt_label": "State of Israel",
     "iso_alpha_2": "IL"
+  },
+  {
+    "code": "ITA",
+    "label": "Italy",
+    "alt_label": "Italian Republic",
+    "iso_alpha_2": "IT"
   },
   {
     "code": "JAM",
@@ -876,6 +810,24 @@
     "iso_alpha_2": "LS"
   },
   {
+    "code": "LTU",
+    "label": "Lithuania",
+    "alt_label": "Republic of Lithuania",
+    "iso_alpha_2": "LT"
+  },
+  {
+    "code": "LUX",
+    "label": "Luxembourg",
+    "alt_label": "Grand Duchy of Luxembourg",
+    "iso_alpha_2": "LU"
+  },
+  {
+    "code": "LVA",
+    "label": "Latvia",
+    "alt_label": "Republic of Latvia",
+    "iso_alpha_2": "LV"
+  },
+  {
     "code": "MAC",
     "label": "Macao",
     "alt_label": "Macao Special Administrative Region of the People\u2019s Republic of China",
@@ -940,6 +892,12 @@
     "label": "Mali",
     "alt_label": "Republic of Mali",
     "iso_alpha_2": "ML"
+  },
+  {
+    "code": "MLT",
+    "label": "Malta",
+    "alt_label": "Republic of Malta",
+    "iso_alpha_2": "MT"
   },
   {
     "code": "MMR",
@@ -1056,6 +1014,12 @@
     "iso_alpha_2": "NU"
   },
   {
+    "code": "NLD",
+    "label": "Netherlands",
+    "alt_label": "Kingdom of the Netherlands",
+    "iso_alpha_2": "NL"
+  },
+  {
     "code": "NOR",
     "label": "Norway",
     "alt_label": "Kingdom of Norway",
@@ -1064,7 +1028,7 @@
   {
     "code": "NPL",
     "label": "Nepal",
-    "alt_label": "Federal Democratic Republic of Nepal",
+    "alt_label": "Nepal",
     "iso_alpha_2": "NP"
   },
   {
@@ -1084,6 +1048,12 @@
     "label": "Oman",
     "alt_label": "Sultanate of Oman",
     "iso_alpha_2": "OM"
+  },
+  {
+    "code": "OP_DATPRO",
+    "label": "Provisional data",
+    "alt_label": null,
+    "iso_alpha_2": null
   },
   {
     "code": "PAK",
@@ -1128,6 +1098,12 @@
     "iso_alpha_2": "PG"
   },
   {
+    "code": "POL",
+    "label": "Poland",
+    "alt_label": "Republic of Poland",
+    "iso_alpha_2": "PL"
+  },
+  {
     "code": "PRI",
     "label": "Puerto Rico",
     "alt_label": "Commonwealth of Puerto Rico",
@@ -1138,6 +1114,12 @@
     "label": "North Korea",
     "alt_label": "Democratic People\u2019s Republic of Korea",
     "iso_alpha_2": "KP"
+  },
+  {
+    "code": "PRT",
+    "label": "Portugal",
+    "alt_label": "Portuguese Republic",
+    "iso_alpha_2": "PT"
   },
   {
     "code": "PRY",
@@ -1168,6 +1150,12 @@
     "label": "R\u00e9union",
     "alt_label": "R\u00e9union",
     "iso_alpha_2": "RE"
+  },
+  {
+    "code": "ROU",
+    "label": "Romania",
+    "alt_label": "Romania",
+    "iso_alpha_2": "RO"
   },
   {
     "code": "RUS",
@@ -1282,6 +1270,24 @@
     "label": "Suriname",
     "alt_label": "Republic of Suriname",
     "iso_alpha_2": "SR"
+  },
+  {
+    "code": "SVK",
+    "label": "Slovakia",
+    "alt_label": "Slovak Republic",
+    "iso_alpha_2": "SK"
+  },
+  {
+    "code": "SVN",
+    "label": "Slovenia",
+    "alt_label": "Republic of Slovenia",
+    "iso_alpha_2": "SI"
+  },
+  {
+    "code": "SWE",
+    "label": "Sweden",
+    "alt_label": "Kingdom of Sweden",
+    "iso_alpha_2": "SE"
   },
   {
     "code": "SWZ",
@@ -1465,8 +1471,8 @@
   },
   {
     "code": "VNM",
-    "label": "Vietnam",
-    "alt_label": "Socialist Republic of Vietnam",
+    "label": "Viet Nam",
+    "alt_label": "Socialist Republic of Viet Nam",
     "iso_alpha_2": "VN"
   },
   {
@@ -1747,7 +1753,19 @@
   },
   {
     "code": "XXP",
-    "label": "China/Philippines/Vietnam/Taiwan/Malaysia (disputed territory)",
+    "label": "China/Philippines/Viet Nam/Taiwan/Malaysia (disputed territory)",
+    "alt_label": null,
+    "iso_alpha_2": null
+  },
+  {
+    "code": "XXR",
+    "label": "Gabon/Equatorial Guinea (disputed territory)",
+    "alt_label": null,
+    "iso_alpha_2": null
+  },
+  {
+    "code": "XXS",
+    "label": "Chagos Islands (disputed territory)",
     "alt_label": null,
     "iso_alpha_2": null
   },

--- a/backend/howtheyvote/data/eurovoc.json
+++ b/backend/howtheyvote/data/eurovoc.json
@@ -3029,21 +3029,10 @@
   },
   {
     "id": "12",
-    "label": "accession to the European Union",
-    "alt_labels": [
-      "EU accession",
-      "accession to the Community",
-      "act of accession",
-      "application for accession",
-      "consequence of accession",
-      "request for accession"
-    ],
-    "related_ids": [
-      "6725"
-    ],
-    "broader_ids": [
-      "4057"
-    ],
+    "label": "12 LAW",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
     "geo_area_code": null
   },
   {
@@ -15427,10 +15416,16 @@
   },
   {
     "id": "20",
-    "label": "20 TRADE",
-    "alt_labels": [],
+    "label": "award of contract",
+    "alt_labels": [
+      "automatic public tendering",
+      "award notice",
+      "award procedure"
+    ],
     "related_ids": [],
-    "broader_ids": [],
+    "broader_ids": [
+      "1810"
+    ],
     "geo_area_code": null
   },
   {
@@ -34138,10 +34133,16 @@
   },
   {
     "id": "32",
-    "label": "32 EDUCATION AND COMMUNICATIONS",
+    "label": "Communism",
     "alt_labels": [],
-    "related_ids": [],
-    "broader_ids": [],
+    "related_ids": [
+      "2250",
+      "382",
+      "7134"
+    ],
+    "broader_ids": [
+      "1282"
+    ],
     "geo_area_code": null
   },
   {
@@ -46057,10 +46058,16 @@
   },
   {
     "id": "40",
-    "label": "40 BUSINESS AND COMPETITION",
-    "alt_labels": [],
-    "related_ids": [],
-    "broader_ids": [],
+    "label": "competence of the Member States",
+    "alt_labels": [
+      "supporting competence"
+    ],
+    "related_ids": [
+      "36"
+    ],
+    "broader_ids": [
+      "4017"
+    ],
     "geo_area_code": null
   },
   {
@@ -59331,10 +59338,15 @@
   },
   {
     "id": "48",
-    "label": "48 TRANSPORT",
-    "alt_labels": [],
+    "label": "educational administration",
+    "alt_labels": [
+      "school administration",
+      "university administration"
+    ],
     "related_ids": [],
-    "broader_ids": [],
+    "broader_ids": [
+      "4705"
+    ],
     "geo_area_code": null
   },
   {
@@ -63870,8 +63882,10 @@
   },
   {
     "id": "52",
-    "label": "52 ENVIRONMENT",
-    "alt_labels": [],
+    "label": "composition of the population",
+    "alt_labels": [
+      "population structure"
+    ],
     "related_ids": [],
     "broader_ids": [],
     "geo_area_code": null
@@ -67789,7 +67803,7 @@
       "5775",
       "914"
     ],
-    "geo_area_code": "BYS"
+    "geo_area_code": "BLR"
   },
   {
     "id": "5459",
@@ -69917,18 +69931,9 @@
   },
   {
     "id": "56",
-    "label": "national accounts",
-    "alt_labels": [
-      "national account"
-    ],
-    "related_ids": [
-      "1800",
-      "3193",
-      "4369",
-      "4633",
-      "54",
-      "655"
-    ],
+    "label": "56 AGRICULTURE, FORESTRY AND FISHERIES",
+    "alt_labels": [],
+    "related_ids": [],
     "broader_ids": [],
     "geo_area_code": null
   },
@@ -81761,12 +81766,10 @@
   },
   {
     "id": "66",
-    "label": "concentration of the population",
+    "label": "66 ENERGY",
     "alt_labels": [],
     "related_ids": [],
-    "broader_ids": [
-      "3300"
-    ],
+    "broader_ids": [],
     "geo_area_code": null
   },
   {
@@ -86980,14 +86983,10 @@
   },
   {
     "id": "76",
-    "label": "international competition",
+    "label": "76 INTERNATIONAL ORGANISATIONS",
     "alt_labels": [],
-    "related_ids": [
-      "11"
-    ],
-    "broader_ids": [
-      "75"
-    ],
+    "related_ids": [],
+    "broader_ids": [],
     "geo_area_code": null
   },
   {
@@ -90767,7 +90766,7 @@
     "broader_ids": [
       "1087"
     ],
-    "geo_area_code": "ATF"
+    "geo_area_code": "FQ0"
   },
   {
     "id": "8375",

--- a/backend/howtheyvote/data/eurovoc.json
+++ b/backend/howtheyvote/data/eurovoc.json
@@ -1,27 +1,15 @@
 [
   {
-    "id": "04",
-    "label": "04 POLITICS",
-    "alt_labels": [],
-    "related_ids": [],
-    "broader_ids": [],
-    "geo_area_code": null
-  },
-  {
-    "id": "08",
-    "label": "08 INTERNATIONAL RELATIONS",
-    "alt_labels": [],
-    "related_ids": [],
-    "broader_ids": [],
-    "geo_area_code": null
-  },
-  {
     "id": "10",
-    "label": "10 EUROPEAN UNION",
+    "label": "domestic trade",
     "alt_labels": [],
-    "related_ids": [],
-    "broader_ids": [],
-    "geo_area_code": "EUR"
+    "related_ids": [
+      "1806"
+    ],
+    "broader_ids": [
+      "2449"
+    ],
+    "geo_area_code": null
   },
   {
     "id": "100",
@@ -55,6 +43,174 @@
     "broader_ids": [
       "1000"
     ],
+    "geo_area_code": null
+  },
+  {
+    "id": "100142",
+    "label": "04 POLITICS",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100143",
+    "label": "08 INTERNATIONAL RELATIONS",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100144",
+    "label": "10 EUROPEAN UNION",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": "EUR"
+  },
+  {
+    "id": "100145",
+    "label": "12 LAW",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100146",
+    "label": "16 ECONOMICS",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100147",
+    "label": "20 TRADE",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100148",
+    "label": "24 FINANCE",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100149",
+    "label": "28 SOCIAL QUESTIONS",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100150",
+    "label": "32 EDUCATION AND COMMUNICATIONS",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100151",
+    "label": "36 SCIENCE",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100152",
+    "label": "40 BUSINESS AND COMPETITION",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100153",
+    "label": "44 EMPLOYMENT AND WORKING CONDITIONS",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100154",
+    "label": "48 TRANSPORT",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100155",
+    "label": "52 ENVIRONMENT",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100156",
+    "label": "56 AGRICULTURE, FORESTRY AND FISHERIES",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100157",
+    "label": "60 AGRI-FOODSTUFFS",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100158",
+    "label": "64 PRODUCTION, TECHNOLOGY AND RESEARCH",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100159",
+    "label": "66 ENERGY",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100160",
+    "label": "68 INDUSTRY",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100161",
+    "label": "72 GEOGRAPHY",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
+    "geo_area_code": null
+  },
+  {
+    "id": "100162",
+    "label": "76 INTERNATIONAL ORGANISATIONS",
+    "alt_labels": [],
+    "related_ids": [],
+    "broader_ids": [],
     "geo_area_code": null
   },
   {
@@ -3029,10 +3185,21 @@
   },
   {
     "id": "12",
-    "label": "12 LAW",
-    "alt_labels": [],
-    "related_ids": [],
-    "broader_ids": [],
+    "label": "accession to the European Union",
+    "alt_labels": [
+      "EU accession",
+      "accession to the Community",
+      "act of accession",
+      "application for accession",
+      "consequence of accession",
+      "request for accession"
+    ],
+    "related_ids": [
+      "6725"
+    ],
+    "broader_ids": [
+      "4057"
+    ],
     "geo_area_code": null
   },
   {
@@ -9285,14 +9452,6 @@
     "broader_ids": [
       "41"
     ],
-    "geo_area_code": null
-  },
-  {
-    "id": "16",
-    "label": "16 ECONOMICS",
-    "alt_labels": [],
-    "related_ids": [],
-    "broader_ids": [],
     "geo_area_code": null
   },
   {
@@ -52518,10 +52677,12 @@
   },
   {
     "id": "44",
-    "label": "44 EMPLOYMENT AND WORKING CONDITIONS",
+    "label": "territorial jurisdiction",
     "alt_labels": [],
     "related_ids": [],
-    "broader_ids": [],
+    "broader_ids": [
+      "42"
+    ],
     "geo_area_code": null
   },
   {
@@ -67803,7 +67964,7 @@
       "5775",
       "914"
     ],
-    "geo_area_code": "BLR"
+    "geo_area_code": "BYS"
   },
   {
     "id": "5459",
@@ -69931,9 +70092,18 @@
   },
   {
     "id": "56",
-    "label": "56 AGRICULTURE, FORESTRY AND FISHERIES",
-    "alt_labels": [],
-    "related_ids": [],
+    "label": "national accounts",
+    "alt_labels": [
+      "national account"
+    ],
+    "related_ids": [
+      "1800",
+      "3193",
+      "4369",
+      "4633",
+      "54",
+      "655"
+    ],
     "broader_ids": [],
     "geo_area_code": null
   },
@@ -80801,10 +80971,14 @@
   },
   {
     "id": "64",
-    "label": "64 PRODUCTION, TECHNOLOGY AND RESEARCH",
+    "label": "tied sales outlet",
     "alt_labels": [],
-    "related_ids": [],
-    "broader_ids": [],
+    "related_ids": [
+      "4663"
+    ],
+    "broader_ids": [
+      "806"
+    ],
     "geo_area_code": null
   },
   {
@@ -81766,10 +81940,12 @@
   },
   {
     "id": "66",
-    "label": "66 ENERGY",
+    "label": "concentration of the population",
     "alt_labels": [],
     "related_ids": [],
-    "broader_ids": [],
+    "broader_ids": [
+      "3300"
+    ],
     "geo_area_code": null
   },
   {
@@ -83405,10 +83581,23 @@
   },
   {
     "id": "68",
-    "label": "68 INDUSTRY",
-    "alt_labels": [],
-    "related_ids": [],
-    "broader_ids": [],
+    "label": "local government",
+    "alt_labels": [
+      "county council",
+      "local administration",
+      "local powers",
+      "municipal authority",
+      "town council"
+    ],
+    "related_ids": [
+      "1017",
+      "2515",
+      "3924",
+      "699"
+    ],
+    "broader_ids": [
+      "77"
+    ],
     "geo_area_code": null
   },
   {
@@ -85261,10 +85450,12 @@
   },
   {
     "id": "72",
-    "label": "72 GEOGRAPHY",
+    "label": "concessionaire",
     "alt_labels": [],
     "related_ids": [],
-    "broader_ids": [],
+    "broader_ids": [
+      "3218"
+    ],
     "geo_area_code": null
   },
   {
@@ -86983,10 +87174,14 @@
   },
   {
     "id": "76",
-    "label": "76 INTERNATIONAL ORGANISATIONS",
+    "label": "international competition",
     "alt_labels": [],
-    "related_ids": [],
-    "broader_ids": [],
+    "related_ids": [
+      "11"
+    ],
+    "broader_ids": [
+      "75"
+    ],
     "geo_area_code": null
   },
   {

--- a/backend/howtheyvote/data/groups.json
+++ b/backend/howtheyvote/data/groups.json
@@ -1,99 +1,5 @@
 [
   {
-    "code": "ECR",
-    "official_label": "European Conservatives and Reformists Group",
-    "label": "European Conservatives and Reformists",
-    "short_label": "ECR",
-    "alt_labels": [],
-    "start_date": "2009-07-14",
-    "end_date": null
-  },
-  {
-    "code": "EPP",
-    "official_label": "Group of the European People\u2019s Party",
-    "label": "European People\u2019s Party",
-    "short_label": "EPP",
-    "alt_labels": [
-      "Group of the European People\u2019s Party (Christian Democrats) and European Democrats",
-      "Group of the European People\u2019s Party (Christian Democrats)",
-      "Group of the European People\u2019s Party (Christian-Democratic Group)"
-    ],
-    "start_date": "1979-07-17",
-    "end_date": null
-  },
-  {
-    "code": "GREEN_EFA",
-    "official_label": "Group of the Greens/European Free Alliance",
-    "label": "Greens/European Free Alliance",
-    "short_label": "Greens/EFA",
-    "alt_labels": [
-      "Verts/ALE"
-    ],
-    "start_date": "1999-07-20",
-    "end_date": null
-  },
-  {
-    "code": "GUE_NGL",
-    "official_label": "The Left group in the European Parliament \u2013 GUE/NGL",
-    "label": "The Left in the European Parliament \u2013 GUE/NGL",
-    "short_label": "GUE/NGL",
-    "alt_labels": [
-      "European United Left \u2013 Nordic Green Left",
-      "Confederal Group of the European United Left \u2013 Nordic Green Left"
-    ],
-    "start_date": "1995-01-06",
-    "end_date": null
-  },
-  {
-    "code": "ID",
-    "official_label": "Identity and Democracy Group",
-    "label": "Identity and Democracy",
-    "short_label": "ID",
-    "alt_labels": [],
-    "start_date": "2019-07-02",
-    "end_date": null
-  },
-  {
-    "code": "NI",
-    "official_label": "Non-attached Members",
-    "label": "Non-attached Members",
-    "short_label": "Non-attached",
-    "alt_labels": [
-      "NI"
-    ],
-    "start_date": "1953-06-23",
-    "end_date": null
-  },
-  {
-    "code": "RENEW",
-    "official_label": "Renew Europe Group",
-    "label": "Renew Europe",
-    "short_label": "Renew",
-    "alt_labels": [],
-    "start_date": "2019-06-12",
-    "end_date": null
-  },
-  {
-    "code": "SD",
-    "official_label": "Group of the Progressive Alliance of Socialists and Democrats in the European Parliament",
-    "label": "Progressive Alliance of Socialists and Democrats",
-    "short_label": "S&D",
-    "alt_labels": [
-      "Progressive Alliance of Socialists and Democrats in the European Parliament"
-    ],
-    "start_date": "2009-07-14",
-    "end_date": null
-  },
-  {
-    "code": "SEC",
-    "official_label": "Political groups\u2019 secretariats",
-    "label": "Political groups\u2019 secretariats",
-    "short_label": "Political groups\u2019 secretariats",
-    "alt_labels": [],
-    "start_date": "1958-03-19",
-    "end_date": null
-  },
-  {
     "code": "ALDE",
     "official_label": "Group of the Alliance of Liberals and Democrats for Europe",
     "label": "Alliance of Liberals and Democrats for Europe",
@@ -153,8 +59,8 @@
     "label": "Communist and Allies",
     "short_label": "Communist and Allies",
     "alt_labels": [
-      "Communists and Allies",
       "Communist and Allies Group (SF, Ind. Sin.)",
+      "Communists and Allies",
       "Communists and Allies (SF, Ind. Sin.)"
     ],
     "start_date": "1973-10-16",
@@ -197,8 +103,8 @@
     "label": "Technical Group of the European Right",
     "short_label": "Technical Group of the European Right",
     "alt_labels": [
-      "Group of the European Right",
-      "European Right"
+      "European Right",
+      "Group of the European Right"
     ],
     "start_date": "1984-07-24",
     "end_date": "1994-07-18"
@@ -213,6 +119,15 @@
     ],
     "start_date": "1973-01-16",
     "end_date": "1979-07-16"
+  },
+  {
+    "code": "ECR",
+    "official_label": "European Conservatives and Reformists Group",
+    "label": "European Conservatives and Reformists",
+    "short_label": "ECR",
+    "alt_labels": [],
+    "start_date": "2009-07-14",
+    "end_date": null
   },
   {
     "code": "ED",
@@ -279,6 +194,28 @@
     "end_date": "2019-07-01"
   },
   {
+    "code": "EPP",
+    "official_label": "Group of the European People\u2019s Party",
+    "label": "European People\u2019s Party",
+    "short_label": "EPP",
+    "alt_labels": [
+      "Group of the European People\u2019s Party (Christian Democrats)",
+      "Group of the European People\u2019s Party (Christian Democrats) and European Democrats",
+      "Group of the European People\u2019s Party (Christian-Democratic Group)"
+    ],
+    "start_date": "1979-07-17",
+    "end_date": null
+  },
+  {
+    "code": "ESN",
+    "official_label": "Europe of Sovereign Nations Group",
+    "label": "Europe of Sovereign Nations",
+    "short_label": "ESN",
+    "alt_labels": [],
+    "start_date": "2024-07-10",
+    "end_date": null
+  },
+  {
     "code": "EUL",
     "official_label": "Group for the European United Left",
     "label": "Group for the European United Left",
@@ -310,6 +247,17 @@
     "end_date": "1999-07-19"
   },
   {
+    "code": "GREEN_EFA",
+    "official_label": "Group of the Greens/European Free Alliance",
+    "label": "Greens/European Free Alliance",
+    "short_label": "Greens/EFA",
+    "alt_labels": [
+      "Verts/ALE"
+    ],
+    "start_date": "1999-07-20",
+    "end_date": null
+  },
+  {
     "code": "GUE",
     "official_label": "Confederal Group of the European United Left",
     "label": "Confederal Group of the European United Left",
@@ -319,6 +267,28 @@
     ],
     "start_date": "1994-07-19",
     "end_date": "1995-01-05"
+  },
+  {
+    "code": "GUE_NGL",
+    "official_label": "The Left group in the European Parliament \u2013 GUE/NGL",
+    "label": "The Left in the European Parliament \u2013 GUE/NGL",
+    "short_label": "GUE/NGL",
+    "alt_labels": [
+      "Confederal Group of the European United Left \u2013 Nordic Green Left",
+      "European United Left \u2013 Nordic Green Left",
+      "The Left group in the European Parliament"
+    ],
+    "start_date": "1995-01-06",
+    "end_date": null
+  },
+  {
+    "code": "ID",
+    "official_label": "Identity and Democracy Group",
+    "label": "Identity and Democracy",
+    "short_label": "ID",
+    "alt_labels": [],
+    "start_date": "2019-07-02",
+    "end_date": "2024-07-07"
   },
   {
     "code": "IEDN",
@@ -383,16 +353,36 @@
     "end_date": "1994-07-18"
   },
   {
+    "code": "NI",
+    "official_label": "Non-attached Members",
+    "label": "Non-attached Members",
+    "short_label": "Non-attached",
+    "alt_labels": [
+      "NI"
+    ],
+    "start_date": "1953-06-23",
+    "end_date": null
+  },
+  {
+    "code": "PFE",
+    "official_label": "Patriots for Europe Group",
+    "label": "Patriots for Europe",
+    "short_label": "Patriots for Europe",
+    "alt_labels": [],
+    "start_date": "2024-07-08",
+    "end_date": null
+  },
+  {
     "code": "PSE",
     "official_label": "Socialist Group in the European Parliament",
     "label": "Socialist Group in the European Parliament",
     "short_label": "Socialist Group in the European Parliament",
     "alt_labels": [
-      "Party of European Socialists",
-      "Socialists",
-      "Socialist Group",
       "Group of the Party of European Socialists",
-      "Socialist"
+      "Party of European Socialists",
+      "Socialist",
+      "Socialist Group",
+      "Socialists"
     ],
     "start_date": "1953-06-23",
     "end_date": "2009-07-13"
@@ -405,6 +395,35 @@
     "alt_labels": [],
     "start_date": "1984-07-23",
     "end_date": "1995-07-04"
+  },
+  {
+    "code": "RENEW",
+    "official_label": "Renew Europe Group",
+    "label": "Renew Europe",
+    "short_label": "Renew",
+    "alt_labels": [],
+    "start_date": "2019-06-12",
+    "end_date": null
+  },
+  {
+    "code": "SD",
+    "official_label": "Group of the Progressive Alliance of Socialists and Democrats in the European Parliament",
+    "label": "Progressive Alliance of Socialists and Democrats",
+    "short_label": "S&D",
+    "alt_labels": [
+      "Progressive Alliance of Socialists and Democrats in the European Parliament"
+    ],
+    "start_date": "2009-07-14",
+    "end_date": null
+  },
+  {
+    "code": "SEC",
+    "official_label": "Political groups\u2019 secretariats",
+    "label": "Political groups\u2019 secretariats",
+    "short_label": "Political groups\u2019 secretariats",
+    "alt_labels": [],
+    "start_date": "1958-03-19",
+    "end_date": null
   },
   {
     "code": "TDI",
@@ -436,22 +455,5 @@
     ],
     "start_date": "1995-07-05",
     "end_date": "1999-07-19"
-  },
-  {
-    "code": "ESN",
-    "official_label": "Europe of Sovereign Nations Group",
-    "label": "Europe of Sovereign Nations",
-    "short_label": "ESN",
-    "start_date": "2024-07-10",
-    "alt_labels": []
-
-  },
-  {
-    "code": "PFE",
-    "official_label": "Patriots for Europe Group",
-    "label": "Patriots for Europe",
-    "short_label": "PFE",
-    "start_date": "2024-07-08",
-    "alt_labels": []
   }
 ]

--- a/backend/howtheyvote/models/eurovoc.py
+++ b/backend/howtheyvote/models/eurovoc.py
@@ -22,9 +22,9 @@ class EurovocConceptMeta(type):
 class EurovocConcept(DeserializableDataclass, metaclass=EurovocConceptMeta):
     id: str
     label: str
-    alt_labels: set[str]
-    related_ids: set[str]
-    broader_ids: set[str]
+    alt_labels: list[str]
+    related_ids: list[str]
+    broader_ids: list[str]
     geo_area_code: str | None
 
     def __hash__(self) -> int:

--- a/backend/tests/test_data.py
+++ b/backend/tests/test_data.py
@@ -16,7 +16,7 @@ class ExampleDataclass(DeserializableDataclass):
         return cls(**data)
 
 
-def test_dataclass_container__save(tmp_path: Path):
+def test_dataclass_container_save(tmp_path: Path):
     file_path = tmp_path.joinpath("container.json")
 
     container = DataclassContainer(
@@ -29,6 +29,29 @@ def test_dataclass_container__save(tmp_path: Path):
     container.save()
 
     expected = json.dumps([{"id": "foo", "label": "bar"}], indent=2)
+    assert file_path.read_text() == expected
+
+
+def test_dataclass_container_save_sorted(tmp_path: Path):
+    file_path = tmp_path.joinpath("container.json")
+
+    container = DataclassContainer(
+        dataclass=ExampleDataclass,
+        file_path=file_path,
+        key_attr="id",
+    )
+
+    container.add(ExampleDataclass(id="foo", label="foo"))
+    container.add(ExampleDataclass(id="bar", label="bar"))
+    container.save()
+
+    expected = json.dumps(
+        [
+            {"id": "bar", "label": "bar"},
+            {"id": "foo", "label": "foo"},
+        ],
+        indent=2,
+    )
     assert file_path.read_text() == expected
 
 


### PR DESCRIPTION
This fixes the last remaining task in #960.

I’ve also implemented a few small changes to sort records and list values. This should make it much easier to diff the resulting JSON files. (Right now, rerunning some of the `htv load-*` commands can lead to large diffs, even though there have been only small or no changes.)

Also had to fix how we send SPARQL requests because some SPARQL endpoints now only accept POST requests. (We were using GET requests before.)