### PR TITLE
Rename exceptions to follow PEP8

### DIFF
--- a/backend/howtheyvote/pipelines/common.py
+++ b/backend/howtheyvote/pipelines/common.py
@@ -18,15 +18,11 @@ class PipelineResult:
     checksum: str | None
 
 
-class PipelineError(Exception):
+class DataUnavailable(Exception):  # noqa: N818
     pass
 
 
-class DataUnavailableError(PipelineError):
-    pass
-
-
-class DataUnchangedError(PipelineError):
+class DataUnchanged(Exception):  # noqa: N818
     pass
 
 
@@ -45,9 +41,9 @@ class BasePipeline(ABC):
         try:
             self._run()
             status = PipelineStatus.SUCCESS
-        except DataUnavailableError:
+        except DataUnavailable:
             status = PipelineStatus.DATA_UNAVAILABLE
-        except DataUnchangedError:
+        except DataUnchanged:
             status = PipelineStatus.DATA_UNCHANGED
         except ScrapingError:
             status = PipelineStatus.FAILURE

--- a/backend/howtheyvote/pipelines/rcv_list.py
+++ b/backend/howtheyvote/pipelines/rcv_list.py
@@ -29,8 +29,8 @@ from ..sharepics import generate_vote_sharepic
 from ..store import Aggregator, BulkWriter, index_records, map_vote, map_vote_group
 from .common import (
     BasePipeline,
-    DataUnavailableError,
-    DataUnchangedError,
+    DataUnavailable,
+    DataUnchanged,
     compute_response_checksum,
 )
 
@@ -99,15 +99,13 @@ class RCVListPipeline(BasePipeline):
         try:
             fragments = scraper.run()
         except NoWorkingUrlError as exc:
-            raise DataUnavailableError("Pipeline data source is not available") from exc
+            raise DataUnavailable("Pipeline data source is not available") from exc
 
         if (
             self.last_run_checksum is not None
             and self.last_run_checksum == compute_response_checksum(scraper.response)
         ):
-            raise DataUnchangedError(
-                "The data source hasn't changed since the last pipeline run."
-            )
+            raise DataUnchanged("The data source hasn't changed since the last pipeline run.")
 
         self.checksum = compute_response_checksum(scraper.response)
 

--- a/backend/howtheyvote/worker/__init__.py
+++ b/backend/howtheyvote/worker/__init__.py
@@ -19,7 +19,7 @@ from ..pipelines import (
 )
 from ..query import session_is_current_at
 from .worker import (
-    SkipPipelineError,
+    SkipPipeline,
     Weekday,
     Worker,
     last_pipeline_run_checksum,
@@ -35,10 +35,10 @@ def op_rcv_midday() -> PipelineResult:
     today = datetime.date.today()
 
     if not _is_session_day(today):
-        raise SkipPipelineError()
+        raise SkipPipeline()
 
     if pipeline_ran_successfully(RCVListPipeline, today):
-        raise SkipPipelineError()
+        raise SkipPipeline()
 
     pipeline = RCVListPipeline(term=config.CURRENT_TERM, date=today)
     return pipeline.run()
@@ -53,10 +53,10 @@ def op_rcv_evening() -> PipelineResult:
     today = datetime.date.today()
 
     if not _is_session_day(today):
-        raise SkipPipelineError()
+        raise SkipPipeline()
 
     if pipeline_ran_successfully(RCVListPipeline, today, count=2):
-        raise SkipPipelineError()
+        raise SkipPipeline()
 
     last_run_checksum = last_pipeline_run_checksum(
         pipeline=RCVListPipeline,
@@ -76,7 +76,7 @@ def op_press() -> PipelineResult:
     today = datetime.date.today()
 
     if not _is_session_day(today):
-        raise SkipPipelineError()
+        raise SkipPipeline()
 
     pipeline = PressPipeline(date=today, with_rss=True)
     return pipeline.run()

--- a/backend/howtheyvote/worker/worker.py
+++ b/backend/howtheyvote/worker/worker.py
@@ -42,7 +42,7 @@ PIPELINE_NEXT_RUN = Gauge(
 )
 
 
-class SkipPipelineError(Exception):
+class SkipPipeline(Exception):  # noqa: N818
     pass
 
 
@@ -179,7 +179,7 @@ class Worker:
                 result = handler()
                 status = result.status
                 checksum = result.checksum
-            except SkipPipelineError:
+            except SkipPipeline:
                 # Do not log skipped pipeline runs
                 return
             except Exception:


### PR DESCRIPTION
These are not errors, so they should have no suffix at all. See: https://peps.python.org/pep-0008/#exception-names

Fixes #1077