### PR TITLE
Remove "Featured" indicator in frontend

### DIFF
--- a/frontend/src/components/Tag.css
+++ b/frontend/src/components/Tag.css
@@ -6,9 +6,3 @@
   border-radius: var(--border-radius-sm);
   border: 1px solid var(--gray-light);
 }
-
-.tag--featured {
-  background-color: var(--orange-lightest);
-  color: var(--orange-darker);
-  border-color: var(--orange-light);
-}

--- a/frontend/src/components/Tag.tsx
+++ b/frontend/src/components/Tag.tsx
@@ -1,15 +1,13 @@
 import type { ComponentChildren } from "preact";
-import { bem } from "../lib/bem";
 
 import "./Tag.css";
 
 type TagProps = {
-  style?: "featured";
   children: ComponentChildren;
 };
 
-function Tag({ style, children }: TagProps) {
-  return <span className={bem("tag", style)}>{children}</span>;
+function Tag({ children }: TagProps) {
+  return <span className="tag">{children}</span>;
 }
 
 export default Tag;

--- a/frontend/src/components/VoteCard.tsx
+++ b/frontend/src/components/VoteCard.tsx
@@ -15,7 +15,6 @@ export default function VoteCard({ vote }: VoteCardProps) {
         <a href={`/votes/${vote.id}`}>{vote.display_title}</a>
       </h2>
       <div class="vote-card__meta">
-        {vote.is_featured && <Tag style="featured">Featured</Tag>}
         {vote.geo_areas.length > 0 &&
           vote.geo_areas.map((area) => <Tag key={area.code}>{area.label}</Tag>)}
         {formatDate(new Date(vote.timestamp))}

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -231,14 +231,6 @@ function MethodologySection() {
           </p>
         </Stack>
       </Disclosure>
-      <Disclosure title="What is a featured vote?">
-        <p>
-          HowTheyVote.eu marks a vote as featured when we have found a press
-          release about the vote published by the European Parliament. However,
-          we are not always able to reliably link press releases to votes. In
-          the future, we may use additional indicators for featured votes.
-        </p>
-      </Disclosure>
     </div>
   );
 }


### PR DESCRIPTION
We still use this under the hood, especially to inform the ranking. However, as we got quite a bit of feedback that it is not clear what this actually means, we remove it from the frontend for now.
We briefly discussed whether to rename it to something more telling, but decided against it, as our goal should be to get press releases/additional information for as many votes as possible anyways.