### PR TITLE
Update Twitter test

### DIFF
--- a/backend/tests/scrapers/data/members/member_info_aaltola_home.html
+++ b/backend/tests/scrapers/data/members/member_info_aaltola_home.html
@@ -50,7 +50,7 @@
 
 	
 
-	<meta name="available" content="13-01-2025" />
+	<meta name="available" content="16-02-2025" />
 
 	
 		<link rel="canonical" href="https://www.europarl.europa.eu/meps/en/256810/MIKA_AALTOLA/home" />
@@ -1094,7 +1094,7 @@
 				
 				
 
-				<a class="link_twitt mr-2" href="https://x.com/MikaAaltola?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor"
+				<a class="link_twitt mr-2" href="https://x.com/MikaAaltola"
 				   target="_blank" data-toggle="tooltip" data-original-title="X">
 					<span class="sr-only">X</span>
 					<svg aria-hidden="true" class="es_icon es_icon-twitter-x">
@@ -1253,6 +1253,21 @@
 				
 				<!-- end status -->
 				
+				<!-- start status -->
+				<div class="badges">
+					
+						
+							<a href="/committees/en/euds"
+								class="erpl_badge erpl_badge-committee mr-1"
+								title="Special committee on the European Democracy Shield">EUDS</a>
+						
+						
+					
+				<div class="erpl_committee">Special committee on the European Democracy Shield</div>
+				</div>
+				
+				<!-- end status -->
+				
 				
 		</div>
 		
@@ -1274,6 +1289,21 @@
 						
 					
 				<div class="erpl_committee">Committee on International Trade</div>
+				</div>
+				
+				<!-- end status -->
+				
+				<!-- start status -->
+				<div class="badges">
+					
+						
+							<a href="/delegations/en/deea"
+								class="erpl_badge erpl_badge-committee mr-1"
+								title="Delegation for Northern cooperation and for relations with Switzerland and Norway and to the EU-Iceland Joint Parliamentary Committee and the European Economic Area (EEA) Joint Parliamentary Committee">DEEA</a>
+						
+						
+					
+				<div class="erpl_committee">Delegation for Northern cooperation and for relations with Switzerland and Norway and to the EU-Iceland Joint Parliamentary Committee and the European Economic Area (EEA) Joint Parliamentary Committee</div>
 				</div>
 				
 				<!-- end status -->
@@ -1330,13 +1360,11 @@
     	
 	        <h3 class="erpl_document-title erpl_title-h3 mb-0 a-i">        
 	        	
-		        	<a href="https://www.europarl.europa.eu/doceo/document/CRE-10-2024-12-17-INT-2017008826953_FI.html" class="t-y" target="">
+		        	<a href="https://www.europarl.europa.eu/doceo/document/CRE-10-2025-02-13-INT-2017015294368_EN.html" class="t-y" target="">
 		        
 		        		
-		        		<span class="t-item">Toppling of the Syrian regime, its geopolitical implications and the humanitarian situation in the region (debate)</span> 
+		        		<span class="t-item">Threats to EU sovereignty through strategic dependencies in communication infrastructure (debate)</span> 
 		        		
-		        		
-		        			<span class="erpl_badge erpl_badge-language ml-25">FI</span>
 		        		
 		        		
 		        
@@ -1360,7 +1388,7 @@
 
 
 
-<span class="erpl_document-subtitle-fragment ">17-12-2024</span>
+<span class="erpl_document-subtitle-fragment ">13-02-2025</span>
 
 
 
@@ -1376,7 +1404,7 @@
 
 
 
-<span class="erpl_document-subtitle-fragment ">P10_CRE-REV(2024)12-17(2-0090-0000)</span>
+<span class="erpl_document-subtitle-fragment ">P10_CRE-REV(2025)02-13(4-0142-0000)</span>
 
 
 
@@ -1444,10 +1472,10 @@
     	
 	        <h3 class="erpl_document-title erpl_title-h3 mb-0 a-i">        
 	        	
-		        	<a href="https://www.europarl.europa.eu/doceo/document/CRE-10-2024-12-17-INT-2017008917531_FI.html" class="t-y" target="">
+		        	<a href="https://www.europarl.europa.eu/doceo/document/CRE-10-2025-02-12-INT-2017015128602_FI.html" class="t-y" target="">
 		        
 		        		
-		        		<span class="t-item">Russia’s disinformation and historical falsification to justify its war of aggression against Ukraine (debate)</span> 
+		        		<span class="t-item">Need for targeted support to EU regions bordering Russia, Belarus and Ukraine (debate)</span> 
 		        		
 		        		
 		        			<span class="erpl_badge erpl_badge-language ml-25">FI</span>
@@ -1474,7 +1502,7 @@
 
 
 
-<span class="erpl_document-subtitle-fragment ">17-12-2024</span>
+<span class="erpl_document-subtitle-fragment ">12-02-2025</span>
 
 
 
@@ -1490,7 +1518,7 @@
 
 
 
-<span class="erpl_document-subtitle-fragment ">P10_CRE-REV(2024)12-17(2-0464-0000)</span>
+<span class="erpl_document-subtitle-fragment ">P10_CRE-REV(2025)02-12(3-0331-0000)</span>
 
 
 
@@ -1558,10 +1586,10 @@
     	
 	        <h3 class="erpl_document-title erpl_title-h3 mb-0 a-i">        
 	        	
-		        	<a href="https://www.europarl.europa.eu/doceo/document/CRE-10-2024-11-28-INT-2017006883545_FI.html" class="t-y" target="">
+		        	<a href="https://www.europarl.europa.eu/doceo/document/CRE-10-2025-02-11-INT-2017014847821_FI.html" class="t-y" target="">
 		        
 		        		
-		        		<span class="t-item">Strengthening children’s rights in the EU - 35th anniversary of the adoption of the United Nations Convention on the Rights of the Child (debate)</span> 
+		        		<span class="t-item">Continuing the unwavering EU support for Ukraine, after three years of Russia’s war of aggression (debate)</span> 
 		        		
 		        		
 		        			<span class="erpl_badge erpl_badge-language ml-25">FI</span>
@@ -1588,7 +1616,7 @@
 
 
 
-<span class="erpl_document-subtitle-fragment ">28-11-2024</span>
+<span class="erpl_document-subtitle-fragment ">11-02-2025</span>
 
 
 
@@ -1604,7 +1632,7 @@
 
 
 
-<span class="erpl_document-subtitle-fragment ">P10_CRE-REV(2024)11-28(4-0078-0000)</span>
+<span class="erpl_document-subtitle-fragment ">P10_CRE-REV(2025)02-11(2-0137-0000)</span>
 
 
 

--- a/backend/tests/scrapers/test_members.py
+++ b/backend/tests/scrapers/test_members.py
@@ -38,10 +38,7 @@ def test_member_info_scraper(responses):
         fragment.data.get("facebook")
         == "https://www.facebook.com/MikaAaltola2024/?locale=fi_FI"
     )
-    assert (
-        fragment.data.get("twitter")
-        == "https://x.com/MikaAaltola?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor"
-    )
+    assert fragment.data.get("twitter") == "https://x.com/MikaAaltola"
     assert fragment.data.get("email") == "mika.aaltola@europarl.europa.eu"
 
 


### PR DESCRIPTION
Tests were failing against the live data source as the tracking params were removed from the URL.