### PR TITLE
Fix press releases procedure extraction

### DIFF
--- a/backend/howtheyvote/scrapers/press_releases.py
+++ b/backend/howtheyvote/scrapers/press_releases.py
@@ -236,7 +236,10 @@ class PressReleaseScraper(BeautifulSoupScraper):
 
         for link in self._links(doc):
             if not link.startswith(
-                "https://oeil.secure.europarl.europa.eu/oeil/popups/ficheprocedure.do"
+                (
+                    "https://oeil.secure.europarl.europa.eu/oeil/popups/ficheprocedure.do",
+                    "https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file",
+                )
             ):
                 continue
 

--- a/backend/tests/scrapers/data/press_releases/press-release_20221014IPR43206.html
+++ b/backend/tests/scrapers/data/press_releases/press-release_20221014IPR43206.html
@@ -1,0 +1,2295 @@
+<!DOCTYPE html>
+<html lang="en">
+
+    
+    <head>
+
+    
+    
+        
+
+    
+
+    <title>
+
+
+Car-recharging stations should be available every 60 km, say MEPs | News | European Parliament</title>
+    <meta property="og:title" content="
+
+
+Car-recharging stations should be available every 60 km, say MEPs | News | European Parliament"/>
+    <meta property="twitter:title" content="
+
+
+Car-recharging stations should be available every 60 km, say MEPs | News | European Parliament"/>
+    <meta itemprop="name" content="
+
+
+Car-recharging stations should be available every 60 km, say MEPs | News | European Parliament"/>
+    <meta name="description" content="To help the EU become climate neutral, MEPs want car-recharging stations every 60 km, hydrogen refuelling stations every 100 km and fewer emissions from ships."/>
+    <meta property="og:description" content="To help the EU become climate neutral, MEPs want car-recharging stations every 60 km, hydrogen refuelling stations every 100 km and fewer emissions from ships."/>
+    <meta property="twitter:description" content="To help the EU become climate neutral, MEPs want car-recharging stations every 60 km, hydrogen refuelling stations every 100 km and fewer emissions from ships."/>
+    <meta itemprop="description" content="To help the EU become climate neutral, MEPs want car-recharging stations every 60 km, hydrogen refuelling stations every 100 km and fewer emissions from ships."/>
+    <meta charset="UTF-8"/>
+
+    
+    <meta name="available" content="19-10-2022"/>
+
+    <meta http-equiv="last-modified" content="2022-10-19 13:14:00.0"/>
+
+    <meta name="language" content="en"/>
+    <meta name="planet" content="news"/>
+    <link rel="canonical" href="https://www.europarl.europa.eu/news/en/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"/>
+    <meta property="og:url" content="https://www.europarl.europa.eu/news/en/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"/>
+    
+        
+        
+            <meta name="robots" content="index, follow, noodp, noydir, notranslate, noarchive"/>
+        
+    
+    <meta property="og:type" content="article"/>
+
+    
+    
+        <meta property="og:image" content="https://www.europarl.europa.eu/resources/library/images/20221017PHT44001/20221017PHT44001_original.jpg"/>
+        <meta property="twitter:image" content="https://www.europarl.europa.eu/resources/library/images/20221017PHT44001/20221017PHT44001_original.jpg"/>
+        <meta itemprop="image" content="https://www.europarl.europa.eu/resources/library/images/20221017PHT44001/20221017PHT44001_original.jpg"/>
+    
+    
+
+
+
+    
+        <meta name="keywords" content="productType:PRESS_RELEASE,com:TRAN,plenaryDate:17-10-2022"/>
+    
+    <meta name="routes" content="productSubType:PLENARY_SESSION"/>
+
+
+    
+    
+
+    
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+
+    <link rel="stylesheet" type="text/css" href="/news/css/header-ep.css"/>
+
+    
+        
+    <link rel="stylesheet" type="text/css" href="/news/css/atomicdesign.css"/>
+    <link rel="stylesheet" type="text/css" href="/news/css/components-ep.css"/>
+    <link rel="stylesheet" type="text/css" href="/news/css/structure.css"/>
+    <noscript>
+        <link rel="stylesheet" type="text/css" href="/news/css/no-js.css" />
+    </noscript>
+
+    
+
+    <noscript>
+        <link rel="stylesheet" type="text/css" href="/news/css/header-ep-nojs.css"/>
+    </noscript>
+    
+
+    <script type="text/javascript" defer data-tracker-name="ATInternet"
+            data-value="/website/webanalytics/ati-news.js"
+            src="/website/privacy-policy/privacy-policy.js"></script>
+
+    
+        <script>
+            /*<![CDATA[*/
+            // AMD define stub: delay handling of define calls until our amd dependency
+            // manager has been loaded (from behaviour.js)
+
+            var __amd$delayedDefines = []
+            function define() {
+                var args = Array.prototype.slice.call(arguments)
+                window.__amd$delayedDefines.push(function () {
+                    window.define.apply(window, args)
+                })
+            }
+            define.amd = {}
+            define('eng-scripts',
+                {
+                    'weekly-agenda-widget': { url: "\/news\/js\/weekly-agenda-widget.js", fetched: false }
+                    , 'weekly-agenda': { url: "\/news\/js\/weekly-agenda.js", fetched: false }
+                    , 'week-selector': { url: "\/news\/js\/week-selector.js", fetched: false }
+                    , 'tst-continuous-loading': { url: "\/news\/js\/tst-continuous-loading.js", fetched: false }
+                    , 'slideshow': { url: "\/news\/js\/slideshow.js", fetched: false }
+                    , 'load-more': { url: "\/news\/js\/load-more.js", fetched: false }
+                    , 'infographic': { url: "\/news\/js\/infographic.js", fetched: false }
+                    , 'filter-form': { url: "\/news\/js\/filter-form.js", fetched: false }
+                    , 'datepicker': { url: "\/news\/js\/datepicker.js", fetched: false }
+                    , 'video-player': { url: "\/news\/js\/video-player.js", fetched: false }
+                    , 'election-results': { url: "\/website\/election-results\/js\/ep_electionresults_app.js", fetched: false }
+                    , 'ec-sml-loader': { url: "\/news\/js\/ec-sml-loader.js", fetched: false }
+                    , 'quiz-loader': { url: "https:\/\/quizweb.europarl.europa.eu\/embed\/js\/ep-ee19-quiz.js", fetched: false }
+                    , 'timeline': { url: "\/news\/js\/timeline.js", fetched: false }
+                }
+            )
+            define( 'global', { document: window.document, window: window } )
+            /*]]>*/
+        </script>
+
+        <script async="async" type="text/javascript" src="/news/js/behaviour.js"></script>
+
+        <script type="text/javascript">
+            define('change-language', [ 'behaviour.js'], function moduleFactory() {
+                Select.updateparams('language-select', {cb_beforesubmit: function() {
+                        window.location.href = document.getElementById('language-select').value;
+                        return false;
+                    }})
+            })
+        </script>
+    
+
+
+    
+    <script defer type="text/javascript" src="/news/js/bundle.js"></script>
+
+
+    
+
+    
+    
+        
+    
+
+    
+    
+        
+    
+
+
+
+</head>
+
+    
+    <body lang="en">
+
+    
+    <input type="hidden" value="https://www.europarl.europa.eu/news/en/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps" id="dev_product_url"/>
+
+    
+    <div id="website">
+
+        
+        
+            
+
+    
+    
+    
+    
+
+    <div id="website-header" class="ep-header">
+        <!-- COMPOSANT "WAI SHORTCUTS" -->
+        <nav class="wai-shortcut" aria-label="Shortcuts">
+            <ul id="waimenu">
+                <li><a href="#website-body"><span class="label">Access to page content (press &quot;Enter&quot;)</span></a></li>
+                <li><a href="#language-select"><span class="label">Direct access to language menu (press &quot;Enter&quot;)</span></a></li>
+                <li><a href="#search-field"><span class="label">Direct access to search menu (press &quot;Enter&quot;)</span></a></li>
+            </ul>
+        </nav>
+
+        <!-- START OF REFACTORING -->
+
+        <!-- COMPOSANT "TOOLBAR" TOP -->
+        <div class="toolbar toolbar_top">
+            <div class="toolbar-grid m-column no-padding-m">
+                <!-- COMPOSANT "LANGUAGE MENU" -->
+                <div class="dropdown-lang" id="language-select">
+                    <!-- Select language no js -->
+                    <noscript>
+                        <div class="dropdown">
+                            <div class="dropdown-lang no-js">
+                                <div class="wrapper-dropdown-lang">
+                                    <form method="get" action="/news/changeLanguage" aria-label="Navigation">
+                                        <div class="select">
+                                            <label for="change_language_nojs" class="sr-only">Change the navigation language</label>
+                                            <select id="change_language_nojs" name="url" required>
+                                                <!-- // TODO : values need to be set by -->
+                                                <option
+                                                        lang="bg"
+                                                        value="/news/bg/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >BG - български</option>
+                                                <option
+                                                        lang="es"
+                                                        value="/news/es/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >ES - español</option>
+                                                <option
+                                                        lang="cs"
+                                                        value="/news/cs/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >CS - čeština</option>
+                                                <option
+                                                        lang="da"
+                                                        value="/news/da/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >DA - dansk</option>
+                                                <option
+                                                        lang="de"
+                                                        value="/news/de/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >DE - Deutsch</option>
+                                                <option
+                                                        lang="et"
+                                                        value="/news/et/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >ET - eesti keel</option>
+                                                <option
+                                                        lang="el"
+                                                        value="/news/el/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >EL - ελληνικά</option>
+                                                <option
+                                                        lang="en"
+                                                        value="/news/en/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >EN - English</option>
+                                                <option
+                                                        lang="fr"
+                                                        value="/news/fr/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >FR - français</option>
+                                                <option
+                                                        lang="ga"
+                                                        value="/news/ga/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >GA - Gaeilge</option>
+                                                <option
+                                                        lang="hr"
+                                                        value="/news/hr/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >HR - hrvatski</option>
+                                                <option
+                                                        lang="it"
+                                                        value="/news/it/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >IT - italiano</option>
+                                                <option
+                                                        lang="lv"
+                                                        value="/news/lv/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >LV - latviešu valoda</option>
+                                                <option
+                                                        lang="lt"
+                                                        value="/news/lt/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >LT - lietuvių kalba</option>
+                                                <option
+                                                        lang="hu"
+                                                        value="/news/hu/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >HU - magyar</option>
+                                                <option
+                                                        lang="mt"
+                                                        value="/news/mt/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >MT - Malti</option>
+                                                <option
+                                                        lang="nl"
+                                                        value="/news/nl/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >NL - Nederlands</option>
+                                                <option
+                                                        lang="pl"
+                                                        value="/news/pl/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >PL - polski</option>
+                                                <option
+                                                        lang="pt"
+                                                        value="/news/pt/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >PT - português</option>
+                                                <option
+                                                        lang="ro"
+                                                        value="/news/ro/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >RO - română</option>
+                                                <option
+                                                        lang="sk"
+                                                        value="/news/sk/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >SK - slovenčina</option>
+                                                <option
+                                                        lang="sl"
+                                                        value="/news/sl/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >SL - slovenščina</option>
+                                                <option
+                                                        lang="fi"
+                                                        value="/news/fi/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >FI - suomi</option>
+                                                <option
+                                                        lang="sv"
+                                                        value="/news/sv/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps"
+                                                >SV - svenska</option>
+                                            </select>
+                                        </div>
+                                        <button type="submit" class="btn">Change the navigation language</button>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </noscript>
+                    <!-- End Select language no js -->
+                    <nav class="custom-select dropdown" aria-label="Change the navigation language">
+                        <button id="dropdown" class="btn lang_select" type="submit" aria-haspopup="true" aria-expanded="false">EN - English</button>
+                        <ul class="no-display menu-content">
+
+                            <li>
+                                <a
+                                   lang="bg"
+                                   hreflang="bg"
+                                   href="/news/bg/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">BG - български</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="es"
+                                   hreflang="es"
+                                   href="/news/es/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">ES - español</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="cs"
+                                   hreflang="cs"
+                                   href="/news/cs/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">CS - čeština</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="da"
+                                   hreflang="da"
+                                   href="/news/da/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">DA - dansk</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="de"
+                                   hreflang="de"
+                                   href="/news/de/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">DE - Deutsch</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="et"
+                                   hreflang="et"
+                                   href="/news/et/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">ET - eesti keel</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="el"
+                                   hreflang="el"
+                                   href="/news/el/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">EL - ελληνικά</span></span>
+                                </a>
+                            </li>
+
+                            <li class="current" aria-current="true">
+                                <a
+                                   lang="en"
+                                   hreflang="en"
+                                   href="/news/en/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">EN - English</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="fr"
+                                   hreflang="fr"
+                                   href="/news/fr/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">FR - français</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="ga"
+                                   hreflang="ga"
+                                   href="/news/ga/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">GA - Gaeilge</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="hr"
+                                   hreflang="hr"
+                                   href="/news/hr/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">HR - hrvatski</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="it"
+                                   hreflang="it"
+                                   href="/news/it/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">IT - italiano</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="lv"
+                                   hreflang="lv"
+                                   href="/news/lv/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">LV - latviešu valoda</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="lt"
+                                   hreflang="lt"
+                                   href="/news/lt/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">LT - lietuvių kalba</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="hu"
+                                   hreflang="hu"
+                                   href="/news/hu/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">HU - magyar</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="mt"
+                                   hreflang="mt"
+                                   href="/news/mt/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">MT - Malti</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="nl"
+                                   hreflang="nl"
+                                   href="/news/nl/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">NL - Nederlands</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="pl"
+                                   hreflang="pl"
+                                   href="/news/pl/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">PL - polski</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="pt"
+                                   hreflang="pt"
+                                   href="/news/pt/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">PT - português</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="ro"
+                                   hreflang="ro"
+                                   href="/news/ro/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">RO - română</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="sk"
+                                   hreflang="sk"
+                                   href="/news/sk/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">SK - slovenčina</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="sl"
+                                   hreflang="sl"
+                                   href="/news/sl/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">SL - slovenščina</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="fi"
+                                   hreflang="fi"
+                                   href="/news/fi/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">FI - suomi</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="sv"
+                                   hreflang="sv"
+                                   href="/news/sv/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps">
+                                    <span class="wrapper-label"><span class="label">SV - svenska</span></span>
+                                </a>
+                            </li>
+                        </ul>
+                    </nav>
+                </div>
+                <!-- COMPOSANT "OTHER TOOLS LINKS" -->
+                <nav class="navigation-menu nav-top" aria-label="Navigation">
+                    <div class="menu-container">
+                        <div class="focusable">
+                            <!--href ?  -->
+                            <a role="button" class="btn-open-menu" aria-haspopup="true" aria-expanded="false" tabindex="0">View other websites</a>
+                            <ul class="menu-level-0" aria-label="View menu: News">
+                                <li class="level-0">
+                                    <a class="" href="/news/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">News</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/topics/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">Topics</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/meps/en/home" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">MEPs</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/about-parliament/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">About Parliament</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/plenary/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">Plenary</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/committees/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">Committees</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0 nopadding-right">
+                                    <a class="" href="/delegations/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">Delegations</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0 nopadding-right">
+                                    <a class="" href="https://elections.europa.eu/en">
+                          <span class="content">
+
+                            <span class="label">Elections</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0 has-menu-dropdown">
+                                    <a role="button" class="icon-arrow-dropdown" id="otherWebsitesLink" aria-haspopup="true" aria-expanded="false" tabindex="0">
+                                      <span class="content">
+                                          <span class="sr-only">View submenu:</span>
+                                          <span class="label">Other websites</span>
+                                      </span>
+                                    </a>
+                                    <ul class="menu-level-1">
+                                        <li class="level-1">
+                                            <a href="https://multimedia.europarl.europa.eu/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Multimedia Centre</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/the-president/en/" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">President’s website</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/the-secretary-general/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Secretariat-general</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/thinktank/en/home.html" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Think tank</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="https://www.epnewshub.eu" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">EP Newshub</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/at-your-service/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">At your service</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/visiting/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Visits</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/legislative-train" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Legislative train</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/contracts-and-grants/en/" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Contracts and Grants</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/RegistreWeb/home/welcome.htm?language=en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Register</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="https://data.europarl.europa.eu/en/home" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Open Data Portal</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="https://liaison-offices.europarl.europa.eu/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Liaison offices</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </div>
+                        <!--<input class="menu-btn" type="checkbox" id="menu-btn-navigationtop" aria-label="Click to open the other websites menu" />
+                        <label class="menu-icon" for="menu-btn-navigationtop">View other websites</label>-->
+                    </div>
+                </nav>
+            </div>
+        </div>
+        <!-- LOGO + TITLE -->
+        <header class="header">
+            <div class="header-wrapper no-padding">
+                <!--<a class="grid" href="https://www.europarl.europa.eu/portal/en">
+                  <span class="sr-only">Go back to the Europarl portal</span>
+                  <img src="../europarl/img/ep-logo.svg" alt="" class="ep_logo" />
+                </a>-->
+                <div class="grid">
+				<span class="title-wrapper">
+					
+					<a href="/news/en" class="title"><span class="labeltxt">News</span></a>
+					<a href="/portal/en" class="subtitle">
+                      <span class="labeltxt">European Parliament</span>
+                      <span class="logo"></span>
+                    </a>
+				</span>
+                </div>
+            </div>
+        </header>
+        <!-- COMPOSANT "TOOLBAR" BOTTOM -->
+        <div class="toolbar toolbar_bottom sticky">
+            <div class="toolbar-grid no-padding flex-end">
+                <!-- COMPOSANT "NAVIGATION MENU" -->
+                <nav class="navigation-menu nav-main" aria-label="Main navigation">
+                    <div class="menu-container">
+                        <!--<input class="menu-btn" type="checkbox" id="menu-btn-navigationmain" aria-label="Click to open the main menu" />
+                        <label class="menu-icon" for="menu-btn-navigationmain"><span class="nav-icon"></span></label>-->
+                        <a role="button" class="menu-icon" tabindex="0">
+                            <span class="label">Menu</span>
+                            <span class="nav-icon"></span>
+                        </a>
+                        <ul class="menu-level-0">
+
+                            <li class="level-0">
+                                <a class="" href="/news/en" aria-haspopup="true">
+                                  <span class="content">
+                                    <span class="label">Homepage</span>
+                                    <span class="current-element"></span>
+                                  </span>
+                                </a>
+                            </li>
+
+                            <li class="level-0 current has-menu-dropdown">
+                                <a role="button" class="icon-arrow-dropdown" aria-current="true" aria-haspopup="true" tabindex="0">
+                                  <span class="content">
+                                    <span class="label">Press room</span>
+                                    <span class="current-element"></span>
+                                  </span>
+                                </a>
+                                <ul class="menu-level-1" aria-label="View submenu">
+                                    
+                                        <li class="level-1">
+                                            <a href="https://www.europarl.europa.eu/news/en/press-room/accreditation">
+                                                <span class="content">
+
+                                                  <span class="label">Accreditation</span>
+                                                </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="https://www.europarl.europa.eu/news/en/press-room/press-tool-kit">
+                                                <span class="content">
+
+                                                  <span class="label">Press Tool Kit</span>
+                                                </span>
+                                            </a>
+                                        </li>
+                                    
+                                    
+
+                                    <li class="level-1">
+                                        <a href="/news/en/press-room/contacts">
+                                            <span class="content">
+
+                                              <span class="label">Contacts</span>
+                                            </span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </li>
+
+
+                            <li class="level-0 has-menu-dropdown">
+                                <a role="button" class="icon-arrow-dropdown" aria-haspopup="true" tabindex="0">
+                                  <span class="content">
+                                    <span class="label">Agenda</span>
+                                    <span class="current-element"></span>
+                                  </span>
+                                </a>
+                                <ul class="menu-level-1" aria-label="View submenu">
+                                    <li class="level-1">
+                                        <a href="/news/en/agenda">
+                                            <span class="content">
+
+                                              <span class="label">Highlights</span>
+                                            </span>
+                                        </a>
+                                    </li>
+                                    <li class="level-1">
+                                        <a href="/news/en/agenda/weekly-agenda">
+                                            <span class="content">
+
+                                              <span class="label">Weekly agenda</span>
+                                            </span>
+                                        </a>
+                                    </li>
+                                    <li class="level-1">
+                                        <a href="/news/en/agenda/briefing">
+                                            <span class="content">
+
+                                              <span class="label">Briefing</span>
+                                            </span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li class="level-0">
+                                <a class="" href="/news/en/faq" aria-haspopup="true">
+                                  <span class="content">
+                                    <span class="label">FAQ</span>
+                                    <span class="current-element"></span>
+                                  </span>
+                                </a>
+                            </li>
+
+                            
+
+                            <li class="level-0 current">
+                                <a href="/news/en/press-room/press-tool-kit">
+                                    <span class="content">
+
+                                      <span class="label">Press Kit</span>
+                                    </span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </nav>
+                
+                    <!-- COMPOSANT "SEARCH MENU" -->
+
+                    <nav class="search-global-form" aria-label="Click to open the search component">
+                        <!-- Add class 'active' to change the style of the <a> -->
+                        <a href="#" class="search-icon" aria-haspopup="true" aria-expanded="false">
+                            <span class="sr-only">Access to search field</span>
+                            <span class="icon"></span>
+                        </a>
+                    </nav>
+                    <!-- Remove class 'posinit' to display the input search -->
+                    <form class="form-field-search" id="search" action="/news/en/search" method="get" role="search" aria-label="Search">
+                        <div class="field-wrapper">
+                            <div class="field">
+                                <input class="ep_field" type="text" id="search-field" name="searchQuery" value="" aria-label="Please fill out this field" title="Please fill out this field" placeholder="Search" required/>
+                                <button class="btn-send active" type="submit" aria-label="Launch the search" disabled>
+                                    <span class="sr-only">Launch the search</span>
+                                    <span class="icon">&nbsp;</span>
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                    <!-- TITLE ON SCROLL -->
+                    <span class="title-toolbar" aria-hidden="true"><span class="label">European Parliament</span></span>
+                
+            </div>
+
+        </div>
+        <!-- COMPOSANT "BREADCRUMB" -->
+        <nav id="website-breadcrumb" class="ep_breadcrumb" aria-label="You are here:">
+    <div class="ep_fulllist">
+        <span class="ep_mandatory">
+            
+    
+        <a class="ep_item" href="/news/en/press-room">
+            <span class="ep_hidden">Go back to page : Press room</span>
+            <span class="ep_name">Press room</span>
+            <span class="ep_icon">&nbsp;</span></a>
+        <span class="ep_separator"></span>
+    
+    
+
+        </span>
+
+        
+    <span class="ep_mandatory" aria-current="page">
+        <span class="ep_item">
+            <span class="ep_hidden">Current page:</span>
+            <span class="ep_name">
+
+
+Car-recharging stations should be available every 60 km, say MEPs</span>
+            <span class="ep_icon">&nbsp;</span>
+        </span>
+    </span>
+
+    </div>
+    <div class="ep_previouslink">
+        
+    
+        <a class="ep_item" href="/news/en/press-room">
+            <span class="ep_hidden">Go back to page : Press room</span>
+            <span class="ep_name">Press room</span>
+            <span class="ep_icon">&nbsp;</span></a>
+        <span class="ep_separator"></span>
+    
+    
+
+    </div>
+</nav>
+    </div>
+    <!-- END OF REFACTORING -->
+
+        
+        
+
+        
+        <article id="website-body" role="main">
+
+    
+    
+    
+        
+            <input type="hidden" id="webanalytic-id_chapters" value="press-room"/>
+        
+            <input type="hidden" id="webanalytic-id_sub-chapters" value="pressroom"/>
+        
+            <input type="hidden" id="webanalytic-id_sub-sub-chapters" value="regions-and-transport~transport"/>
+        
+            <input type="hidden" id="webanalytic-id_pages" value="alternative-fuels"/>
+        
+            <input type="hidden" id="webanalytic-id_type" value=""/>
+        
+            <input type="hidden" id="webanalytic-ep_bodies" value="plenary~17.10.2022~20.10.2022/committees~tran"/>
+        
+            <input type="hidden" id="webanalytics-topics_by_weeks" value=""/>
+        
+            <input type="hidden" id="webanalytics-priority_category" value=""/>
+        
+            <input type="hidden" id="webanalytics-priority_wordlink" value=""/>
+        
+            <input type="hidden" id="webanalytics-reference" value=""/>
+        
+            <input type="hidden" id="webanalytics-language" value=""/>
+        
+    
+
+
+    
+    <div class="ep_gridrow ep-o_product">
+        <div class="ep_gridrow-content">
+            <div class="ep_gridcolumn" data-view1200="2" data-view1020="2" data-view750="1" data-view640="1" data-view480="0" data-view320="0">
+                <div class="ep_gridcolumn-content">&nbsp;</div>
+            </div>
+            <div class="ep_gridcolumn ep-m_header" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                <div class="ep_gridcolumn-content">
+                    <div class="ep-a_heading ep-layout_level1">
+                        <h1 class="ep_title">
+                            <div class="ep-p_text"><span class="ep_name">
+
+
+Car-recharging stations should be available every 60 km, say MEPs</span><span class="ep_icon">&nbsp;</span></div>
+                        </h1>
+                        <div class="ep_subtitle">
+
+                            <div class="ep-p_text ep-layout_category"><span class="ep_name">Press Releases</span><span class="ep_icon">&nbsp;</span></div>
+
+                            
+
+                            
+
+    
+        <div class="ep-p_text ep-layout_contenttype ep-layout_plenary">
+            <a href="/news/en?contentType=plenary" >
+                <span class="ep_name">Plenary session</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+        
+    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
+        <a href="/news/en?contentType=committee&amp;keywordValue=TRAN" >
+            <span class="ep_name"><abbr title="Transport and Tourism">TRAN</abbr></span><span class="ep_icon">&nbsp;</span>
+        </a>
+    </div>
+
+    
+
+    
+
+
+
+                            
+    
+        
+        
+            
+    <div class="ep-p_text ep-layout_date">
+        <span class="ep_name">
+            
+    
+    
+        <time itemprop="datePublished"
+              datetime="2022-10-19T13:14:00">19-10-2022 - 13:14</time>
+    
+
+        </span><span class="ep_icon">&nbsp;</span>
+    </div>
+
+        
+
+    
+
+    
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    
+    <div class="ep_gridrow ep-o_product">
+        <div class="ep_gridrow-content">
+            <div class="ep_gridcolumn" data-view1200="1" data-view1020="1" data-view750="0" data-view640="0" data-view480="0" data-view320="0">
+                <div class="ep_gridcolumn-content">&nbsp;</div>
+            </div>
+
+            
+            
+                
+
+    <div class="ep_gridcolumn ep-m_product ep-layout_followingscroll" data-view1200="1" data-view1020="1" data-view750="1" data-view640="1" data-view480="0" data-view320="0">
+        <div class="ep_gridcolumn-content">
+            <div class="ep-a_share ep-layout_socialnetwok">
+                <div>
+                    
+
+    <div class="ep_share">
+        <h2 class="ep_title">
+            <div class="ep-p_text"><span class="ep_name">Share this page:</span><span class="ep_icon">&nbsp;</span></div>
+        </h2>
+        <ul>
+            <li>
+                <div class="ep-p_text ep-layout_facebook">
+                    <a href="https://www.facebook.com/share.php?u=https://www.europarl.europa.eu/news/en/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Bfacebook%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Balternative-fuels%5D-" title="Share this page on Facebook" target="_blank" ><span class="ep_name">Facebook</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+            <li>
+                <div class="ep-p_text ep-layout_twitter">
+                    <a href="https://twitter.com/intent/tweet?text=%0A%0A%0ACar-recharging%20stations%20should%20be%20available%20every%2060%20km,%20say%20MEPs&amp;url=https://www.europarl.europa.eu/news/en/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Btwitter%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Balternative-fuels%5D-&amp;via=Europarl_EN" title="Share this page on Twitter" target="_blank"><span class="ep_name">Twitter</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+            <li>
+                <div class="ep-p_text ep-layout_linkedin">
+                    <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https://www.europarl.europa.eu/news/en/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Blinkedin%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Balternative-fuels%5D%26&amp;title=European%20Parliament&amp;summary=&amp;source=" title="Share this page on LinkedIn" target="_blank" ><span class="ep_name">LinkedIn</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+
+            <li>
+                <div class="ep-p_text ep-layout_whatsapp">
+                    <a href="https://api.whatsapp.com/send?text=https://www.europarl.europa.eu/news/en/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Bwhatsapp%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Balternative-fuels%5D%26" title="Share this page on WhatsApp" target="_blank"><span class="ep_name">WhatsApp</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+        </ul>
+    </div>
+
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+            
+
+            
+            <div class="ep_gridcolumn" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                <div class="ep_gridrow">
+                    <div class="ep_gridrow-content">
+
+                        
+                        
+                        
+
+    
+        
+            
+            
+            
+            
+            
+                
+
+    <!-- Fact list -->
+    <div class="ep_gridcolumn ep-m_product" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content">
+            <div class="ep-a_facts">
+                <div>
+                    
+                    <ul class="ep_list">
+                        
+                            
+    <li><div class="ep-p_text"><span class="ep_name">Faster roll-out of recharging stations needed on main EU roads</span><span class="ep_icon">&nbsp;</span></div></li>
+
+                        
+                            
+    <li><div class="ep-p_text"><span class="ep_name">Easy to use and affordable recharging/refuelling</span><span class="ep_icon">&nbsp;</span></div></li>
+
+                        
+                            
+    <li><div class="ep-p_text"><span class="ep_name">Fewer emissions in the maritime sector</span><span class="ep_icon">&nbsp;</span></div></li>
+
+                        
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+        
+            
+            
+            
+            
+            
+            
+            
+            
+                
+                    
+
+      
+        
+
+    <div class="ep_gridcolumn ep-m_product" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content">
+            
+    <div class="ep-a_media">
+        <figure>
+            <div class="ep_media ep-layout_image">
+                <div class="ep-p_image ep-layout_original">
+                    
+                    
+                        <a href="https://www.europarl.europa.eu/resources/library/images/20221017PHT44001/20221017PHT44001_original.jpg" title="Open in a new window" target="_blank">
+                            
+    <div class="ep_image">
+        
+        
+             <img src="https://www.europarl.europa.eu/resources/library/images/20221017PHT44001/20221017PHT44001-cl.jpg" alt="MEPs want car-recharging stations every 60 km © Tapui / Adobe Stock"/>
+        
+
+<span class="ep_small" style="background-image:url(https://www.europarl.europa.eu/resources/library/images/20221017PHT44001/20221017PHT44001-cs.jpg);">&nbsp;</span>
+<span class="ep_medium" style="background-image:url(https://www.europarl.europa.eu/resources/library/images/20221017PHT44001/20221017PHT44001-cm.jpg);">&nbsp;</span>
+<span class="ep_large" style="background-image:url(https://www.europarl.europa.eu/resources/library/images/20221017PHT44001/20221017PHT44001-cl.jpg);">&nbsp;</span>
+<span class="ep_icon">&nbsp;</span>
+</div>
+
+                        </a>
+                    
+                </div>
+            </div>
+
+            <figcaption class="ep_text">
+                <div class="ep-p_text ep-layout_legend">
+                    <span class="ep_name">MEPs want car-recharging stations every 60 km © Tapui / Adobe Stock</span>
+                    <span class="ep_icon">&nbsp;</span>
+                </div>
+            </figcaption>
+
+        </figure>
+    </div>
+
+        </div>
+    </div>
+
+
+    
+
+
+                
+                
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+        
+            
+            
+                
+
+    <div class="ep_gridcolumn ep-m_product" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content">
+            <div class="ep-a_text ep-layout_chapo">
+                <p>To help the EU become climate neutral, MEPs want car-recharging stations every 60 km, hydrogen refuelling stations every 100 km and fewer emissions from ships.</p>
+            </div>
+        </div>
+    </div>
+
+
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+        
+            
+            
+            
+            
+                
+
+    <!-- Text content -->
+    <div class="ep_gridcolumn ep-m_product" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content" >
+            <div class="ep-a_text"><p class="ep-wysiwig_paragraph">On Wednesday, Parliament adopted its position on draft EU rules aimed at spurring the deployment of recharging and alternative refuelling stations (such as electric or hydrogen) for cars, trucks, trains and planes and supporting the uptake of sustainable vehicles. The new rules are part of the <a href="https://ec.europa.eu/commission/presscorner/detail/en/IP_21_3541" target="_blank" rel="noopener">“Fit for 55 in 2030 package”</a>, the EU’s plan to reduce greenhouse gas emissions by at least 55% by 2030 compared to 1990 levels.</p>
+<br />
+<p class="ep-wysiwig_paragraph"><strong>More recharging/refuelling stations</strong></p>
+<p class="ep-wysiwig_paragraph"></p>
+<p class="ep-wysiwig_paragraph">MEPs agreed to set minimum mandatory national targets for the deployment of alternative fuels infrastructure. Member states will have to present their plan by 2024 on how to achieve it.</p>
+<br />
+<p class="ep-wysiwig_paragraph">According to the adopted text, by 2026 there should be at least one electric charging pool for cars every 60 km along <a href="https://ec.europa.eu/transport/infrastructure/tentec/tentec-portal/site/maps_upload/tent_modes/EU_A0Landscape2019_roads.png" target="_blank" rel="noopener">main EU roads</a>. The same requirement would apply for trucks and buses, but only on <a href="https://ec.europa.eu/transport/infrastructure/tentec/tentec-portal/site/maps_upload/SchematicA0_EUcorridor_map.pdf" target="_blank" rel="noopener">core TEN-T networks</a> and with more powerful stations. There will be some exemptions for outermost regions, islands and roads with very little traffic.</p>
+<br />
+<p class="ep-wysiwig_paragraph">MEPs also suggest setting up more hydrogen refuelling stations along main EU roads (every 100 km as opposed to every 150 km, as proposed by the Commission) and to do it faster (by 2028 instead of by 2031).</p>
+<br />
+<p class="ep-wysiwig_paragraph"><strong>Simple recharging</strong></p>
+<p class="ep-wysiwig_paragraph"></p>
+<p class="ep-wysiwig_paragraph">Alternative refuelling stations should be accessible to all vehicle brands and payment should be easy. They should display the price per kWh or per kg and it should be affordable and comparable. MEPs also want an EU access point for alternative fuels data to be set up by 2027 to provide information on the availability, waiting times and prices at different stations across Europe.</p>
+<br />
+<p class="ep-wysiwig_paragraph"><strong>Sustainable maritime fuels</strong></p>
+<p class="ep-wysiwig_paragraph"></p>
+<p class="ep-wysiwig_paragraph">MEPs also adopted their position on draft EU rules on the use of renewable and low-carbon fuels in maritime transport. Parliament wants the maritime sector to cut greenhouse gas (GHG) emissions from ships by 2% as of 2025, 20% as of 2035 and 80% as of 2050 compared to 2020 level (the Commission proposed a 13% and 75% reduction).</p>
+<br />
+<p class="ep-wysiwig_paragraph">This would apply for ships above a gross tonnage of 5000, in principle responsible for 90% of CO2 emissions, to all energy used on board in or between EU ports, and to 50% of energy used on voyages where the departure or arrival port is outside of the EU or in its outermost regions.</p>
+<br />
+<p class="ep-wysiwig_paragraph">MEPs also set a target of 2% of renewable fuels usage and mandated containerships and passenger ships to use on-shore power supply while at berth at main EU ports as of 2030. This would significantly reduce air pollution in ports.</p>
+<br />
+<p class="ep-wysiwig_paragraph">To ensure compliance, MEPs favour the introduction of penalties. Revenues generated from these should go to the Ocean Fund and contribute to decarbonising the maritime sector, energy efficiency and zero-emission propulsion technologies.</p>
+<br />
+<p class="ep-wysiwig_paragraph"><strong>Quotes </strong></p>
+<p class="ep-wysiwig_paragraph"></p>
+<p class="ep-wysiwig_paragraph">EP rapporteur on alternative fuels infrastructure <a href="https://www.europarl.europa.eu/meps/en/96842/ISMAIL_ERTUG/home" target="_blank" rel="noopener">Ismail Ertug (S&amp;D, DE)</a> said: “At the moment we have 377 000 charging stations in the EU, but this is half the amount that should have been achieved had EU countries lived up to their promises. We need to tackle this decarbonisation bottleneck and quickly roll out the alternative fuels infrastructure to save the Green Deal.”</p>
+<p class="ep-wysiwig_paragraph"></p>
+<p class="ep-wysiwig_paragraph"></p>
+<p class="ep-wysiwig_paragraph">EP rapporteur on sustainable maritime fuels <a href="https://www.europarl.europa.eu/meps/en/197405/JORGEN_WARBORN/home" target="_blank" rel="noopener">Jörgen Warborn (EPP, SE)</a> stressed: “This is by far the world’s most ambitious pathway to maritime decarbonisation. Parliament's position ensures that our climate targets will be met rapidly and effectively, safeguarding the maritime sector's competitiveness and ensuring there won’t be carbon leakage or jobs leaving Europe.”</p>
+<br />
+<p class="ep-wysiwig_paragraph"><strong>Next steps</strong></p>
+<br />
+<p class="ep-wysiwig_paragraph">The negotiating mandate on the deployment of alternative fuels infrastructure was adopted by 485 votes to 65 and 80 abstentions and on sustainable maritime fuels by 451 votes to 137 and 54 abstentions. Parliament is now ready to start negotiations with member states.</p>
+<p class="ep-wysiwig_paragraph"><br /><br /></p></div>
+        </div>
+    </div>
+
+
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+        
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+
+
+
+
+                        
+                        
+
+    <!-- Contact -->
+    
+    <div class="ep_gridcolumn ep-m_product" role="region" aria-labelledby="asideregion931406" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content">
+            <div class="ep-a_contacts">
+                <h2 class="ep_title" id="asideregion931406">
+                    <div class="ep-p_text"><span class="ep_name">Contacts:</span><span class="ep_icon">&nbsp;</span></div>
+                </h2>
+                <ul>
+                    
+                        <li class="ep_item">
+                            <div class="ep_card">
+                                <h3 class="ep_name">
+                                    <span class="ep-p_text"><span class="ep_name">Gediminas VILKAS</span><span class="ep_icon">&nbsp;</span></span>
+                                </h3>
+                                
+                                
+                                    <div class="ep_information">
+                                        <span class="ep-p_text"><span class="ep_name">Press Officer</span><span class="ep_icon">&nbsp;</span></span>
+                                    </div>
+                                
+                                <div class="ep_data">
+                                    <div class="ep-p_text ep_hidden"><span class="ep_name">Contact data:</span><span class="ep_icon">&nbsp;</span></div>
+                                    <ul>
+                                        
+                                            
+                                                
+                                                    <li class="ep_phone">
+                                                        <a href="tel:(+32) 2 28 33592" class="ep-p_text"><span class="ep_name" title="Phone number"><span class="ep_hidden">Phone number: </span>(+32) 2 28 33592<abbr class="ep_location" title="Brussels"> (BXL)</abbr></span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_portable">
+                                                        <a href="tel:(+32) 470 89 29 21" class="ep-p_text"><span class="ep_name" title="Mobile number"><span class="ep_hidden">Mobile number: </span>(+32) 470 89 29 21</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_mail">
+                                                        <a href="mailto:gediminas.vilkas@europarl.europa.eu" class="ep-p_text" title="E-mail: gediminas.vilkas@europarl.europa.eu"><span class="ep_name"><span class="ep_hidden">E-mail:  </span>gediminas.vilkas@europarl.europa.eu</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_mail">
+                                                        <a href="mailto:tran-press@europarl.europa.eu" class="ep-p_text" title="E-mail: tran-press@europarl.europa.eu"><span class="ep_name"><span class="ep_hidden">E-mail:  </span>tran-press@europarl.europa.eu</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_twitter">
+                                                        <a href="http://twitter.com/EP_Transport " class="ep-p_text" title="Open a Twitter account in a new window" target="_blank"><span class="ep_name"><span class="ep_hidden">Twitter account: </span>@EP_Transport </span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                            
+                                        
+                                    </ul>
+                                </div>
+                            </div>
+                            
+                        </li>
+                    
+                </ul>
+            </div>
+        </div>
+    </div>
+
+
+
+                    </div>
+                </div>
+            </div>
+            <!-- ADDITIONAL LINKS COLUMN -->
+            <section class="ep_gridcolumn ep-layout_followingscroll" data-view1200="3" data-view1020="3" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
+                <div class="ep_gridrow">
+                    <div class="ep_gridrow-content">
+                        <div class="ep_gridcolumn" data-view1200="0" data-view1020="0" data-view750="1" data-view640="1" data-view480="0" data-view320="0">
+                            <div class="ep_gridcolumn-content">&nbsp;</div>
+                        </div>
+                        <div class="ep_gridcolumn" data-view1200="3" data-view1020="3" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                            <div class="ep_gridrow">
+                                <div class="ep_gridrow-content">
+
+                                    
+                                    
+
+                                    
+                                    
+                                        
+                                            
+                                        
+                                    
+                                        
+                                            
+                                        
+                                    
+                                        
+                                            
+                                        
+                                    
+                                        
+                                            
+                                        
+                                    
+                                        
+                                            
+                                                
+    <!-- List of links -->
+    <div class="ep_gridcolumn ep-m_product" data-layout1200="border" data-layout1020="border" data-view1200="3" data-view1020="3" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        
+    <div class="ep_gridcolumn-content">
+        <div class="ep-a_links">
+            <h2 class="ep_title">
+                <div class="ep-p_text"><span class="ep_name">Further information</span><span class="ep_icon">&nbsp;</span></div>
+            </h2>
+            <ul class="ep_list">
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" href="/doceo/document/A-9-2022-0234_EN.html
+"><span class="ep_name">
+
+
+Draft report on alternative fuels infrastructure
+
+</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" href="/doceo/document/A-9-2022-0233_EN.html"><span class="ep_name">Draft report on sustainable maritime fuels
+</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" href="/plenary/en/debate-details.html?date=20221017&amp;detailBy=date"><span class="ep_name">
+
+
+
+
+
+Video of the debate (17.10.2022)
+
+</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" target="_blank" href="https://multimedia.europarl.europa.eu/en/webstreaming/press-conference-by-ismail-ertug-and-jorgen-warborn-rapporteurs-on-alternative-fuels-infrastructure_20221019-1500-SPECIAL-PRESSER"><span class="ep_name">
+
+
+
+
+
+Live webstreaming of the press conference (19.10.2022)
+
+</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_pdf">
+            <a title="Read the PDF document" target="_blank" href="/RegData/etudes/ATAG/2022/733688/EPRS_ATA(2022)733688_EN.pdf">
+                <span class="ep_name">
+
+
+
+
+
+
+
+
+EP Research Service brief on alternative fuels infrastructure (October 2022)
+
+ </span>
+                <span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+
+            
+
+            
+
+            
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" href="/RegData/etudes/ATAG/2022/733689/EPRS_ATA(2022)733689_EN.pdf
+"><span class="ep_name">
+
+
+
+
+
+EP Research Service brief on sustainable maritime fuels (October 2022)
+
+</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" target="_blank" href="https://oeil.secure.europarl.europa.eu/oeil/popups/ficheprocedure.do?reference=2021/0223(COD)&amp;l=en"><span class="ep_name">
+
+
+
+
+
+Procedure file on alternative fuels infrastructure (AFIR)
+
+</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" target="_blank" href="https://oeil.secure.europarl.europa.eu/oeil/popups/ficheprocedure.do?reference=2021/0210(COD)&amp;l=en"><span class="ep_name">
+
+
+
+
+
+Procedure file on sustainable maritime fuels (FuelEU Maritime)
+
+</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" href="/committees/en/tran/home.html"><span class="ep_name">Committee on Transport and Tourism</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+            </ul>
+        </div>
+    </div>
+
+    </div>
+
+                                            
+                                        
+                                    
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Product reference -->
+            <div class="ep_gridcolumn" data-view1200="12" data-view1020="12" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
+                <div class="ep_gridrow">
+                    <div class="ep_gridrow-content">
+                        <div class="ep_gridcolumn" data-view1200="2" data-view1020="2" data-view750="1" data-view640="1" data-view480="0" data-view320="0">
+                            <div class="ep_gridcolumn-content">&nbsp;</div>
+                        </div>
+                        <div class="ep_gridcolumn" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                            <div class="ep_gridrow">
+                                <div class="ep_gridrow-content">
+                                    <div class="ep_gridcolumn ep-m_footer" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                                        <div class="ep_gridcolumn-content">
+                                            <h2 class="ep-a_heading ep_hidden">
+                                                <div class="ep_title">
+                                                    <div class="ep-p_text"><span class="ep_name">Product information</span><span class="ep_icon">&nbsp;</span></div>
+                                                </div>
+                                            </h2>
+                                            <div class="ep-a_reference">
+                                                <div class="ep_reference">
+                                                    <span class="ep-p_text"><span class="ep_name"><abbr title="Product reference">Ref.:</abbr></span><span class="ep_icon">&nbsp;</span></span>
+                                                    <span class="ep-p_text"><span class="ep_name">20221014IPR43206</span><span class="ep_icon">&nbsp;</span></span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+    
+    
+        
+
+    <div class="ep_gridrow ep-o_footerpage">
+        <div class="ep_gridrow-content">
+            <div class="ep_gridcolumn ep-m_product" data-view1200="12" data-view1020="12" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
+                <div class="ep_gridcolumn-content">
+                    <div class="ep-a_share">
+                        <div>
+                            
+
+    <div class="ep_share">
+        <h2 class="ep_title">
+            <div class="ep-p_text"><span class="ep_name">Share this page:</span><span class="ep_icon">&nbsp;</span></div>
+        </h2>
+        <ul>
+            <li>
+                <div class="ep-p_text ep-layout_facebook">
+                    <a href="https://www.facebook.com/share.php?u=https://www.europarl.europa.eu/news/en/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Bfacebook%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Balternative-fuels%5D-" title="Share this page on Facebook" target="_blank" ><span class="ep_name">Facebook</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+            <li>
+                <div class="ep-p_text ep-layout_twitter">
+                    <a href="https://twitter.com/intent/tweet?text=%0A%0A%0ACar-recharging%20stations%20should%20be%20available%20every%2060%20km,%20say%20MEPs&amp;url=https://www.europarl.europa.eu/news/en/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Btwitter%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Balternative-fuels%5D-&amp;via=Europarl_EN" title="Share this page on Twitter" target="_blank"><span class="ep_name">Twitter</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+            <li>
+                <div class="ep-p_text ep-layout_linkedin">
+                    <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https://www.europarl.europa.eu/news/en/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Blinkedin%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Balternative-fuels%5D%26&amp;title=European%20Parliament&amp;summary=&amp;source=" title="Share this page on LinkedIn" target="_blank" ><span class="ep_name">LinkedIn</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+
+            <li>
+                <div class="ep-p_text ep-layout_whatsapp">
+                    <a href="https://api.whatsapp.com/send?text=https://www.europarl.europa.eu/news/en/press-room/20221014IPR43206/car-recharging-stations-should-be-available-every-60-km-say-meps?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Bwhatsapp%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Balternative-fuels%5D%26" title="Share this page on WhatsApp" target="_blank"><span class="ep_name">WhatsApp</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+        </ul>
+    </div>
+
+
+                            <div class="ep_links">
+                                <div class="ep-p_text ep-layout_mail"><a href="/subscription/en"><span class="ep_name">Sign up for mail updates</span></a></div>
+
+                                
+                                <div class="ep-p_text ep-layout_pdf"><a href="/pdfs/news/expert/2022/10/press_release/20221014IPR43206/20221014IPR43206_en.pdf"><span class="ep_name">PDF version</span><span class="ep_icon">&nbsp;</span></a></div>
+
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+    
+
+
+</article>
+
+        
+        
+            
+
+    <footer id="website-footer" role="contentinfo">
+        
+        <div class="ep_footer-relatedlinks">
+            <div class="ep_websitelinks" id="website-links">
+                <h2 class="ep_title" id="website-links-title">
+                    <span class="ep_name">News</span>
+                    <span class="ep_icon">&nbsp;</span>
+                </h2>
+                <div class="ep_menu-access ep_openaccess" id="website-links-access" aria-controls="website-links-content" role="tab">
+                    <a href="#website-links">
+                        <span class="ep_name">View menu: News</span>
+                        <span class="ep_icon">&nbsp;</span></a>
+                </div>
+                <div class="ep_list ep-layout_category" id="website-links-content">
+                    <div>
+                        <div class="ep_category">
+                            <h3 class="ep_subtitle" id="website-links-category1-title">
+                                <span class="ep_name">Parliament in your country</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </h3>
+                            
+                                <ul aria-labelledby="website-links-category1-title">
+                                    
+                                        <li class="ep_item">
+                                            <a href="/unitedkingdom" class="ep_button" target="_blank" >
+                                                <span class="ep_hidden">Open in a new page</span>
+                                                <span class="ep_name">London</span>
+                                            </a>
+                                        </li>
+                                    
+                                        <li class="ep_item">
+                                            <a href="/ireland" class="ep_button" target="_blank" >
+                                                <span class="ep_hidden">Open in a new page</span>
+                                                <span class="ep_name">Dublin</span>
+                                            </a>
+                                        </li>
+                                    
+                                        <li class="ep_item">
+                                            <a href="/malta" class="ep_button" target="_blank" >
+                                                <span class="ep_hidden">Open in a new page</span>
+                                                <span class="ep_name">Valletta</span>
+                                            </a>
+                                        </li>
+                                    
+                                        <li class="ep_item">
+                                            <a href="/unitedstates" class="ep_button" target="_blank" >
+                                                <span class="ep_hidden">Open in a new page</span>
+                                                <span class="ep_name">Washington</span>
+                                            </a>
+                                        </li>
+                                    
+                                </ul>
+                            
+                        </div>
+                        <div class="ep_category">
+                            <h3 class="ep_subtitle" id="website-links-category2-title">
+                                <span class="ep_name">Tools</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </h3>
+                            <ul aria-labelledby="website-links-category2-title">
+                                <li class="ep_item">
+                                    <a href="/oeil/home/home.do" class="ep_button">
+                                        <span class="ep_hidden">Open in a new page</span>
+                                        <span class="ep_name">Legislative Observatory</span>
+                                    </a>
+                                </li>
+                                <li class="ep_item">
+                                    <a href="https://multimedia.europarl.europa.eu/en" class="ep_button" target="_blank" >
+                                        <span class="ep_hidden">Open in a new page</span>
+                                        <span class="ep_name">Multimedia Centre</span>
+                                    </a>
+                                </li>
+                                <li class="ep_item">
+                                    <a href="https://ec.europa.eu/avservices/ebs/schedule.cfm?sitelang=en"  class="ep_button" target="_blank" >
+                                        <span class="ep_hidden">Open in a new page</span>
+                                        <span class="ep_name">EbS</span>
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="ep_category">
+                            <h3 class="ep_subtitle" id="website-links-category3-title">
+                                <span class="ep_name">The President of the European Parliament</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </h3>
+                            <ul aria-labelledby="website-links-category3-title">
+                                <li class="ep_item">
+                                    <a href="/the-president/en/" class="ep_button">
+                                        <span class="ep_hidden">Open in a new page</span>
+                                        <span class="ep_name">European Parliament President’s website</span>
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="ep_menu-access ep_closeaccess">
+                    <a href="#website-links-access" title="Hide menu">
+                        <span class="ep_name">Hide menu: News</span>
+                        <span class="ep_icon">&nbsp;</span>
+                    </a>
+                </div>
+            </div>
+            <div class="ep_europarllinks" id="europarl-links">
+                <h2 class="ep_title" id="europarl-links-title">
+                    <span class="ep_name">European Parliament</span>
+                    <span class="ep_icon">&nbsp;</span>
+                </h2>
+                <div class="ep_menu-access ep_openaccess" id="europarl-links-access" aria-controls="europarl-links-content" role="tab">
+                    <a href="#europarl-links" >
+                        <span class="ep_name">View menu: European Parliament</span>
+                        <span class="ep_icon">&nbsp;</span>
+                    </a>
+                </div>
+                <div class="ep_list">
+                    <ul id="europarl-links-content" aria-labelledby="europarl-links-title">
+                        <li class="ep_item">
+                            <a class="ep_button" href="/news/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">News</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/topics/en" >
+                                <span class="ep_name">Topics</span><span class="icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/meps/en/home" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">MEPs</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/about-parliament/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">About Parliament</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/plenary/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">Plenary</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/committees/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">Committees</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/delegations/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">Delegations</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="https://elections.europa.eu/en" >
+                                <span class="ep_name">Elections</span><span class="icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                    </ul>
+                </div>
+                <div class="ep_menu-access ep_closeaccess">
+                    <a href="#europarl-links-access" title="Hide menu"><span class="ep_name">Hide menu: European Parliament</span><span class="ep_icon">&nbsp;</span></a></div>
+            </div>
+        </div>
+        <span class="ep_footer-separator">&nbsp;</span>
+        <div class="ep_footer-otherlinks">
+            
+            <div class="ep_sociallinks" id="socialmedia">
+                <h2 class="ep_hidden" id="socialmedia-title">
+                    <span class="ep_name">The Parliament on social media</span>
+                    <span class="ep_icon">&nbsp;</span>
+                </h2>
+                <div class="ep_list">
+                    <ul aria-labelledby="socialmedia-title">
+                        <li class="ep_item">
+                            <a href="https://www.facebook.com/europeanparliament"  class="ep_button ep_facebook" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Facebook</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://twitter.com/Europarl_en" class="ep_button ep_twitter" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Twitter</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.flickr.com/photos/european_parliament/" class="ep_button ep_flickr"	target="_blank" >
+                                <span class="ep_name">Check out Parliament on Flickr</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.linkedin.com/company/european-parliament" class="ep_button ep_linkedin" target="_blank" >
+                                <span class="ep_name">Check out Parliament on LinkedIn</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.youtube.com/user/EuropeanParliament" class="ep_button ep_youtube" target="_blank" >
+                                <span class="ep_name">Check out Parliament on YouTube</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://instagram.com/europeanparliament" class="ep_button ep_instagram" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Instagram</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.pinterest.com/epinfographics/" class="ep_button ep_pinterest" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Pinterest</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.snapchat.com/add/europarl" class="ep_button ep_snapchat" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Snapchat</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.reddit.com/r/europeanparliament/" class="ep_button ep_reddit" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Reddit</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <!-- COMPOSANT "MANDATORY LINKS" -->
+            <div class="ep_mandatorylinks" id="informationlinks">
+                <h2 class="ep_hidden" id="informationlinks-title"><span class="ep_name">Information links</span><span class="ep_icon">&nbsp;</span></h2>
+                <div class="ep_list">
+                    <ul aria-labelledby="informationlinks-title">
+                        <li class="ep_item"><a href="/portal/en/contact"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Contact</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/at-your-service/en/stay-informed/rss-feeds"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">RSS</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/portal/en/sitemap"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Sitemap</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/legal-notice/en"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Legal notice</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/privacy-policy/en/"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Privacy policy</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/portal/en/accessibility"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Accessibility</span><span class="ep_icon">&nbsp;</span></a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+
+        
+    </div>
+
+    <!-- Backdrop / Gray Overlay for compact menu opening-->
+    <div class="back-overlay"></div>
+
+    
+    
+
+    
+    
+        <script>
+            (function rewriteUrlIfNeeded() {
+                function getHash(url) {
+                    return url.hash !== '' && document.getElementById(url.hash.slice(1)) ?
+                        url.hash :
+                        '';
+                }
+
+                function rewriteUrl(currentUrl, baseUrl) {
+                    // ensure that hash is present only if it actually exists
+                    const url = new URL(currentUrl);
+                    return `${baseUrl}${url.search}${getHash(url)}`;
+                }
+
+                // pre-condition: #dev_product_url ALWAYS exists see <input ...> above.
+                const productUrl = document.getElementById('dev_product_url').value;
+
+                if (productUrl === '') {
+                    return;
+                }
+
+                const newUrl = rewriteUrl(window.location.href, productUrl);
+
+                if (newUrl !== window.location.href) {
+                    window.history.replaceState(null, '', newUrl)
+                }
+            }())
+        </script>
+    
+
+        <script type="text/javascript">
+            // safari blinking workaround. Cf jira ENG-32999 & ENG-33001
+        </script>
+    </body>
+
+</html>

--- a/backend/tests/scrapers/data/press_releases/press-release_20241212IPR25960.html
+++ b/backend/tests/scrapers/data/press_releases/press-release_20241212IPR25960.html
@@ -1,0 +1,2325 @@
+<!DOCTYPE html>
+<html lang="en">
+
+    
+    <head>
+
+    
+    
+        
+
+    
+
+    <title>EP paves way for the use of EU funds to finance natural disaster recovery | News | European Parliament</title>
+    <meta property="og:title" content="EP paves way for the use of EU funds to finance natural disaster recovery | News | European Parliament"/>
+    <meta property="twitter:title" content="EP paves way for the use of EU funds to finance natural disaster recovery | News | European Parliament"/>
+    <meta itemprop="name" content="EP paves way for the use of EU funds to finance natural disaster recovery | News | European Parliament"/>
+    <meta name="description" content="Two new EU laws will offer quick EU funding for recovery measures following natural disasters that have occurred after 1 January 2024."/>
+    <meta property="og:description" content="Two new EU laws will offer quick EU funding for recovery measures following natural disasters that have occurred after 1 January 2024."/>
+    <meta property="twitter:description" content="Two new EU laws will offer quick EU funding for recovery measures following natural disasters that have occurred after 1 January 2024."/>
+    <meta itemprop="description" content="Two new EU laws will offer quick EU funding for recovery measures following natural disasters that have occurred after 1 January 2024."/>
+    <meta charset="UTF-8"/>
+
+    
+    <meta name="available" content="17-12-2024"/>
+
+    <meta http-equiv="last-modified" content="2024-12-17 13:17:00.0"/>
+
+    <meta name="language" content="en"/>
+    <meta name="planet" content="news"/>
+    <link rel="canonical" href="https://www.europarl.europa.eu/news/en/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"/>
+    <meta property="og:url" content="https://www.europarl.europa.eu/news/en/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"/>
+    
+        
+        
+            <meta name="robots" content="index, follow, noodp, noydir, notranslate, noarchive"/>
+        
+    
+    <meta property="og:type" content="article"/>
+
+    
+    
+        <meta property="og:image" content="https://www.europarl.europa.eu/resources/library/images/20241216PHT25979/20241216PHT25979_original.jpg"/>
+        <meta property="twitter:image" content="https://www.europarl.europa.eu/resources/library/images/20241216PHT25979/20241216PHT25979_original.jpg"/>
+        <meta itemprop="image" content="https://www.europarl.europa.eu/resources/library/images/20241216PHT25979/20241216PHT25979_original.jpg"/>
+    
+    
+
+
+
+    
+        <meta name="keywords" content="productType:PRESS_RELEASE,com:AGRI,com:EMPL,com:REGI,plenaryDate:16-12-2024"/>
+    
+    <meta name="routes" content="productSubType:PLENARY_SESSION"/>
+
+
+    
+    
+
+    
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+
+    <link rel="stylesheet" type="text/css" href="/news/css/header-ep.css"/>
+
+    
+        
+    <link rel="stylesheet" type="text/css" href="/news/css/atomicdesign.css"/>
+    <link rel="stylesheet" type="text/css" href="/news/css/components-ep.css"/>
+    <link rel="stylesheet" type="text/css" href="/news/css/structure.css"/>
+    <noscript>
+        <link rel="stylesheet" type="text/css" href="/news/css/no-js.css" />
+    </noscript>
+
+    
+
+    <noscript>
+        <link rel="stylesheet" type="text/css" href="/news/css/header-ep-nojs.css"/>
+    </noscript>
+    
+
+    <script type="text/javascript" defer data-tracker-name="ATInternet"
+            data-value="/website/webanalytics/ati-news.js"
+            src="/website/privacy-policy/privacy-policy.js"></script>
+
+    
+        <script>
+            /*<![CDATA[*/
+            // AMD define stub: delay handling of define calls until our amd dependency
+            // manager has been loaded (from behaviour.js)
+
+            var __amd$delayedDefines = []
+            function define() {
+                var args = Array.prototype.slice.call(arguments)
+                window.__amd$delayedDefines.push(function () {
+                    window.define.apply(window, args)
+                })
+            }
+            define.amd = {}
+            define('eng-scripts',
+                {
+                    'weekly-agenda-widget': { url: "\/news\/js\/weekly-agenda-widget.js", fetched: false }
+                    , 'weekly-agenda': { url: "\/news\/js\/weekly-agenda.js", fetched: false }
+                    , 'week-selector': { url: "\/news\/js\/week-selector.js", fetched: false }
+                    , 'tst-continuous-loading': { url: "\/news\/js\/tst-continuous-loading.js", fetched: false }
+                    , 'slideshow': { url: "\/news\/js\/slideshow.js", fetched: false }
+                    , 'load-more': { url: "\/news\/js\/load-more.js", fetched: false }
+                    , 'infographic': { url: "\/news\/js\/infographic.js", fetched: false }
+                    , 'filter-form': { url: "\/news\/js\/filter-form.js", fetched: false }
+                    , 'datepicker': { url: "\/news\/js\/datepicker.js", fetched: false }
+                    , 'video-player': { url: "\/news\/js\/video-player.js", fetched: false }
+                    , 'election-results': { url: "\/website\/election-results\/js\/ep_electionresults_app.js", fetched: false }
+                    , 'ec-sml-loader': { url: "\/news\/js\/ec-sml-loader.js", fetched: false }
+                    , 'quiz-loader': { url: "https:\/\/quizweb.europarl.europa.eu\/embed\/js\/ep-ee19-quiz.js", fetched: false }
+                    , 'timeline': { url: "\/news\/js\/timeline.js", fetched: false }
+                }
+            )
+            define( 'global', { document: window.document, window: window } )
+            /*]]>*/
+        </script>
+
+        <script async="async" type="text/javascript" src="/news/js/behaviour.js"></script>
+
+        <script type="text/javascript">
+            define('change-language', [ 'behaviour.js'], function moduleFactory() {
+                Select.updateparams('language-select', {cb_beforesubmit: function() {
+                        window.location.href = document.getElementById('language-select').value;
+                        return false;
+                    }})
+            })
+        </script>
+    
+
+
+    
+    <script defer type="text/javascript" src="/news/js/bundle.js"></script>
+
+
+    
+
+    
+    
+        
+    
+
+    
+    
+        
+    
+
+
+
+</head>
+
+    
+    <body lang="en">
+
+    
+    <input type="hidden" value="https://www.europarl.europa.eu/news/en/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery" id="dev_product_url"/>
+
+    
+    <div id="website">
+
+        
+        
+            
+
+    
+    
+    
+    
+
+    <div id="website-header" class="ep-header">
+        <!-- COMPOSANT "WAI SHORTCUTS" -->
+        <nav class="wai-shortcut" aria-label="Shortcuts">
+            <ul id="waimenu">
+                <li><a href="#website-body"><span class="label">Access to page content (press &quot;Enter&quot;)</span></a></li>
+                <li><a href="#language-select"><span class="label">Direct access to language menu (press &quot;Enter&quot;)</span></a></li>
+                <li><a href="#search-field"><span class="label">Direct access to search menu (press &quot;Enter&quot;)</span></a></li>
+            </ul>
+        </nav>
+
+        <!-- START OF REFACTORING -->
+
+        <!-- COMPOSANT "TOOLBAR" TOP -->
+        <div class="toolbar toolbar_top">
+            <div class="toolbar-grid m-column no-padding-m">
+                <!-- COMPOSANT "LANGUAGE MENU" -->
+                <div class="dropdown-lang" id="language-select">
+                    <!-- Select language no js -->
+                    <noscript>
+                        <div class="dropdown">
+                            <div class="dropdown-lang no-js">
+                                <div class="wrapper-dropdown-lang">
+                                    <form method="get" action="/news/changeLanguage" aria-label="Navigation">
+                                        <div class="select">
+                                            <label for="change_language_nojs" class="sr-only">Change the navigation language</label>
+                                            <select id="change_language_nojs" name="url" required>
+                                                <!-- // TODO : values need to be set by -->
+                                                <option
+                                                        lang="bg"
+                                                        value="/news/bg/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >BG - български</option>
+                                                <option
+                                                        lang="es"
+                                                        value="/news/es/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >ES - español</option>
+                                                <option
+                                                        lang="cs"
+                                                        value="/news/cs/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >CS - čeština</option>
+                                                <option
+                                                        lang="da"
+                                                        value="/news/da/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >DA - dansk</option>
+                                                <option
+                                                        lang="de"
+                                                        value="/news/de/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >DE - Deutsch</option>
+                                                <option
+                                                        lang="et"
+                                                        value="/news/et/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >ET - eesti keel</option>
+                                                <option
+                                                        lang="el"
+                                                        value="/news/el/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >EL - ελληνικά</option>
+                                                <option
+                                                        lang="en"
+                                                        value="/news/en/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >EN - English</option>
+                                                <option
+                                                        lang="fr"
+                                                        value="/news/fr/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >FR - français</option>
+                                                <option
+                                                        lang="ga"
+                                                        value="/news/ga/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >GA - Gaeilge</option>
+                                                <option
+                                                        lang="hr"
+                                                        value="/news/hr/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >HR - hrvatski</option>
+                                                <option
+                                                        lang="it"
+                                                        value="/news/it/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >IT - italiano</option>
+                                                <option
+                                                        lang="lv"
+                                                        value="/news/lv/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >LV - latviešu valoda</option>
+                                                <option
+                                                        lang="lt"
+                                                        value="/news/lt/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >LT - lietuvių kalba</option>
+                                                <option
+                                                        lang="hu"
+                                                        value="/news/hu/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >HU - magyar</option>
+                                                <option
+                                                        lang="mt"
+                                                        value="/news/mt/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >MT - Malti</option>
+                                                <option
+                                                        lang="nl"
+                                                        value="/news/nl/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >NL - Nederlands</option>
+                                                <option
+                                                        lang="pl"
+                                                        value="/news/pl/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >PL - polski</option>
+                                                <option
+                                                        lang="pt"
+                                                        value="/news/pt/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >PT - português</option>
+                                                <option
+                                                        lang="ro"
+                                                        value="/news/ro/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >RO - română</option>
+                                                <option
+                                                        lang="sk"
+                                                        value="/news/sk/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >SK - slovenčina</option>
+                                                <option
+                                                        lang="sl"
+                                                        value="/news/sl/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >SL - slovenščina</option>
+                                                <option
+                                                        lang="fi"
+                                                        value="/news/fi/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >FI - suomi</option>
+                                                <option
+                                                        lang="sv"
+                                                        value="/news/sv/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery"
+                                                >SV - svenska</option>
+                                            </select>
+                                        </div>
+                                        <button type="submit" class="btn">Change the navigation language</button>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </noscript>
+                    <!-- End Select language no js -->
+                    <nav class="custom-select dropdown" aria-label="Change the navigation language">
+                        <button id="dropdown" class="btn lang_select" type="submit" aria-haspopup="true" aria-expanded="false">EN - English</button>
+                        <ul class="no-display menu-content">
+
+                            <li>
+                                <a
+                                   lang="bg"
+                                   hreflang="bg"
+                                   href="/news/bg/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">BG - български</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="es"
+                                   hreflang="es"
+                                   href="/news/es/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">ES - español</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="cs"
+                                   hreflang="cs"
+                                   href="/news/cs/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">CS - čeština</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="da"
+                                   hreflang="da"
+                                   href="/news/da/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">DA - dansk</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="de"
+                                   hreflang="de"
+                                   href="/news/de/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">DE - Deutsch</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="et"
+                                   hreflang="et"
+                                   href="/news/et/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">ET - eesti keel</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="el"
+                                   hreflang="el"
+                                   href="/news/el/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">EL - ελληνικά</span></span>
+                                </a>
+                            </li>
+
+                            <li class="current" aria-current="true">
+                                <a
+                                   lang="en"
+                                   hreflang="en"
+                                   href="/news/en/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">EN - English</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="fr"
+                                   hreflang="fr"
+                                   href="/news/fr/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">FR - français</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="ga"
+                                   hreflang="ga"
+                                   href="/news/ga/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">GA - Gaeilge</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="hr"
+                                   hreflang="hr"
+                                   href="/news/hr/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">HR - hrvatski</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="it"
+                                   hreflang="it"
+                                   href="/news/it/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">IT - italiano</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="lv"
+                                   hreflang="lv"
+                                   href="/news/lv/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">LV - latviešu valoda</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="lt"
+                                   hreflang="lt"
+                                   href="/news/lt/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">LT - lietuvių kalba</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="hu"
+                                   hreflang="hu"
+                                   href="/news/hu/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">HU - magyar</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="mt"
+                                   hreflang="mt"
+                                   href="/news/mt/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">MT - Malti</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="nl"
+                                   hreflang="nl"
+                                   href="/news/nl/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">NL - Nederlands</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="pl"
+                                   hreflang="pl"
+                                   href="/news/pl/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">PL - polski</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="pt"
+                                   hreflang="pt"
+                                   href="/news/pt/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">PT - português</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="ro"
+                                   hreflang="ro"
+                                   href="/news/ro/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">RO - română</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="sk"
+                                   hreflang="sk"
+                                   href="/news/sk/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">SK - slovenčina</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="sl"
+                                   hreflang="sl"
+                                   href="/news/sl/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">SL - slovenščina</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="fi"
+                                   hreflang="fi"
+                                   href="/news/fi/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">FI - suomi</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="sv"
+                                   hreflang="sv"
+                                   href="/news/sv/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery">
+                                    <span class="wrapper-label"><span class="label">SV - svenska</span></span>
+                                </a>
+                            </li>
+                        </ul>
+                    </nav>
+                </div>
+                <!-- COMPOSANT "OTHER TOOLS LINKS" -->
+                <nav class="navigation-menu nav-top" aria-label="Navigation">
+                    <div class="menu-container">
+                        <div class="focusable">
+                            <!--href ?  -->
+                            <a role="button" class="btn-open-menu" aria-haspopup="true" aria-expanded="false" tabindex="0">View other websites</a>
+                            <ul class="menu-level-0" aria-label="View menu: News">
+                                <li class="level-0">
+                                    <a class="" href="/news/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">News</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/topics/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">Topics</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/meps/en/home" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">MEPs</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/about-parliament/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">About Parliament</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/plenary/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">Plenary</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/committees/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">Committees</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0 nopadding-right">
+                                    <a class="" href="/delegations/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">Delegations</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0 nopadding-right">
+                                    <a class="" href="https://elections.europa.eu/en">
+                          <span class="content">
+
+                            <span class="label">Elections</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0 has-menu-dropdown">
+                                    <a role="button" class="icon-arrow-dropdown" id="otherWebsitesLink" aria-haspopup="true" aria-expanded="false" tabindex="0">
+                                      <span class="content">
+                                          <span class="sr-only">View submenu:</span>
+                                          <span class="label">Other websites</span>
+                                      </span>
+                                    </a>
+                                    <ul class="menu-level-1">
+                                        <li class="level-1">
+                                            <a href="https://multimedia.europarl.europa.eu/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Multimedia Centre</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/the-president/en/" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">President’s website</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/the-secretary-general/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Secretariat-general</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/thinktank/en/home.html" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Think tank</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="https://www.epnewshub.eu" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">EP Newshub</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/at-your-service/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">At your service</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/visiting/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Visits</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/legislative-train" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Legislative train</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/contracts-and-grants/en/" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Contracts and Grants</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/RegistreWeb/home/welcome.htm?language=en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Register</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="https://data.europarl.europa.eu/en/home" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Open Data Portal</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="https://liaison-offices.europarl.europa.eu/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Liaison offices</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </div>
+                        <!--<input class="menu-btn" type="checkbox" id="menu-btn-navigationtop" aria-label="Click to open the other websites menu" />
+                        <label class="menu-icon" for="menu-btn-navigationtop">View other websites</label>-->
+                    </div>
+                </nav>
+            </div>
+        </div>
+        <!-- LOGO + TITLE -->
+        <header class="header">
+            <div class="header-wrapper no-padding">
+                <!--<a class="grid" href="https://www.europarl.europa.eu/portal/en">
+                  <span class="sr-only">Go back to the Europarl portal</span>
+                  <img src="../europarl/img/ep-logo.svg" alt="" class="ep_logo" />
+                </a>-->
+                <div class="grid">
+				<span class="title-wrapper">
+					
+					<a href="/news/en" class="title"><span class="labeltxt">News</span></a>
+					<a href="/portal/en" class="subtitle">
+                      <span class="labeltxt">European Parliament</span>
+                      <span class="logo"></span>
+                    </a>
+				</span>
+                </div>
+            </div>
+        </header>
+        <!-- COMPOSANT "TOOLBAR" BOTTOM -->
+        <div class="toolbar toolbar_bottom sticky">
+            <div class="toolbar-grid no-padding flex-end">
+                <!-- COMPOSANT "NAVIGATION MENU" -->
+                <nav class="navigation-menu nav-main" aria-label="Main navigation">
+                    <div class="menu-container">
+                        <!--<input class="menu-btn" type="checkbox" id="menu-btn-navigationmain" aria-label="Click to open the main menu" />
+                        <label class="menu-icon" for="menu-btn-navigationmain"><span class="nav-icon"></span></label>-->
+                        <a role="button" class="menu-icon" tabindex="0">
+                            <span class="label">Menu</span>
+                            <span class="nav-icon"></span>
+                        </a>
+                        <ul class="menu-level-0">
+
+                            <li class="level-0">
+                                <a class="" href="/news/en" aria-haspopup="true">
+                                  <span class="content">
+                                    <span class="label">Homepage</span>
+                                    <span class="current-element"></span>
+                                  </span>
+                                </a>
+                            </li>
+
+                            <li class="level-0 current has-menu-dropdown">
+                                <a role="button" class="icon-arrow-dropdown" aria-current="true" aria-haspopup="true" tabindex="0">
+                                  <span class="content">
+                                    <span class="label">Press room</span>
+                                    <span class="current-element"></span>
+                                  </span>
+                                </a>
+                                <ul class="menu-level-1" aria-label="View submenu">
+                                    
+                                        <li class="level-1">
+                                            <a href="https://www.europarl.europa.eu/news/en/press-room/accreditation">
+                                                <span class="content">
+
+                                                  <span class="label">Accreditation</span>
+                                                </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="https://www.europarl.europa.eu/news/en/press-room/press-tool-kit">
+                                                <span class="content">
+
+                                                  <span class="label">Press Tool Kit</span>
+                                                </span>
+                                            </a>
+                                        </li>
+                                    
+                                    
+
+                                    <li class="level-1">
+                                        <a href="/news/en/press-room/contacts">
+                                            <span class="content">
+
+                                              <span class="label">Contacts</span>
+                                            </span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </li>
+
+
+                            <li class="level-0 has-menu-dropdown">
+                                <a role="button" class="icon-arrow-dropdown" aria-haspopup="true" tabindex="0">
+                                  <span class="content">
+                                    <span class="label">Agenda</span>
+                                    <span class="current-element"></span>
+                                  </span>
+                                </a>
+                                <ul class="menu-level-1" aria-label="View submenu">
+                                    <li class="level-1">
+                                        <a href="/news/en/agenda">
+                                            <span class="content">
+
+                                              <span class="label">Highlights</span>
+                                            </span>
+                                        </a>
+                                    </li>
+                                    <li class="level-1">
+                                        <a href="/news/en/agenda/weekly-agenda">
+                                            <span class="content">
+
+                                              <span class="label">Weekly agenda</span>
+                                            </span>
+                                        </a>
+                                    </li>
+                                    <li class="level-1">
+                                        <a href="/news/en/agenda/briefing">
+                                            <span class="content">
+
+                                              <span class="label">Briefing</span>
+                                            </span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li class="level-0">
+                                <a class="" href="/news/en/faq" aria-haspopup="true">
+                                  <span class="content">
+                                    <span class="label">FAQ</span>
+                                    <span class="current-element"></span>
+                                  </span>
+                                </a>
+                            </li>
+
+                            
+
+                            <li class="level-0 current">
+                                <a href="/news/en/press-room/press-tool-kit">
+                                    <span class="content">
+
+                                      <span class="label">Press Kit</span>
+                                    </span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </nav>
+                
+                    <!-- COMPOSANT "SEARCH MENU" -->
+
+                    <nav class="search-global-form" aria-label="Click to open the search component">
+                        <!-- Add class 'active' to change the style of the <a> -->
+                        <a href="#" class="search-icon" aria-haspopup="true" aria-expanded="false">
+                            <span class="sr-only">Access to search field</span>
+                            <span class="icon"></span>
+                        </a>
+                    </nav>
+                    <!-- Remove class 'posinit' to display the input search -->
+                    <form class="form-field-search" id="search" action="/news/en/search" method="get" role="search" aria-label="Search">
+                        <div class="field-wrapper">
+                            <div class="field">
+                                <input class="ep_field" type="text" id="search-field" name="searchQuery" value="" aria-label="Please fill out this field" title="Please fill out this field" placeholder="Search" required/>
+                                <button class="btn-send active" type="submit" aria-label="Launch the search" disabled>
+                                    <span class="sr-only">Launch the search</span>
+                                    <span class="icon">&nbsp;</span>
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                    <!-- TITLE ON SCROLL -->
+                    <span class="title-toolbar" aria-hidden="true"><span class="label">European Parliament</span></span>
+                
+            </div>
+
+        </div>
+        <!-- COMPOSANT "BREADCRUMB" -->
+        <nav id="website-breadcrumb" class="ep_breadcrumb" aria-label="You are here:">
+    <div class="ep_fulllist">
+        <span class="ep_mandatory">
+            
+    
+        <a class="ep_item" href="/news/en/press-room">
+            <span class="ep_hidden">Go back to page : Press room</span>
+            <span class="ep_name">Press room</span>
+            <span class="ep_icon">&nbsp;</span></a>
+        <span class="ep_separator"></span>
+    
+    
+
+        </span>
+
+        
+    <span class="ep_mandatory" aria-current="page">
+        <span class="ep_item">
+            <span class="ep_hidden">Current page:</span>
+            <span class="ep_name">EP paves way for the use of EU funds to finance natural disaster recovery</span>
+            <span class="ep_icon">&nbsp;</span>
+        </span>
+    </span>
+
+    </div>
+    <div class="ep_previouslink">
+        
+    
+        <a class="ep_item" href="/news/en/press-room">
+            <span class="ep_hidden">Go back to page : Press room</span>
+            <span class="ep_name">Press room</span>
+            <span class="ep_icon">&nbsp;</span></a>
+        <span class="ep_separator"></span>
+    
+    
+
+    </div>
+</nav>
+    </div>
+    <!-- END OF REFACTORING -->
+
+        
+        
+
+        
+        <article id="website-body" role="main">
+
+    
+    
+    
+        
+            <input type="hidden" id="webanalytic-id_chapters" value="press-room"/>
+        
+            <input type="hidden" id="webanalytic-id_sub-chapters" value="pressroom"/>
+        
+            <input type="hidden" id="webanalytic-id_sub-sub-chapters" value="the-eu-and-its-institutions~institutions"/>
+        
+            <input type="hidden" id="webanalytic-id_pages" value="restore-agri-fund-measures-natural-disasters"/>
+        
+            <input type="hidden" id="webanalytic-id_type" value=""/>
+        
+            <input type="hidden" id="webanalytic-ep_bodies" value="plenary~16.12.2024~19.12.2024/committees~empl~regi~agri"/>
+        
+            <input type="hidden" id="webanalytics-topics_by_weeks" value=""/>
+        
+            <input type="hidden" id="webanalytics-priority_category" value=""/>
+        
+            <input type="hidden" id="webanalytics-priority_wordlink" value=""/>
+        
+            <input type="hidden" id="webanalytics-reference" value=""/>
+        
+            <input type="hidden" id="webanalytics-language" value=""/>
+        
+    
+
+
+    
+    <div class="ep_gridrow ep-o_product">
+        <div class="ep_gridrow-content">
+            <div class="ep_gridcolumn" data-view1200="2" data-view1020="2" data-view750="1" data-view640="1" data-view480="0" data-view320="0">
+                <div class="ep_gridcolumn-content">&nbsp;</div>
+            </div>
+            <div class="ep_gridcolumn ep-m_header" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                <div class="ep_gridcolumn-content">
+                    <div class="ep-a_heading ep-layout_level1">
+                        <h1 class="ep_title">
+                            <div class="ep-p_text"><span class="ep_name">Parliament paves way for the use of EU funds to finance natural disaster recovery</span><span class="ep_icon">&nbsp;</span></div>
+                        </h1>
+                        <div class="ep_subtitle">
+
+                            <div class="ep-p_text ep-layout_category"><span class="ep_name">Press Releases</span><span class="ep_icon">&nbsp;</span></div>
+
+                            
+
+                            
+
+    
+        <div class="ep-p_text ep-layout_contenttype ep-layout_plenary">
+            <a href="/news/en?contentType=plenary" >
+                <span class="ep_name">Plenary session</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+        
+    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
+        <a href="/news/en?contentType=committee&amp;keywordValue=AGRI" >
+            <span class="ep_name"><abbr title="Agriculture and Rural Development">AGRI</abbr></span><span class="ep_icon">&nbsp;</span>
+        </a>
+    </div>
+    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
+        <a href="/news/en?contentType=committee&amp;keywordValue=EMPL" >
+            <span class="ep_name"><abbr title="Employment and Social Affairs">EMPL</abbr></span><span class="ep_icon">&nbsp;</span>
+        </a>
+    </div>
+    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
+        <a href="/news/en?contentType=committee&amp;keywordValue=REGI" >
+            <span class="ep_name"><abbr title="Regional Development">REGI</abbr></span><span class="ep_icon">&nbsp;</span>
+        </a>
+    </div>
+
+    
+
+    
+
+
+
+                            
+    
+        
+        
+            
+    <div class="ep-p_text ep-layout_date">
+        <span class="ep_name">
+            
+    
+    
+        <time itemprop="datePublished"
+              datetime="2024-12-17T13:17:00">17-12-2024 - 13:17</time>
+    
+
+        </span><span class="ep_icon">&nbsp;</span>
+    </div>
+
+        
+
+    
+
+    
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    
+    <div class="ep_gridrow ep-o_product">
+        <div class="ep_gridrow-content">
+            <div class="ep_gridcolumn" data-view1200="1" data-view1020="1" data-view750="0" data-view640="0" data-view480="0" data-view320="0">
+                <div class="ep_gridcolumn-content">&nbsp;</div>
+            </div>
+
+            
+            
+                
+
+    <div class="ep_gridcolumn ep-m_product ep-layout_followingscroll" data-view1200="1" data-view1020="1" data-view750="1" data-view640="1" data-view480="0" data-view320="0">
+        <div class="ep_gridcolumn-content">
+            <div class="ep-a_share ep-layout_socialnetwok">
+                <div>
+                    
+
+    <div class="ep_share">
+        <h2 class="ep_title">
+            <div class="ep-p_text"><span class="ep_name">Share this page:</span><span class="ep_icon">&nbsp;</span></div>
+        </h2>
+        <ul>
+            <li>
+                <div class="ep-p_text ep-layout_facebook">
+                    <a href="https://www.facebook.com/share.php?u=https://www.europarl.europa.eu/news/en/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Bfacebook%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Brestore-agri-fund-measures-natural-disasters%5D-" title="Share this page on Facebook" target="_blank" ><span class="ep_name">Facebook</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+            <li>
+                <div class="ep-p_text ep-layout_twitter">
+                    <a href="https://twitter.com/intent/tweet?text=EP%20paves%20way%20for%20the%20use%20of%20EU%20funds%20to%20finance%20natural%20disaster%20recovery&amp;url=https://www.europarl.europa.eu/news/en/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Btwitter%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Brestore-agri-fund-measures-natural-disasters%5D-&amp;via=Europarl_EN" title="Share this page on Twitter" target="_blank"><span class="ep_name">Twitter</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+            <li>
+                <div class="ep-p_text ep-layout_linkedin">
+                    <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https://www.europarl.europa.eu/news/en/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Blinkedin%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Brestore-agri-fund-measures-natural-disasters%5D%26&amp;title=European%20Parliament&amp;summary=&amp;source=" title="Share this page on LinkedIn" target="_blank" ><span class="ep_name">LinkedIn</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+
+            <li>
+                <div class="ep-p_text ep-layout_whatsapp">
+                    <a href="https://api.whatsapp.com/send?text=https://www.europarl.europa.eu/news/en/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Bwhatsapp%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Brestore-agri-fund-measures-natural-disasters%5D%26" title="Share this page on WhatsApp" target="_blank"><span class="ep_name">WhatsApp</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+        </ul>
+    </div>
+
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+            
+
+            
+            <div class="ep_gridcolumn" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                <div class="ep_gridrow">
+                    <div class="ep_gridrow-content">
+
+                        
+                        
+                        
+
+    
+        
+            
+            
+            
+            
+            
+                
+
+    <!-- Fact list -->
+    <div class="ep_gridcolumn ep-m_product" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content">
+            <div class="ep-a_facts">
+                <div>
+                    
+                    <ul class="ep_list">
+                        
+                            
+    <li><div class="ep-p_text"><span class="ep_name">Regional development funds can be used more flexibly for reconstruction following natural disasters</span><span class="ep_icon">&nbsp;</span></div></li>
+
+                        
+                            
+    <li><div class="ep-p_text"><span class="ep_name">Social funds can also finance post-disaster healthcare and basic necessities</span><span class="ep_icon">&nbsp;</span></div></li>
+
+                        
+                            
+    <li><div class="ep-p_text"><span class="ep_name">Losses for farmers, forest holders and SMEs active in agriculture and forestry can be compensated</span><span class="ep_icon">&nbsp;</span></div></li>
+
+                        
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+        
+            
+            
+            
+            
+            
+            
+            
+            
+                
+                    
+
+      
+        
+
+    <div class="ep_gridcolumn ep-m_product" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content">
+            
+    <div class="ep-a_media">
+        <figure>
+            <div class="ep_media ep-layout_image">
+                <div class="ep-p_image ep-layout_original">
+                    
+                    
+                        <a href="https://www.europarl.europa.eu/resources/library/images/20241216PHT25979/20241216PHT25979_original.jpg" title="Open in a new window" target="_blank">
+                            
+    <div class="ep_image">
+        
+        
+             <img src="https://www.europarl.europa.eu/resources/library/images/20241216PHT25979/20241216PHT25979-cl.jpg" alt="Quick EU funding of recovery measures following natural disasters © JOSE JORDAN / AFP"/>
+        
+
+<span class="ep_small" style="background-image:url(https://www.europarl.europa.eu/resources/library/images/20241216PHT25979/20241216PHT25979-cs.jpg);">&nbsp;</span>
+<span class="ep_medium" style="background-image:url(https://www.europarl.europa.eu/resources/library/images/20241216PHT25979/20241216PHT25979-cm.jpg);">&nbsp;</span>
+<span class="ep_large" style="background-image:url(https://www.europarl.europa.eu/resources/library/images/20241216PHT25979/20241216PHT25979-cl.jpg);">&nbsp;</span>
+<span class="ep_icon">&nbsp;</span>
+</div>
+
+                        </a>
+                    
+                </div>
+            </div>
+
+            <figcaption class="ep_text">
+                <div class="ep-p_text ep-layout_legend">
+                    <span class="ep_name">Quick EU funding of recovery measures following natural disasters © JOSE JORDAN / AFP</span>
+                    <span class="ep_icon">&nbsp;</span>
+                </div>
+            </figcaption>
+
+        </figure>
+    </div>
+
+        </div>
+    </div>
+
+
+    
+
+
+                
+                
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+        
+            
+            
+                
+
+    <div class="ep_gridcolumn ep-m_product" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content">
+            <div class="ep-a_text ep-layout_chapo">
+                <p>Two new EU laws will offer quick EU funding for recovery measures following natural disasters that have occurred after 1 January 2024.</p>
+            </div>
+        </div>
+    </div>
+
+
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+        
+            
+            
+            
+            
+                
+
+    <!-- Text content -->
+    <div class="ep_gridcolumn ep-m_product" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content" >
+            <div class="ep-a_text"><p class="ep-wysiwig_paragraph">The Regional Emergency Support to Reconstruction (“RESTORE”) proposal allows EU countries to more easily channel European regional development funds (ERDF) and cohesion funds to disaster reconstruction. As a result, the EU’s ERDF could fund recovery projects up to 95% of their total cost. To provide quick liquidity to those in need, additional pre-financing of up to 25% of the full amount would also be made available. The proposal would allow for more flexible use of European Social Fund Plus funds to finance short-term work schemes, support access to healthcare and provide basic necessities.</p>
+<br />
+<p class="ep-wysiwig_paragraph">Flexibility would apply to disasters in 2024 or 2025. In 2025, the proposed changes are expected to mobilize €3 billion in funding by front-loading payments for the 2025–2027 period.</p>
+<br />
+<p class="ep-wysiwig_paragraph"><strong>Recovery in agriculture and forestry</strong></p>
+<p class="ep-wysiwig_paragraph">EU countries with unspent money from rural developments programmes will be able to fast-track the use of this money to compensate losses of farmers, forest holders and SMEs active in these sectors that have experienced destruction of at least 30% of their production potential. This money will be paid in lump sums and will be fully covered by EU funds. Payments to beneficiaries will be made by the end of 2025.</p>
+<br />
+<p class="ep-wysiwig_paragraph"><strong>Quotes</strong></p>
+<p class="ep-wysiwig_paragraph"><a href="https://www.europarl.europa.eu/meps/en/257051/ANDRZEJ_BULA/home" target="_blank" rel="noopener">Andrzej BUŁA (EPP, PL)</a>, co-rapporteur for the RESTORE regulation said: “This law is very important for regional and local authorities in regions affected by natural disasters. It shows that the EU is capable of working quickly and flexibly, and that we provide real help for our fellow European citizens. That help can now become quickly available.”</p>
+<br />
+<p class="ep-wysiwig_paragraph"><a href="https://www.europarl.europa.eu/meps/en/30482/YOUNOUS_OMARJEE/home" target="_blank" rel="noopener">Younous OMARJEE (the Left, FR)</a> co-rapporteur for the RESTORE regulation stated: “After Parliament expressed full support for the victims of the unprecedented storm in Mayotte, we adopted the RESTORE law to ensure we can help the victims of this catastrophe and others like it to rebuild what they have lost. We need to adapt our disaster response and regional policy to the new realities of climate change. RESTORE will allow us to respond quickly and effectively to future disasters."</p>
+<br />
+<p class="ep-wysiwig_paragraph"><a href="https://www.europarl.europa.eu/meps/en/197552/VERONIKA_VRECIONOVA/home" target="_blank" rel="noopener">Veronika VRECIONOVÁ (ECR, CZ)</a>, rapporteur for the European Agricultural Fund for Rural Development (EAFRD) related regulation, said: “Several countries have been affected by natural disasters in 2024, and the concrete help the EU is providing is much needed by both countries and citizens. Today’s decision will help many member states release unspent funds more quickly for those who urgently need them.”</p>
+<br />
+<p class="ep-wysiwig_paragraph">The “RESTORE” proposal was adopted by 638 votes in favour, 10 against with 5 abstentions.</p>
+<br />
+<p class="ep-wysiwig_paragraph">The proposal providing assistance from the EAFRD was approved by 644 votes in favour, 6 against with 3 abstentions.</p>
+<br />
+<p class="ep-wysiwig_paragraph"><strong>Next steps</strong></p>
+<br />
+<p class="ep-wysiwig_paragraph">Both laws now need to be formally endorsed by the Council. They will enter into force a day after being published in the EU Official Journal (RESTORE) and the day of its publication (EAFRD).</p>
+<p class="ep-wysiwig_paragraph"><br /><br /></p>
+<p class="ep-wysiwig_paragraph"><strong>Background</strong></p>
+<p class="ep-wysiwig_paragraph">The two proposals responded to floods and wildfires in Central, Eastern and Southern Europe in September 2024.</p></div>
+        </div>
+    </div>
+
+
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+        
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+
+
+
+
+                        
+                        
+
+    <!-- Contact -->
+    
+    <div class="ep_gridcolumn ep-m_product" role="region" aria-labelledby="asideregion323816" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content">
+            <div class="ep-a_contacts">
+                <h2 class="ep_title" id="asideregion323816">
+                    <div class="ep-p_text"><span class="ep_name">Contacts:</span><span class="ep_icon">&nbsp;</span></div>
+                </h2>
+                <ul>
+                    
+                        <li class="ep_item">
+                            <div class="ep_card">
+                                <h3 class="ep_name">
+                                    <span class="ep-p_text"><span class="ep_name">Janne OJAMO</span><span class="ep_icon">&nbsp;</span></span>
+                                </h3>
+                                
+                                
+                                    <div class="ep_information">
+                                        <span class="ep-p_text"><span class="ep_name">Press Officer</span><span class="ep_icon">&nbsp;</span></span>
+                                    </div>
+                                
+                                <div class="ep_data">
+                                    <div class="ep-p_text ep_hidden"><span class="ep_name">Contact data:</span><span class="ep_icon">&nbsp;</span></div>
+                                    <ul>
+                                        
+                                            
+                                                
+                                                    <li class="ep_phone">
+                                                        <a href="tel:(+32) 2 284 12 50" class="ep-p_text"><span class="ep_name" title="Phone number"><span class="ep_hidden">Phone number: </span>(+32) 2 284 12 50<abbr class="ep_location" title="Brussels"> (BXL)</abbr></span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_portable">
+                                                        <a href="tel:(+32) 470 89 21 92" class="ep-p_text"><span class="ep_name" title="Mobile number"><span class="ep_hidden">Mobile number: </span>(+32) 470 89 21 92</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_mail">
+                                                        <a href="mailto:janne.ojamo@europarl.europa.eu" class="ep-p_text" title="E-mail: janne.ojamo@europarl.europa.eu"><span class="ep_name"><span class="ep_hidden">E-mail:  </span>janne.ojamo@europarl.europa.eu</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_mail">
+                                                        <a href="mailto:region-press@europarl.europa.eu" class="ep-p_text" title="E-mail: region-press@europarl.europa.eu"><span class="ep_name"><span class="ep_hidden">E-mail:  </span>region-press@europarl.europa.eu</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_twitter">
+                                                        <a href="http://twitter.com/EP_Regional" class="ep-p_text" title="Open a Twitter account in a new window" target="_blank"><span class="ep_name"><span class="ep_hidden">Twitter account: </span>@EP_Regional</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                            
+                                        
+                                    </ul>
+                                </div>
+                            </div>
+                            
+                        </li>
+                    
+                        <li class="ep_item">
+                            <div class="ep_card">
+                                <h3 class="ep_name">
+                                    <span class="ep-p_text"><span class="ep_name">Lieven COSIJN</span><span class="ep_icon">&nbsp;</span></span>
+                                </h3>
+                                
+                                
+                                    <div class="ep_information">
+                                        <span class="ep-p_text"><span class="ep_name">Press officer</span><span class="ep_icon">&nbsp;</span></span>
+                                    </div>
+                                
+                                <div class="ep_data">
+                                    <div class="ep-p_text ep_hidden"><span class="ep_name">Contact data:</span><span class="ep_icon">&nbsp;</span></div>
+                                    <ul>
+                                        
+                                            
+                                                
+                                                    <li class="ep_phone">
+                                                        <a href="tel:(+32) 2 28 31183" class="ep-p_text"><span class="ep_name" title="Phone number"><span class="ep_hidden">Phone number: </span>(+32) 2 28 31183<abbr class="ep_location" title="Brussels"> (BXL)</abbr></span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_portable">
+                                                        <a href="tel:(+32) 473 864 141" class="ep-p_text"><span class="ep_name" title="Mobile number"><span class="ep_hidden">Mobile number: </span>(+32) 473 864 141</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_mail">
+                                                        <a href="mailto:lieven.cosijn@europarl.europa.eu" class="ep-p_text" title="E-mail: lieven.cosijn@europarl.europa.eu"><span class="ep_name"><span class="ep_hidden">E-mail:  </span>lieven.cosijn@europarl.europa.eu</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_mail">
+                                                        <a href="mailto:empl-press@europarl.europa.eu " class="ep-p_text" title="E-mail: empl-press@europarl.europa.eu "><span class="ep_name"><span class="ep_hidden">E-mail:  </span>empl-press@europarl.europa.eu </span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_twitter">
+                                                        <a href="http://twitter.com/@EPSocialAffairs " class="ep-p_text" title="Open a Twitter account in a new window" target="_blank"><span class="ep_name"><span class="ep_hidden">Twitter account: </span>@@EPSocialAffairs </span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                            
+                                        
+                                    </ul>
+                                </div>
+                            </div>
+                            
+                        </li>
+                    
+                        <li class="ep_item">
+                            <div class="ep_card">
+                                <h3 class="ep_name">
+                                    <span class="ep-p_text"><span class="ep_name">Hana RAISSI</span><span class="ep_icon">&nbsp;</span></span>
+                                </h3>
+                                
+                                
+                                    <div class="ep_information">
+                                        <span class="ep-p_text"><span class="ep_name">Press officer</span><span class="ep_icon">&nbsp;</span></span>
+                                    </div>
+                                
+                                <div class="ep_data">
+                                    <div class="ep-p_text ep_hidden"><span class="ep_name">Contact data:</span><span class="ep_icon">&nbsp;</span></div>
+                                    <ul>
+                                        
+                                            
+                                                
+                                                    <li class="ep_phone">
+                                                        <a href="tel:(+32) 2 28 41587" class="ep-p_text"><span class="ep_name" title="Phone number"><span class="ep_hidden">Phone number: </span>(+32) 2 28 41587<abbr class="ep_location" title="Brussels"> (BXL)</abbr></span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_portable">
+                                                        <a href="tel:(+32) 484 27 87 54" class="ep-p_text"><span class="ep_name" title="Mobile number"><span class="ep_hidden">Mobile number: </span>(+32) 484 27 87 54</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_mail">
+                                                        <a href="mailto:hana.raissi@europarl.europa.eu" class="ep-p_text" title="E-mail: hana.raissi@europarl.europa.eu"><span class="ep_name"><span class="ep_hidden">E-mail:  </span>hana.raissi@europarl.europa.eu</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_mail">
+                                                        <a href="mailto:agri-press@europarl.europa.eu" class="ep-p_text" title="E-mail: agri-press@europarl.europa.eu"><span class="ep_name"><span class="ep_hidden">E-mail:  </span>agri-press@europarl.europa.eu</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_twitter">
+                                                        <a href="http://twitter.com/EP_Agriculture" class="ep-p_text" title="Open a Twitter account in a new window" target="_blank"><span class="ep_name"><span class="ep_hidden">Twitter account: </span>@EP_Agriculture</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                            
+                                        
+                                    </ul>
+                                </div>
+                            </div>
+                            
+                        </li>
+                    
+                </ul>
+            </div>
+        </div>
+    </div>
+
+
+
+                    </div>
+                </div>
+            </div>
+            <!-- ADDITIONAL LINKS COLUMN -->
+            <section class="ep_gridcolumn ep-layout_followingscroll" data-view1200="3" data-view1020="3" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
+                <div class="ep_gridrow">
+                    <div class="ep_gridrow-content">
+                        <div class="ep_gridcolumn" data-view1200="0" data-view1020="0" data-view750="1" data-view640="1" data-view480="0" data-view320="0">
+                            <div class="ep_gridcolumn-content">&nbsp;</div>
+                        </div>
+                        <div class="ep_gridcolumn" data-view1200="3" data-view1020="3" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                            <div class="ep_gridrow">
+                                <div class="ep_gridrow-content">
+
+                                    
+                                    
+
+                                    
+                                    
+                                        
+                                            
+                                        
+                                    
+                                        
+                                            
+                                        
+                                    
+                                        
+                                            
+                                        
+                                    
+                                        
+                                            
+                                        
+                                    
+                                        
+                                            
+                                                
+    <!-- List of links -->
+    <div class="ep_gridcolumn ep-m_product" data-layout1200="border" data-layout1020="border" data-view1200="3" data-view1020="3" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        
+    <div class="ep_gridcolumn-content">
+        <div class="ep-a_links">
+            <h2 class="ep_title">
+                <div class="ep-p_text"><span class="ep_name">Further information</span><span class="ep_icon">&nbsp;</span></div>
+            </h2>
+            <ul class="ep_list">
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" target="_blank" href="https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2024/0275(COD)"><span class="ep_name">
+
+
+Procedure file (RESTORE)
+
+</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" target="_blank" href="https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2024/0274(COD)"><span class="ep_name">Procedure file (EAFRD)
+
+</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" target="_blank" href="https://multimedia.europarl.europa.eu/en/webstreaming/press-conference-by-younous-omarjee-the-left-fr-vice-president-and-andrzej-bula-epp-pl-co-rapporteur_20241217-1330-SPECIAL-PRESSER"><span class="ep_name">Press conference on the RESTORE regulation by co-rapporteurs Younous OMARJEE (The Left, FR) and Andrzej BULA (EPP, PL) (17.12.2024)
+</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" href="/thinktank/en/document/EPRS_ATA(2024)767157"><span class="ep_name">EPRS briefing: Regional emergency support for reconstruction (11.12.2024)
+
+</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" target="_blank" href="https://multimedia.europarl.europa.eu/en/topic/natural-disasters_23503
+"><span class="ep_name">
+
+
+
+
+
+EP Multimedia Centre: free photos, video and audio material (natural disasters)
+</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+            </ul>
+        </div>
+    </div>
+
+    </div>
+
+                                            
+                                        
+                                    
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Product reference -->
+            <div class="ep_gridcolumn" data-view1200="12" data-view1020="12" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
+                <div class="ep_gridrow">
+                    <div class="ep_gridrow-content">
+                        <div class="ep_gridcolumn" data-view1200="2" data-view1020="2" data-view750="1" data-view640="1" data-view480="0" data-view320="0">
+                            <div class="ep_gridcolumn-content">&nbsp;</div>
+                        </div>
+                        <div class="ep_gridcolumn" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                            <div class="ep_gridrow">
+                                <div class="ep_gridrow-content">
+                                    <div class="ep_gridcolumn ep-m_footer" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                                        <div class="ep_gridcolumn-content">
+                                            <h2 class="ep-a_heading ep_hidden">
+                                                <div class="ep_title">
+                                                    <div class="ep-p_text"><span class="ep_name">Product information</span><span class="ep_icon">&nbsp;</span></div>
+                                                </div>
+                                            </h2>
+                                            <div class="ep-a_reference">
+                                                <div class="ep_reference">
+                                                    <span class="ep-p_text"><span class="ep_name"><abbr title="Product reference">Ref.:</abbr></span><span class="ep_icon">&nbsp;</span></span>
+                                                    <span class="ep-p_text"><span class="ep_name">20241212IPR25960</span><span class="ep_icon">&nbsp;</span></span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+    
+    
+        
+
+    <div class="ep_gridrow ep-o_footerpage">
+        <div class="ep_gridrow-content">
+            <div class="ep_gridcolumn ep-m_product" data-view1200="12" data-view1020="12" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
+                <div class="ep_gridcolumn-content">
+                    <div class="ep-a_share">
+                        <div>
+                            
+
+    <div class="ep_share">
+        <h2 class="ep_title">
+            <div class="ep-p_text"><span class="ep_name">Share this page:</span><span class="ep_icon">&nbsp;</span></div>
+        </h2>
+        <ul>
+            <li>
+                <div class="ep-p_text ep-layout_facebook">
+                    <a href="https://www.facebook.com/share.php?u=https://www.europarl.europa.eu/news/en/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Bfacebook%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Brestore-agri-fund-measures-natural-disasters%5D-" title="Share this page on Facebook" target="_blank" ><span class="ep_name">Facebook</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+            <li>
+                <div class="ep-p_text ep-layout_twitter">
+                    <a href="https://twitter.com/intent/tweet?text=EP%20paves%20way%20for%20the%20use%20of%20EU%20funds%20to%20finance%20natural%20disaster%20recovery&amp;url=https://www.europarl.europa.eu/news/en/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Btwitter%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Brestore-agri-fund-measures-natural-disasters%5D-&amp;via=Europarl_EN" title="Share this page on Twitter" target="_blank"><span class="ep_name">Twitter</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+            <li>
+                <div class="ep-p_text ep-layout_linkedin">
+                    <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https://www.europarl.europa.eu/news/en/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Blinkedin%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Brestore-agri-fund-measures-natural-disasters%5D%26&amp;title=European%20Parliament&amp;summary=&amp;source=" title="Share this page on LinkedIn" target="_blank" ><span class="ep_name">LinkedIn</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+
+            <li>
+                <div class="ep-p_text ep-layout_whatsapp">
+                    <a href="https://api.whatsapp.com/send?text=https://www.europarl.europa.eu/news/en/press-room/20241212IPR25960/ep-paves-way-for-the-use-of-eu-funds-to-finance-natural-disaster-recovery?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Bwhatsapp%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Brestore-agri-fund-measures-natural-disasters%5D%26" title="Share this page on WhatsApp" target="_blank"><span class="ep_name">WhatsApp</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+        </ul>
+    </div>
+
+
+                            <div class="ep_links">
+                                <div class="ep-p_text ep-layout_mail"><a href="/subscription/en"><span class="ep_name">Sign up for mail updates</span></a></div>
+
+                                
+                                <div class="ep-p_text ep-layout_pdf"><a href="/pdfs/news/expert/2024/12/press_release/20241212IPR25960/20241212IPR25960_en.pdf"><span class="ep_name">PDF version</span><span class="ep_icon">&nbsp;</span></a></div>
+
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+    
+
+
+</article>
+
+        
+        
+            
+
+    <footer id="website-footer" role="contentinfo">
+        
+        <div class="ep_footer-relatedlinks">
+            <div class="ep_websitelinks" id="website-links">
+                <h2 class="ep_title" id="website-links-title">
+                    <span class="ep_name">News</span>
+                    <span class="ep_icon">&nbsp;</span>
+                </h2>
+                <div class="ep_menu-access ep_openaccess" id="website-links-access" aria-controls="website-links-content" role="tab">
+                    <a href="#website-links">
+                        <span class="ep_name">View menu: News</span>
+                        <span class="ep_icon">&nbsp;</span></a>
+                </div>
+                <div class="ep_list ep-layout_category" id="website-links-content">
+                    <div>
+                        <div class="ep_category">
+                            <h3 class="ep_subtitle" id="website-links-category1-title">
+                                <span class="ep_name">Parliament in your country</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </h3>
+                            
+                                <ul aria-labelledby="website-links-category1-title">
+                                    
+                                        <li class="ep_item">
+                                            <a href="/unitedkingdom" class="ep_button" target="_blank" >
+                                                <span class="ep_hidden">Open in a new page</span>
+                                                <span class="ep_name">London</span>
+                                            </a>
+                                        </li>
+                                    
+                                        <li class="ep_item">
+                                            <a href="/ireland" class="ep_button" target="_blank" >
+                                                <span class="ep_hidden">Open in a new page</span>
+                                                <span class="ep_name">Dublin</span>
+                                            </a>
+                                        </li>
+                                    
+                                        <li class="ep_item">
+                                            <a href="/malta" class="ep_button" target="_blank" >
+                                                <span class="ep_hidden">Open in a new page</span>
+                                                <span class="ep_name">Valletta</span>
+                                            </a>
+                                        </li>
+                                    
+                                        <li class="ep_item">
+                                            <a href="/unitedstates" class="ep_button" target="_blank" >
+                                                <span class="ep_hidden">Open in a new page</span>
+                                                <span class="ep_name">Washington</span>
+                                            </a>
+                                        </li>
+                                    
+                                </ul>
+                            
+                        </div>
+                        <div class="ep_category">
+                            <h3 class="ep_subtitle" id="website-links-category2-title">
+                                <span class="ep_name">Tools</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </h3>
+                            <ul aria-labelledby="website-links-category2-title">
+                                <li class="ep_item">
+                                    <a href="/oeil/home/home.do" class="ep_button">
+                                        <span class="ep_hidden">Open in a new page</span>
+                                        <span class="ep_name">Legislative Observatory</span>
+                                    </a>
+                                </li>
+                                <li class="ep_item">
+                                    <a href="https://multimedia.europarl.europa.eu/en" class="ep_button" target="_blank" >
+                                        <span class="ep_hidden">Open in a new page</span>
+                                        <span class="ep_name">Multimedia Centre</span>
+                                    </a>
+                                </li>
+                                <li class="ep_item">
+                                    <a href="https://ec.europa.eu/avservices/ebs/schedule.cfm?sitelang=en"  class="ep_button" target="_blank" >
+                                        <span class="ep_hidden">Open in a new page</span>
+                                        <span class="ep_name">EbS</span>
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="ep_category">
+                            <h3 class="ep_subtitle" id="website-links-category3-title">
+                                <span class="ep_name">The President of the European Parliament</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </h3>
+                            <ul aria-labelledby="website-links-category3-title">
+                                <li class="ep_item">
+                                    <a href="/the-president/en/" class="ep_button">
+                                        <span class="ep_hidden">Open in a new page</span>
+                                        <span class="ep_name">European Parliament President’s website</span>
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="ep_menu-access ep_closeaccess">
+                    <a href="#website-links-access" title="Hide menu">
+                        <span class="ep_name">Hide menu: News</span>
+                        <span class="ep_icon">&nbsp;</span>
+                    </a>
+                </div>
+            </div>
+            <div class="ep_europarllinks" id="europarl-links">
+                <h2 class="ep_title" id="europarl-links-title">
+                    <span class="ep_name">European Parliament</span>
+                    <span class="ep_icon">&nbsp;</span>
+                </h2>
+                <div class="ep_menu-access ep_openaccess" id="europarl-links-access" aria-controls="europarl-links-content" role="tab">
+                    <a href="#europarl-links" >
+                        <span class="ep_name">View menu: European Parliament</span>
+                        <span class="ep_icon">&nbsp;</span>
+                    </a>
+                </div>
+                <div class="ep_list">
+                    <ul id="europarl-links-content" aria-labelledby="europarl-links-title">
+                        <li class="ep_item">
+                            <a class="ep_button" href="/news/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">News</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/topics/en" >
+                                <span class="ep_name">Topics</span><span class="icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/meps/en/home" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">MEPs</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/about-parliament/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">About Parliament</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/plenary/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">Plenary</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/committees/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">Committees</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/delegations/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">Delegations</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="https://elections.europa.eu/en" >
+                                <span class="ep_name">Elections</span><span class="icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                    </ul>
+                </div>
+                <div class="ep_menu-access ep_closeaccess">
+                    <a href="#europarl-links-access" title="Hide menu"><span class="ep_name">Hide menu: European Parliament</span><span class="ep_icon">&nbsp;</span></a></div>
+            </div>
+        </div>
+        <span class="ep_footer-separator">&nbsp;</span>
+        <div class="ep_footer-otherlinks">
+            
+            <div class="ep_sociallinks" id="socialmedia">
+                <h2 class="ep_hidden" id="socialmedia-title">
+                    <span class="ep_name">The Parliament on social media</span>
+                    <span class="ep_icon">&nbsp;</span>
+                </h2>
+                <div class="ep_list">
+                    <ul aria-labelledby="socialmedia-title">
+                        <li class="ep_item">
+                            <a href="https://www.facebook.com/europeanparliament"  class="ep_button ep_facebook" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Facebook</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://twitter.com/Europarl_en" class="ep_button ep_twitter" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Twitter</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.flickr.com/photos/european_parliament/" class="ep_button ep_flickr"	target="_blank" >
+                                <span class="ep_name">Check out Parliament on Flickr</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.linkedin.com/company/european-parliament" class="ep_button ep_linkedin" target="_blank" >
+                                <span class="ep_name">Check out Parliament on LinkedIn</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.youtube.com/user/EuropeanParliament" class="ep_button ep_youtube" target="_blank" >
+                                <span class="ep_name">Check out Parliament on YouTube</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://instagram.com/europeanparliament" class="ep_button ep_instagram" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Instagram</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.pinterest.com/epinfographics/" class="ep_button ep_pinterest" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Pinterest</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.snapchat.com/add/europarl" class="ep_button ep_snapchat" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Snapchat</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.reddit.com/r/europeanparliament/" class="ep_button ep_reddit" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Reddit</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <!-- COMPOSANT "MANDATORY LINKS" -->
+            <div class="ep_mandatorylinks" id="informationlinks">
+                <h2 class="ep_hidden" id="informationlinks-title"><span class="ep_name">Information links</span><span class="ep_icon">&nbsp;</span></h2>
+                <div class="ep_list">
+                    <ul aria-labelledby="informationlinks-title">
+                        <li class="ep_item"><a href="/portal/en/contact"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Contact</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/at-your-service/en/stay-informed/rss-feeds"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">RSS</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/portal/en/sitemap"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Sitemap</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/legal-notice/en"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Legal notice</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/privacy-policy/en/"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Privacy policy</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/portal/en/accessibility"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Accessibility</span><span class="ep_icon">&nbsp;</span></a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+
+        
+    </div>
+
+    <!-- Backdrop / Gray Overlay for compact menu opening-->
+    <div class="back-overlay"></div>
+
+    
+    
+
+    
+    
+        <script>
+            (function rewriteUrlIfNeeded() {
+                function getHash(url) {
+                    return url.hash !== '' && document.getElementById(url.hash.slice(1)) ?
+                        url.hash :
+                        '';
+                }
+
+                function rewriteUrl(currentUrl, baseUrl) {
+                    // ensure that hash is present only if it actually exists
+                    const url = new URL(currentUrl);
+                    return `${baseUrl}${url.search}${getHash(url)}`;
+                }
+
+                // pre-condition: #dev_product_url ALWAYS exists see <input ...> above.
+                const productUrl = document.getElementById('dev_product_url').value;
+
+                if (productUrl === '') {
+                    return;
+                }
+
+                const newUrl = rewriteUrl(window.location.href, productUrl);
+
+                if (newUrl !== window.location.href) {
+                    window.history.replaceState(null, '', newUrl)
+                }
+            }())
+        </script>
+    
+
+        <script type="text/javascript">
+            // safari blinking workaround. Cf jira ENG-32999 & ENG-33001
+        </script>
+    </body>
+
+</html>

--- a/backend/tests/scrapers/test_press_releases.py
+++ b/backend/tests/scrapers/test_press_releases.py
@@ -26,3 +26,14 @@ def test_press_release_scraper(responses):
         fragment.data.get("facts")
         == "<ul><li>Faster roll-out of recharging stations needed on main EU roads</li><li>Easy to use and affordable recharging/refuelling</li><li>Fewer emissions in the maritime sector</li></ul>"
     )
+
+
+def test_press_release_scraper_new_procedure_urls(responses):
+    responses.get(
+        "https://www.europarl.europa.eu/news/en/press-room/20241212IPR25960",
+        body=load_fixture("scrapers/data/press_releases/press-release_20241212IPR25960.html"),
+    )
+
+    scraper = PressReleaseScraper(release_id="20241212IPR25960")
+    fragment = scraper.run()
+    assert fragment.data.get("procedure_reference") == ["2024/0275(COD)", "2024/0274(COD)"]

--- a/backend/tests/scrapers/test_press_releases.py
+++ b/backend/tests/scrapers/test_press_releases.py
@@ -1,0 +1,28 @@
+import datetime
+
+from howtheyvote.scrapers import PressReleaseScraper
+
+from ..helpers import load_fixture
+
+
+def test_press_release_scraper(responses):
+    responses.get(
+        "https://www.europarl.europa.eu/news/en/press-room/20221014IPR43206",
+        body=load_fixture("scrapers/data/press_releases/press-release_20221014IPR43206.html"),
+    )
+
+    scraper = PressReleaseScraper(release_id="20221014IPR43206")
+    fragment = scraper.run()
+
+    assert fragment.group_key == "20221014IPR43206"
+    assert (
+        fragment.data.get("title")
+        == "Car-recharging stations should be available every 60 km, say MEPs"
+    )
+    assert fragment.data.get("published_at") == datetime.datetime(2022, 10, 19, 13, 14, 0)
+    assert fragment.data.get("reference") == ["A9-0234/2022", "A9-0233/2022"]
+    assert fragment.data.get("procedure_reference") == ["2021/0223(COD)", "2021/0210(COD)"]
+    assert (
+        fragment.data.get("facts")
+        == "<ul><li>Faster roll-out of recharging stations needed on main EU roads</li><li>Easy to use and affordable recharging/refuelling</li><li>Fewer emissions in the maritime sector</li></ul>"
+    )


### PR DESCRIPTION
The OEIL URLs have changed from `https://oeil.secure.europarl.europa.eu/oeil/popups/ficheprocedure.do?lang=en&procedure=...` to `https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=...`. Old press releases still use the old-style links, so we have to support both.