### PR TITLE
Scrape procedure committee

### DIFF
--- a/backend/howtheyvote/alembic/versions/3895af031aea_add_responsible_committee_column_to_.py
+++ b/backend/howtheyvote/alembic/versions/3895af031aea_add_responsible_committee_column_to_.py
@@ -1,0 +1,24 @@
+"""Add responsible_committee column to votes table
+
+Revision ID: 3895af031aea
+Revises: 2f958a6f147d
+Create Date: 2025-02-21 11:31:59.044124
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3895af031aea"
+down_revision = "2f958a6f147d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("votes", sa.Column("responsible_committee", sa.Unicode))
+
+
+def downgrade() -> None:
+    op.drop_column("votes", "responsible_committee")

--- a/backend/howtheyvote/api/openapi_spec.py
+++ b/backend/howtheyvote/api/openapi_spec.py
@@ -5,6 +5,7 @@ from .. import config
 from .openapi_helpers import get_schema, normalize_schema_name
 from .serializers import (
     BaseVoteDict,
+    CommitteeDict,
     CountryDict,
     EurovocConceptDict,
     GroupDict,
@@ -48,6 +49,7 @@ schema_classes = [
     MemberDict,
     GroupDict,
     CountryDict,
+    CommitteeDict,
     EurovocConceptDict,
     PlenarySessionDict,
     PlenarySessionsQueryResponseDict,

--- a/backend/howtheyvote/api/serializers.py
+++ b/backend/howtheyvote/api/serializers.py
@@ -2,6 +2,7 @@ import datetime
 from typing import Annotated, TypedDict
 
 from ..models import (
+    Committee,
     Country,
     EurovocConcept,
     Group,
@@ -67,6 +68,27 @@ def serialize_country(country: Country) -> CountryDict:
         "code": country.code,
         "iso_alpha_2": country.iso_alpha_2,
         "label": country.label,
+    }
+
+
+class CommitteeDict(TypedDict):
+    """Committee of the European Parliament"""
+
+    code: Annotated[str, "LIBE"]
+    """Unique identifier for the committee"""
+
+    label: Annotated[str, "Committee on Civil Liberties, Justice and Home Affairs"]
+    """Name of the committee"""
+
+    abbreviation: Annotated[str | None, "LIBE"]
+    """Abbreviation"""
+
+
+def serialize_committee(committee: Committee) -> CommitteeDict:
+    return {
+        "code": committee.code,
+        "label": committee.label,
+        "abbreviation": committee.abbreviation,
     }
 
 
@@ -236,10 +258,16 @@ class BaseVoteDict(TypedDict):
     """Concepts from the [EuroVoc](https://eur-lex.europa.eu/browse/eurovoc.html) thesaurus
     that are related to this vote"""
 
+    responsible_committee: CommitteeDict | None
+    """Committee responsible for the legislative procedure"""
+
 
 def serialize_base_vote(vote: Vote) -> BaseVoteDict:
     geo_areas = [serialize_country(geo_area) for geo_area in vote.geo_areas]
     eurovoc_concepts = [serialize_eurovoc_concept(ec) for ec in vote.eurovoc_concepts]
+    responsible_committee = (
+        serialize_committee(vote.responsible_committee) if vote.responsible_committee else None
+    )
 
     return {
         "id": vote.id,
@@ -250,6 +278,7 @@ def serialize_base_vote(vote: Vote) -> BaseVoteDict:
         "is_featured": vote.is_featured,
         "geo_areas": geo_areas,
         "eurovoc_concepts": eurovoc_concepts,
+        "responsible_committee": responsible_committee,
     }
 
 

--- a/backend/howtheyvote/api/votes_api.py
+++ b/backend/howtheyvote/api/votes_api.py
@@ -27,7 +27,6 @@ from .serializers import (
     VoteStatsDict,
     serialize_base_vote,
     serialize_country,
-    serialize_eurovoc_concept,
     serialize_group,
     serialize_member,
 )
@@ -236,19 +235,7 @@ def show(vote_id: int) -> Response:
     if not vote:
         return abort(404)
 
-    base_vote: BaseVoteDict = {
-        "id": vote.id,
-        "display_title": vote.display_title,
-        "timestamp": vote.timestamp,
-        "reference": vote.reference,
-        "description": vote.description,
-        "is_featured": vote.is_featured,
-        "geo_areas": [serialize_country(country) for country in vote.geo_areas],
-        "eurovoc_concepts": [
-            serialize_eurovoc_concept(concept) for concept in vote.eurovoc_concepts
-        ],
-    }
-
+    base_vote = serialize_base_vote(vote)
     procedure: ProcedureDict | None = None
 
     if vote.procedure_reference:

--- a/backend/howtheyvote/data.py
+++ b/backend/howtheyvote/data.py
@@ -51,8 +51,11 @@ class DataclassContainer(Generic[DataclassType]):
 
         self.index[key.lower()] = record
 
-    def get(self, key: str) -> DataclassType | None:
+    def get(self, key: str | None) -> DataclassType | None:
         """Get a record by key."""
+        if not key:
+            return None
+
         return self.index.get(key.lower())
 
     def __iter__(self) -> Iterator[DataclassType]:

--- a/backend/howtheyvote/data/committees.json
+++ b/backend/howtheyvote/data/committees.json
@@ -1,0 +1,429 @@
+[
+  {
+    "code": "AFCO",
+    "label": "Committee on Constitutional Affairs",
+    "abbreviation": "AFCO",
+    "start_date": "1982-01-21",
+    "end_date": null
+  },
+  {
+    "code": "AFET",
+    "label": "Committee on Foreign Affairs",
+    "abbreviation": "AFET",
+    "start_date": "1992-01-15",
+    "end_date": null
+  },
+  {
+    "code": "AGRI",
+    "label": "Committee on Agriculture and Rural Development",
+    "abbreviation": "AGRI",
+    "start_date": "1978-03-14",
+    "end_date": null
+  },
+  {
+    "code": "AIDA",
+    "label": "Special Committee on Artificial Intelligence in a Digital Age",
+    "abbreviation": "AIDA",
+    "start_date": "2020-09-14",
+    "end_date": null
+  },
+  {
+    "code": "ANIT",
+    "label": "Committee of Inquiry on the Protection of Animals during Transport",
+    "abbreviation": "ANIT",
+    "start_date": "2020-06-19",
+    "end_date": null
+  },
+  {
+    "code": "ASSOC",
+    "label": "Committee on Associations",
+    "abbreviation": "ASSOC",
+    "start_date": "1975-01-01",
+    "end_date": "1976-12-31"
+  },
+  {
+    "code": "BECA",
+    "label": "Special Committee on Beating Cancer",
+    "abbreviation": "BECA",
+    "start_date": "2020-09-14",
+    "end_date": null
+  },
+  {
+    "code": "BUDE",
+    "label": "European Parliament delegation to the Budgetary Conciliation Committee",
+    "abbreviation": "BUDE",
+    "start_date": "2019-07-14",
+    "end_date": null
+  },
+  {
+    "code": "BUDG",
+    "label": "Committee on Budgets",
+    "abbreviation": "BUDG",
+    "start_date": "1978-03-14",
+    "end_date": null
+  },
+  {
+    "code": "CODE",
+    "label": "Parliament\u2019s delegation to the Conciliation Committee",
+    "abbreviation": "CODE",
+    "start_date": "2004-01-19",
+    "end_date": "2018-07-14"
+  },
+  {
+    "code": "CONT",
+    "label": "Committee on Budgetary Control",
+    "abbreviation": "CONT",
+    "start_date": "1979-07-19",
+    "end_date": null
+  },
+  {
+    "code": "CRIM",
+    "label": "Special Committee on Organised Crime, Corruption and Money Laundering",
+    "abbreviation": "CRIM",
+    "start_date": "2012-03-28",
+    "end_date": "2013-10-23"
+  },
+  {
+    "code": "CRIS",
+    "label": "Special Committee on the Financial, Economic and Social Crisis",
+    "abbreviation": "CRIS",
+    "start_date": "2009-10-07",
+    "end_date": "2011-07-31"
+  },
+  {
+    "code": "CULT",
+    "label": "Committee on Culture and Education",
+    "abbreviation": "CULT",
+    "start_date": "1979-07-19",
+    "end_date": null
+  },
+  {
+    "code": "DELCON",
+    "label": "Delegation to the Conciliation Committee",
+    "abbreviation": "DELCON",
+    "start_date": "1994-07-01",
+    "end_date": null
+  },
+  {
+    "code": "DEVE",
+    "label": "Committee on Development",
+    "abbreviation": "DEVE",
+    "start_date": "1978-03-14",
+    "end_date": null
+  },
+  {
+    "code": "DROI",
+    "label": "Subcommittee on Human Rights",
+    "abbreviation": "DROI",
+    "start_date": "1992-01-15",
+    "end_date": null
+  },
+  {
+    "code": "ECON",
+    "label": "Committee on Economic and Monetary Affairs",
+    "abbreviation": "ECON",
+    "start_date": "1978-03-14",
+    "end_date": null
+  },
+  {
+    "code": "EMIS",
+    "label": "Committee of Inquiry into Emission Measurements in the Automotive Sector",
+    "abbreviation": "EMIS",
+    "start_date": "2016-01-20",
+    "end_date": "2017-04-04"
+  },
+  {
+    "code": "EMPL",
+    "label": "Committee on Employment and Social Affairs",
+    "abbreviation": "EMPL",
+    "start_date": "1978-03-14",
+    "end_date": null
+  },
+  {
+    "code": "ENVI",
+    "label": "Committee on the Environment, Public Health and Food Safety",
+    "abbreviation": "ENVI",
+    "start_date": "1962-03-30",
+    "end_date": null
+  },
+  {
+    "code": "EQUI",
+    "label": "Committee of Inquiry into the crisis of the Equitable Life Assurance Society",
+    "abbreviation": "EQUI",
+    "start_date": "2006-01-18",
+    "end_date": "2007-06-19"
+  },
+  {
+    "code": "FEMM",
+    "label": "Committee on Women\u2019s Rights and Gender Equality",
+    "abbreviation": "FEMM",
+    "start_date": "1984-07-26",
+    "end_date": null
+  },
+  {
+    "code": "FISC",
+    "label": "Subcommittee on Tax Matters",
+    "abbreviation": "FISC",
+    "start_date": "2020-09-14",
+    "end_date": null
+  },
+  {
+    "code": "GER_UNIFIC",
+    "label": "Temporary Committee on the Impact of German unification on the EC",
+    "abbreviation": "GER_UNIFIC",
+    "start_date": "1990-01-01",
+    "end_date": "1990-12-31"
+  },
+  {
+    "code": "IMCO",
+    "label": "Committee on the Internal Market and Consumer Protection",
+    "abbreviation": "IMCO",
+    "start_date": "2004-07-20",
+    "end_date": null
+  },
+  {
+    "code": "IMMU",
+    "label": "Committee on the Rules of Procedure, the Verification of Credentials and Immunities",
+    "abbreviation": "IMMU",
+    "start_date": "1982-01-21",
+    "end_date": "1999-07-19"
+  },
+  {
+    "code": "INGE",
+    "label": "Special Committee on Foreign Interference in all Democratic Processes in the European Union, including Disinformation",
+    "abbreviation": "INGE",
+    "start_date": "2020-09-14",
+    "end_date": null
+  },
+  {
+    "code": "INQWOM",
+    "label": "Committee of inquiry into the situation of women in Europe",
+    "abbreviation": "INQWOM",
+    "start_date": "1982-01-21",
+    "end_date": "1984-07-23"
+  },
+  {
+    "code": "INTA",
+    "label": "Committee on International Trade",
+    "abbreviation": "INTA",
+    "start_date": "2004-07-20",
+    "end_date": null
+  },
+  {
+    "code": "ITRE",
+    "label": "Committee on Industry, Research and Energy",
+    "abbreviation": "ITRE",
+    "start_date": "1978-03-14",
+    "end_date": null
+  },
+  {
+    "code": "JURI",
+    "label": "Committee on Legal Affairs",
+    "abbreviation": "JURI",
+    "start_date": "1978-03-14",
+    "end_date": null
+  },
+  {
+    "code": "LIBE",
+    "label": "Committee on Civil Liberties, Justice and Home Affairs",
+    "abbreviation": "LIBE",
+    "start_date": "1992-01-15",
+    "end_date": null
+  },
+  {
+    "code": "PANA",
+    "label": "Committee of Inquiry into Money Laundering, Tax Avoidance and Tax Evasion",
+    "abbreviation": "PANA",
+    "start_date": "2016-06-23",
+    "end_date": "2019-07-01"
+  },
+  {
+    "code": "PECH",
+    "label": "Committee on Fisheries",
+    "abbreviation": "PECH",
+    "start_date": "1994-07-21",
+    "end_date": null
+  },
+  {
+    "code": "PEST",
+    "label": "Special Committee on the Union\u2019s authorisation procedure for pesticides",
+    "abbreviation": "PEST",
+    "start_date": "2018-02-08",
+    "end_date": "2018-12-12"
+  },
+  {
+    "code": "PETI",
+    "label": "Committee on Petitions",
+    "abbreviation": "PETI",
+    "start_date": "1962-03-30",
+    "end_date": null
+  },
+  {
+    "code": "POLI",
+    "label": "Political Affairs Committee",
+    "abbreviation": "POLI",
+    "start_date": "1978-03-14",
+    "end_date": "1992-01-14"
+  },
+  {
+    "code": "REGI",
+    "label": "Committee on Regional Development",
+    "abbreviation": "REGI",
+    "start_date": "1978-03-14",
+    "end_date": null
+  },
+  {
+    "code": "RELA",
+    "label": "Committee on External Economic Relations",
+    "abbreviation": "RELA",
+    "start_date": "1978-03-14",
+    "end_date": "1999-07-19"
+  },
+  {
+    "code": "SC_MONAFF",
+    "label": "Subcommittee on Monetary Affairs",
+    "abbreviation": "SC_MONAFF",
+    "start_date": "1992-04-27",
+    "end_date": "1999-07-19"
+  },
+  {
+    "code": "SC_PECH",
+    "label": "Subcommittee on Fisheries",
+    "abbreviation": "SC_PECH",
+    "start_date": "1992-01-15",
+    "end_date": "1994-07-18"
+  },
+  {
+    "code": "SC_SEDIS",
+    "label": "Subcommittee on Security and Disarmament",
+    "abbreviation": "SC_SEDIS",
+    "start_date": "1992-01-15",
+    "end_date": "1999-07-19"
+  },
+  {
+    "code": "SEDE",
+    "label": "Subcommittee on Security and Defence",
+    "abbreviation": "SEDE",
+    "start_date": "2004-07-20",
+    "end_date": null
+  },
+  {
+    "code": "STOA",
+    "label": "Panel for the Future of Science and Technology",
+    "abbreviation": "STOA",
+    "start_date": "1992-05-26",
+    "end_date": null
+  },
+  {
+    "code": "SURE",
+    "label": "Special committee on the policy challenges and budgetary resources for a sustainable European Union after 2013",
+    "abbreviation": "SURE",
+    "start_date": "2010-06-16",
+    "end_date": "2011-06-30"
+  },
+  {
+    "code": "TAX2",
+    "label": "Special Committee on Tax Rulings and Other Measures Similar in Nature or Effect (TAXE 2)",
+    "abbreviation": "TAXE 2",
+    "start_date": "2015-12-02",
+    "end_date": "2016-08-02"
+  },
+  {
+    "code": "TAX3",
+    "label": "Special committee on financial crimes, tax evasion and tax avoidance",
+    "abbreviation": "TAX3",
+    "start_date": "2018-03-01",
+    "end_date": "2019-03-28"
+  },
+  {
+    "code": "TAXE",
+    "label": "Special Committee on Tax Rulings and Other Measures Similar in Nature or Effect",
+    "abbreviation": "TAXE",
+    "start_date": "2015-02-12",
+    "end_date": "2015-12-01"
+  },
+  {
+    "code": "TC_BSE",
+    "label": "Temporary committee instructed to monitor the action taken on the recommendations made concerning BSE (bovine spongiform encephalopathy)",
+    "abbreviation": "TC_BSE",
+    "start_date": "1996-07-18",
+    "end_date": "1997-11-19"
+  },
+  {
+    "code": "TC_CLIM",
+    "label": "Temporary Committee on Climate Change",
+    "abbreviation": "TC_CLIM",
+    "start_date": "2007-04-25",
+    "end_date": "2009-02-04"
+  },
+  {
+    "code": "TC_CTS",
+    "label": "Temporary committee of Inquiry into the Community Transit System",
+    "abbreviation": "TC_CTS",
+    "start_date": "1995-12-14",
+    "end_date": "1997-03-13"
+  },
+  {
+    "code": "TC_ECHE",
+    "label": "Temporary committee on the Echelon interception system",
+    "abbreviation": "TC_ECHE",
+    "start_date": "2000-07-05",
+    "end_date": "2001-09-05"
+  },
+  {
+    "code": "TC_EMPL",
+    "label": "Temporary committee on employment",
+    "abbreviation": "TC_EMPL",
+    "start_date": "1994-07-21",
+    "end_date": "1995-07-19"
+  },
+  {
+    "code": "TC_FIAP",
+    "label": "Temporary committee on foot and mouth disease",
+    "abbreviation": "TC_FIAP",
+    "start_date": "2002-01-15",
+    "end_date": "2002-12-17"
+  },
+  {
+    "code": "TC_FINP",
+    "label": "Temporary committee on policy challenges and budgetary means of the enlarged Union 2007-2013",
+    "abbreviation": "TC_FINP",
+    "start_date": "2004-10-13",
+    "end_date": "2005-06-08"
+  },
+  {
+    "code": "TC_GENE",
+    "label": "Temporary committee on human genetics and other new technologies in modern medicine",
+    "abbreviation": "TC_GENE",
+    "start_date": "2000-12-13",
+    "end_date": "2001-11-29"
+  },
+  {
+    "code": "TC_MARE",
+    "label": "Temporary committee on improving safety at sea",
+    "abbreviation": "TC_MARE",
+    "start_date": "2003-11-06",
+    "end_date": "2004-04-21"
+  },
+  {
+    "code": "TC_TDIP",
+    "label": "Temporary Committee on the alleged use of European countries by the CIA for the transport and illegal detention of prisoners",
+    "abbreviation": "TC_TDIP",
+    "start_date": "2006-01-18",
+    "end_date": "2007-02-14"
+  },
+  {
+    "code": "TERR",
+    "label": "Special Committee on Terrorism",
+    "abbreviation": "TERR",
+    "start_date": "2017-09-12",
+    "end_date": "2018-11-14"
+  },
+  {
+    "code": "TRAN",
+    "label": "Committee on Transport and Tourism",
+    "abbreviation": "TRAN",
+    "start_date": "1979-07-19",
+    "end_date": null
+  }
+]

--- a/backend/howtheyvote/export/__init__.py
+++ b/backend/howtheyvote/export/__init__.py
@@ -143,6 +143,9 @@ class VoteRow(TypedDict):
     procedure_title: str | None
     """Title of the legislative procedure as listed in the Legislative Observatory"""
 
+    responsible_committee_code: str | None
+    """Committee responsible for the legislative procedure"""
+
 
 class MemberVoteRow(TypedDict):
     """Each row represents how an MEP voted in a roll-call vote."""
@@ -335,6 +338,10 @@ class Export:
                 if idx % 1000 == 0:
                     log.info("Writing vote", index=idx)
 
+                responsible_committee_code = (
+                    vote.responsible_committee.code if vote.responsible_committee else None
+                )
+
                 votes.write_row(
                     {
                         "id": vote.id,
@@ -346,6 +353,7 @@ class Export:
                         "is_featured": vote.is_featured,
                         "procedure_reference": vote.procedure_reference,
                         "procedure_title": vote.procedure_title,
+                        "responsible_committee_code": responsible_committee_code,
                     }
                 )
 

--- a/backend/howtheyvote/models/__init__.py
+++ b/backend/howtheyvote/models/__init__.py
@@ -1,3 +1,4 @@
+from .committee import Committee, CommitteeType
 from .common import Base, BaseWithId, DataIssue, Fragment, PipelineRun, PipelineStatus
 from .country import Country, CountryType
 from .eurovoc import EurovocConcept, EurovocConceptType
@@ -31,6 +32,8 @@ __all__ = [
     "Group",
     "EurovocConcept",
     "EurovocConceptType",
+    "Committee",
+    "CommitteeType",
     "PlenarySession",
     "PlenarySessionLocation",
     "PlenarySessionStatus",

--- a/backend/howtheyvote/models/committee.py
+++ b/backend/howtheyvote/models/committee.py
@@ -1,0 +1,62 @@
+import dataclasses
+import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.engine import Dialect
+from sqlalchemy.types import TypeDecorator
+
+from ..data import DATA_DIR, DataclassContainer, DeserializableDataclass
+
+
+class CommitteeMeta(type):
+    def __getitem__(cls, key: str) -> "Committee":
+        committee = committees.get(key)
+
+        if not committee:
+            raise KeyError()
+
+        return committee
+
+
+@dataclasses.dataclass(frozen=True)
+class Committee(DeserializableDataclass, metaclass=CommitteeMeta):
+    code: str
+    label: str
+    abbreviation: str
+    start_date: datetime.date
+    end_date: datetime.date | None
+
+    def __hash__(self) -> int:
+        return hash(self.code)
+
+    @classmethod
+    def get(cls, key: str) -> "Committee | None":
+        try:
+            return cls[key]
+        except KeyError:
+            return None
+
+
+committees = DataclassContainer(
+    dataclass=Committee,
+    file_path=DATA_DIR.joinpath("committees.json"),
+    key_attr="code",
+)
+committees.load()
+
+
+class CommitteeType(TypeDecorator[Committee]):
+    impl = sa.Unicode
+    cache_ok = True
+
+    def process_bind_param(self, value: Committee | None, dialect: Dialect) -> str | None:
+        if not value:
+            return None
+
+        return value.code
+
+    def process_result_value(self, value: str | None, dialect: Dialect) -> Committee | None:
+        if not value:
+            return None
+
+        return committees.get(value)

--- a/backend/howtheyvote/models/vote.py
+++ b/backend/howtheyvote/models/vote.py
@@ -9,6 +9,7 @@ from sqlalchemy.engine import Dialect
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.types import TypeDecorator
 
+from .committee import Committee, CommitteeType
 from .common import BaseWithId, DataIssue
 from .country import Country, CountryType
 from .eurovoc import EurovocConcept, EurovocConceptType
@@ -89,6 +90,7 @@ class Vote(BaseWithId):
     eurovoc_concepts: Mapped[list[EurovocConcept]] = mapped_column(
         ListType(EurovocConceptType())
     )
+    responsible_committee: Mapped[Committee] = mapped_column(CommitteeType())
     issues: Mapped[list[DataIssue]] = mapped_column(ListType(sa.Enum(DataIssue)))
 
     @property

--- a/backend/howtheyvote/store/mappings.py
+++ b/backend/howtheyvote/store/mappings.py
@@ -1,6 +1,7 @@
 import datetime
 
 from ..models import (
+    Committee,
     Country,
     Member,
     PlenarySession,
@@ -59,6 +60,7 @@ def map_vote(record: CompositeRecord) -> Vote:
     member_votes = [deserialize_member_vote(mv) for mv in record.first("member_votes")]
     geo_areas = {Country[code] for code in record.chain("geo_areas")}
     eurovoc_concepts = {EurovocConcept[id_] for id_ in record.chain("eurovoc_concepts")}
+    responsible_committee = Committee.get(record.first("responsible_committee"))
 
     return Vote(
         id=record.group_key,
@@ -77,6 +79,7 @@ def map_vote(record: CompositeRecord) -> Vote:
         member_votes=member_votes,
         geo_areas=geo_areas,
         eurovoc_concepts=eurovoc_concepts,
+        responsible_committee=responsible_committee,
         issues=record.chain("issues"),
     )
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,7 +26,9 @@ dependencies = [
 ]
 
 [tool.poetry]
-package-mode = false
+packages = [
+    { include = "./howtheyvote" }
+]
 
 [project.scripts]
 htv = "howtheyvote.cli:cli"

--- a/backend/tests/api/test_votes_api.py
+++ b/backend/tests/api/test_votes_api.py
@@ -536,6 +536,7 @@ def test_votes_api_show(records, db_session, api):
         ],
         "geo_areas": [],
         "eurovoc_concepts": [],
+        "responsible_committee": None,
         "related": [],
         "sources": [
             {

--- a/backend/tests/export/test_init.py
+++ b/backend/tests/export/test_init.py
@@ -138,8 +138,8 @@ def test_export_votes(db_session, tmp_path):
     votes_meta = tmp_path.joinpath("votes.csv-metadata.json")
 
     expected = (
-        "id,timestamp,display_title,reference,description,is_main,is_featured,procedure_reference,procedure_title\n"
-        "123456,2024-01-01 00:00:00,Lorem Ipsum,,,False,False,,\n"
+        "id,timestamp,display_title,reference,description,is_main,is_featured,procedure_reference,procedure_title,responsible_committee_code\n"
+        "123456,2024-01-01 00:00:00,Lorem Ipsum,,,False,False,,,\n"
     )
 
     assert votes_csv.read_text() == expected

--- a/backend/tests/scrapers/test_votes.py
+++ b/backend/tests/scrapers/test_votes.py
@@ -248,6 +248,7 @@ def test_procedure_scraper(responses):
         data={
             "procedure_title": "Implementation of the 2018 Geoblocking Regulation in the Digital Single Market",
             "geo_areas": [],
+            "responsible_committee": "IMCO",
         },
     )
 


### PR DESCRIPTION
This PR includes changes to scrape the committee responsible for the legislative procedure a vote belongs to. We already scrape information about the procedure from the OEIL, so I simply extended what information the existing scraper extracts.

Similar to countries and political groups, I’ve loaded a list of all committees using the SPARQL endpoint of the Publications Office.

I’ve added the responsible committee to API responses and the CSV export, but for now it’s not displayed in the UI or available as a filter etc.