### PR TITLE
Match press releases and votes based on vote result

### DIFF
--- a/backend/howtheyvote/alembic/versions/2fb74cc3d20c_add_text_and_position_counts_column_to_press_releases_table.py
+++ b/backend/howtheyvote/alembic/versions/2fb74cc3d20c_add_text_and_position_counts_column_to_press_releases_table.py
@@ -1,0 +1,26 @@
+"""Add text and position_counts column to press_releases table
+
+Revision ID: 2fb74cc3d20c
+Revises: 3895af031aea
+Create Date: 2025-02-23 13:13:56.054579
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2fb74cc3d20c"
+down_revision = "3895af031aea"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("press_releases", sa.Column("text", sa.Unicode))
+    op.add_column("press_releases", sa.Column("position_counts", sa.JSON))
+
+
+def downgrade() -> None:
+    op.drop_column("press_releases", "text")
+    op.drop_column("press_releases", "position_counts")

--- a/backend/howtheyvote/alembic/versions/848ef24718dd_add_press_release_column_to_votes_table.py
+++ b/backend/howtheyvote/alembic/versions/848ef24718dd_add_press_release_column_to_votes_table.py
@@ -1,0 +1,24 @@
+"""Add press_release column to votes table
+
+Revision ID: 848ef24718dd
+Revises: 2fb74cc3d20c
+Create Date: 2025-03-01 21:27:44.628151
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "848ef24718dd"
+down_revision = "2fb74cc3d20c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("votes", sa.Column("press_release", sa.Unicode))
+
+
+def downgrade() -> None:
+    op.drop_column("votes", "press_release")

--- a/backend/howtheyvote/analysis/__init__.py
+++ b/backend/howtheyvote/analysis/__init__.py
@@ -1,14 +1,14 @@
 from .press_releases import VotePositionCountsAnalyzer
 from .votes import (
-    FeaturedVotesAnalyzer,
     MainVoteAnalyzer,
+    PressReleaseAnalyzer,
     VoteDataIssuesAnalyzer,
     VoteGroupsAnalyzer,
     VoteGroupsDataIssuesAnalyzer,
 )
 
 __all__ = [
-    "FeaturedVotesAnalyzer",
+    "PressReleaseAnalyzer",
     "MainVoteAnalyzer",
     "VoteDataIssuesAnalyzer",
     "VoteGroupsAnalyzer",

--- a/backend/howtheyvote/analysis/__init__.py
+++ b/backend/howtheyvote/analysis/__init__.py
@@ -1,3 +1,4 @@
+from .press_releases import VotePositionCountsAnalyzer
 from .votes import (
     FeaturedVotesAnalyzer,
     MainVoteAnalyzer,
@@ -12,4 +13,5 @@ __all__ = [
     "VoteDataIssuesAnalyzer",
     "VoteGroupsAnalyzer",
     "VoteGroupsDataIssuesAnalyzer",
+    "VotePositionCountsAnalyzer",
 ]

--- a/backend/howtheyvote/analysis/helpers.py
+++ b/backend/howtheyvote/analysis/helpers.py
@@ -1,0 +1,85 @@
+import re
+
+from ..models import VotePositionCounts
+
+NUMBER_REGEX = r"(one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|\d+)"
+
+INTEGER_WORDS = {
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+    "ten": 10,
+    "eleven": 11,
+    "twelve": 12,
+}
+
+
+def parse_int(text: str) -> int:
+    """Converts a string representation of a number (either a string of digits or
+    the English language word for integers up to 12) to a Python integer. Raises a
+    ValueError if the input cannot be parsed."""
+    if text.lower() in INTEGER_WORDS:
+        return INTEGER_WORDS[text.lower()]
+
+    return int(text)
+
+
+VOTE_RESULT_REGEX = re.compile(
+    NUMBER_REGEX
+    + r"\s(?:votes?|MEPs? voted)\sin\sfavou?r,\s"
+    + NUMBER_REGEX
+    + r"\sagainst,?\s(?:and|with)\s"
+    + NUMBER_REGEX
+    + r"\s(?:abstentions?|abstained)",
+    flags=re.I,
+)
+
+VOTE_RESULT_REGEX_ADOPTED = re.compile(
+    r"adopted\swith\s"
+    + NUMBER_REGEX
+    + r"\svotes\sto\s"
+    + NUMBER_REGEX
+    + r"\sand\s"
+    + NUMBER_REGEX
+    + r"\sabstentions"
+)
+
+
+def extract_vote_results(text: str) -> list[VotePositionCounts]:
+    matches = VOTE_RESULT_REGEX.finditer(text)
+    results: list[VotePositionCounts] = []
+
+    for match in matches:
+        try:
+            results.append(
+                {
+                    "FOR": parse_int(match.group(1)),
+                    "AGAINST": parse_int(match.group(2)),
+                    "ABSTENTION": parse_int(match.group(3)),
+                    "DID_NOT_VOTE": 0,
+                }
+            )
+        except ValueError:
+            continue
+
+    matches = VOTE_RESULT_REGEX_ADOPTED.finditer(text)
+    for match in matches:
+        try:
+            results.append(
+                {
+                    "FOR": parse_int(match.group(1)),
+                    "AGAINST": parse_int(match.group(2)),
+                    "ABSTENTION": parse_int(match.group(3)),
+                    "DID_NOT_VOTE": 0,
+                }
+            )
+        except ValueError:
+            continue
+
+    return results

--- a/backend/howtheyvote/analysis/press_releases.py
+++ b/backend/howtheyvote/analysis/press_releases.py
@@ -1,0 +1,27 @@
+from ..models import Fragment
+from .helpers import extract_vote_results
+
+
+class VotePositionCountsAnalyzer:
+    """Extracts mentioned vote position counts from press release text."""
+
+    def __init__(self, release_id: str, text: str):
+        self.release_id = release_id
+        self.text = text
+
+    def run(self) -> Fragment | None:
+        if not self.text:
+            return None
+
+        position_counts = extract_vote_results(self.text)
+
+        if not position_counts:
+            return None
+
+        return Fragment(
+            model="PressRelease",
+            source_id=self.release_id,
+            source_name=type(self).__name__,
+            group_key=self.release_id,
+            data={"position_counts": position_counts},
+        )

--- a/backend/howtheyvote/analysis/votes.py
+++ b/backend/howtheyvote/analysis/votes.py
@@ -142,11 +142,11 @@ class MainVoteAnalyzer:
         return False
 
 
-class FeaturedVotesAnalyzer:
-    """This analyzer takes a set of press releases and a set of votes (typically from
-    # the same session) and finds matches between the two sets based on document or
-    # procedure references. If a press release exists for a vote, we consider it to be
-    # particularly relevant and assign a flag that can be used for filtering."""
+class PressReleaseAnalyzer:
+    """This analyzer takes a set of press releases and a set of votes (typically from the
+    same session) and finds matches between the two sets. If we find a match, we store a
+    reference to the press release in the vote record. This can later be used to display
+    press release excerpts for a vote, for search results ranking, etc."""
 
     def __init__(self, votes: Iterable[Vote], press_releases: Iterable[PressRelease]):
         self.votes = votes
@@ -185,8 +185,20 @@ class FeaturedVotesAnalyzer:
                     source_id=f"{vote.id}:{release_id}",
                     source_name=type(self).__name__,
                     group_key=vote.id,
-                    data={"is_featured": True},
+                    data={"press_release": release_id},
                 )
+
+    def _by_reference(self, vote: Vote) -> set[str]:
+        if not vote.reference:
+            return set()
+
+        return self.by_reference[vote.reference]
+
+    def _by_procedure_reference(self, vote: Vote) -> set[str]:
+        if not vote.procedure_reference:
+            return set()
+
+        return self.by_procedure_reference[vote.procedure_reference]
 
 
 class VoteDataIssuesAnalyzer:

--- a/backend/howtheyvote/api/votes_api.py
+++ b/backend/howtheyvote/api/votes_api.py
@@ -10,7 +10,7 @@ from structlog import get_logger
 from ..db import Session
 from ..helpers import PROCEDURE_REFERENCE_REGEX, REFERENCE_REGEX, flatten_dict, subset_dict
 from ..models import Fragment, Member, PressRelease, Vote
-from ..query import fragments_for_records, press_release_references_vote
+from ..query import fragments_for_records
 from ..vote_stats import count_vote_positions, count_vote_positions_by_group
 from .query import DatabaseQuery, Order, Query, SearchQuery
 from .serializers import (
@@ -369,7 +369,10 @@ def _load_fragments(vote: Vote, press_release: PressRelease | None) -> Iterable[
 
 
 def _load_press_release(vote: Vote) -> PressRelease | None:
-    stmt = select(PressRelease).where(press_release_references_vote(vote))
+    if not vote.press_release:
+        return None
+
+    stmt = select(PressRelease).where(PressRelease.id == vote.press_release)
     return Session.execute(stmt).scalar()
 
 

--- a/backend/howtheyvote/models/__init__.py
+++ b/backend/howtheyvote/models/__init__.py
@@ -16,6 +16,7 @@ from .vote import (
     Vote,
     VoteGroup,
     VotePosition,
+    VotePositionCounts,
     deserialize_member_vote,
     serialize_member_vote,
 )
@@ -40,6 +41,7 @@ __all__ = [
     "GroupMembership",
     "Member",
     "VotePosition",
+    "VotePositionCounts",
     "MemberVote",
     "Vote",
     "VoteGroup",

--- a/backend/howtheyvote/models/press_release.py
+++ b/backend/howtheyvote/models/press_release.py
@@ -4,6 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .common import BaseWithId
+from .vote import VotePositionCounts
 
 
 class PressRelease(BaseWithId):
@@ -16,3 +17,7 @@ class PressRelease(BaseWithId):
     references: Mapped[list[str]] = mapped_column(sa.JSON)
     procedure_references: Mapped[list[str]] = mapped_column(sa.JSON)
     facts: Mapped[str] = mapped_column(sa.Unicode)
+    text: Mapped[str] = mapped_column(sa.Unicode)
+    position_counts: Mapped[list[VotePositionCounts]] = mapped_column(
+        sa.JSON(none_as_null=True)
+    )

--- a/backend/howtheyvote/models/vote.py
+++ b/backend/howtheyvote/models/vote.py
@@ -69,6 +69,13 @@ class MemberVoteType(TypeDecorator[MemberVote]):
         return deserialize_member_vote(value)
 
 
+class VotePositionCounts(TypedDict):
+    FOR: int
+    AGAINST: int
+    ABSTENTION: int
+    DID_NOT_VOTE: int
+
+
 class Vote(BaseWithId):
     __tablename__ = "votes"
 

--- a/backend/howtheyvote/models/vote.py
+++ b/backend/howtheyvote/models/vote.py
@@ -98,6 +98,7 @@ class Vote(BaseWithId):
         ListType(EurovocConceptType())
     )
     responsible_committee: Mapped[Committee] = mapped_column(CommitteeType())
+    press_release: Mapped[str | None] = mapped_column(sa.Unicode)
     issues: Mapped[list[DataIssue]] = mapped_column(ListType(sa.Enum(DataIssue)))
 
     @property

--- a/backend/howtheyvote/scrapers/press_releases.py
+++ b/backend/howtheyvote/scrapers/press_releases.py
@@ -164,6 +164,7 @@ class PressReleaseScraper(BeautifulSoupScraper):
                 "reference": self._references(doc),
                 "procedure_reference": self._procedure_references(doc),
                 "facts": self._facts(doc),
+                "text": self._text(doc),
             },
         )
 
@@ -188,6 +189,15 @@ class PressReleaseScraper(BeautifulSoupScraper):
         items = [item.text.strip() for item in list_.select("li")]
         items = [f"<li>{item}</li>" for item in items]
         return "<ul>" + "".join(items) + "</ul>"
+
+    def _text(self, doc: BeautifulSoup) -> str | None:
+        paragraphs = doc.select(
+            'article[role="main"] :where(.ep-wysiwig_paragraph, .ep-a_text p)'
+        )
+        text = "\n\n".join(
+            [p.get_text(strip=True) for p in paragraphs if p.get_text(strip=True)]
+        )
+        return text if text else None
 
     def _published_at(self, doc: BeautifulSoup) -> datetime.datetime | None:
         element = doc.select_one('.ep_subtitle time[itemprop="datePublished"]')

--- a/backend/howtheyvote/store/index.py
+++ b/backend/howtheyvote/store/index.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable
 from typing import TypeVar, cast
 
 from sqlalchemy.dialects.sqlite import insert
@@ -24,7 +24,7 @@ RecordType = TypeVar("RecordType", bound=BaseWithId)
 
 def index_records(
     model_cls: type[RecordType],
-    records: Iterator[RecordType],
+    records: Iterable[RecordType],
     chunk_size: int | None = None,
 ) -> None:
     """Writes aggregated records to the database and search backend."""
@@ -57,7 +57,11 @@ def index_db(model_cls: type[RecordType], records: Iterable[RecordType]) -> None
         log.warning("Skipping indexing to database as list of records is empty")
         return
 
-    log.info("Writing aggregated records to database.", count=len(values))
+    log.info(
+        "Writing aggregated records to database.",
+        model=model_cls.__name__,
+        count=len(values),
+    )
 
     stmt = insert(model_cls).values(values)
     stmt = stmt.on_conflict_do_update(

--- a/backend/howtheyvote/store/mappings.py
+++ b/backend/howtheyvote/store/mappings.py
@@ -62,6 +62,9 @@ def map_vote(record: CompositeRecord) -> Vote:
     eurovoc_concepts = {EurovocConcept[id_] for id_ in record.chain("eurovoc_concepts")}
     responsible_committee = Committee.get(record.first("responsible_committee"))
 
+    press_release = record.first("press_release")
+    is_featured = record.first("is_featured") or press_release is not None
+
     return Vote(
         id=record.group_key,
         timestamp=datetime.datetime.fromisoformat(record.first("timestamp")),
@@ -74,12 +77,13 @@ def map_vote(record: CompositeRecord) -> Vote:
         procedure_title=record.first("procedure_title"),
         procedure_reference=record.first("procedure_reference"),
         is_main=record.first("is_main") or False,
-        is_featured=record.first("is_featured") or False,
+        is_featured=is_featured,
         group_key=record.first("group_key"),
         member_votes=member_votes,
         geo_areas=geo_areas,
         eurovoc_concepts=eurovoc_concepts,
         responsible_committee=responsible_committee,
+        press_release=press_release,
         issues=record.chain("issues"),
     )
 

--- a/backend/howtheyvote/store/mappings.py
+++ b/backend/howtheyvote/store/mappings.py
@@ -111,4 +111,6 @@ def map_press_release(record: CompositeRecord) -> PressRelease:
         references=record.chain("reference"),
         procedure_references=record.chain("procedure_reference"),
         facts=record.first("facts"),
+        text=record.first("text"),
+        position_counts=record.first("position_counts"),
     )

--- a/backend/howtheyvote/vote_stats.py
+++ b/backend/howtheyvote/vote_stats.py
@@ -1,0 +1,53 @@
+from collections import defaultdict
+from collections.abc import Callable
+from typing import TypeVar
+
+from .models import MemberVote, VotePositionCounts
+
+GroupBy = TypeVar("GroupBy")
+
+
+def count_vote_positions(member_votes: list[MemberVote]) -> VotePositionCounts:
+    """Calculates the number of MEPs that voted for/against/abstention for the given
+    list of member votes."""
+    counts: VotePositionCounts = {
+        "FOR": 0,
+        "AGAINST": 0,
+        "ABSTENTION": 0,
+        "DID_NOT_VOTE": 0,
+    }
+
+    for member_vote in member_votes:
+        counts[member_vote.position.value] += 1
+
+    return counts
+
+
+def count_vote_positions_by_group(
+    member_votes: list[MemberVote],
+    group_by: Callable[[MemberVote], GroupBy],
+) -> dict[GroupBy, VotePositionCounts]:
+    """Calculates the number of MEPs that voted for/against/abstention for the given
+    list of member votes for each group. The second argument is a function that returns
+    the group for each member vote."""
+    grouped_member_votes: dict[GroupBy, list[MemberVote]] = defaultdict(list)
+
+    for member_vote in member_votes:
+        group = group_by(member_vote)
+        grouped_member_votes[group].append(member_vote)
+
+    # Sort by group size
+    grouped_member_votes = dict(
+        sorted(
+            grouped_member_votes.items(),
+            key=lambda item: len(item[1]),
+            reverse=True,
+        )
+    )
+
+    grouped_counts: dict[GroupBy, VotePositionCounts] = {}
+
+    for group, member_votes in grouped_member_votes.items():
+        grouped_counts[group] = count_vote_positions(member_votes)
+
+    return grouped_counts

--- a/backend/tests/analysis/test_helpers.py
+++ b/backend/tests/analysis/test_helpers.py
@@ -1,0 +1,45 @@
+import pytest
+
+from howtheyvote.analysis.helpers import extract_vote_results, parse_int
+
+
+def test_parse_int():
+    assert parse_int("1") == 1
+    assert parse_int("one") == 1
+    assert parse_int("One") == 1
+    assert parse_int("12") == 12
+    assert parse_int("twelve") == 12
+
+    with pytest.raises(ValueError):
+        assert parse_int("")
+
+    with pytest.raises(ValueError):
+        assert parse_int("invalid")
+
+
+def test_extract_vote_results():
+    for example in [
+        "400 votes in favour, 63 against with 81 abstentions",
+        "400 votes in favor, 63 against with 81 abstentions",
+        "400 votes in favour, 63 against, with 81 abstentions",
+        "400 votes in favour, 63 against and 81 abstentions",
+        "400 votes in favour, 63 against, and 81 abstentions",
+        "400 MEPs voted in favour, 63 against and 81 abstained",
+        "400 MEPs voted in favour, 63 against, and 81 abstained",
+        "400 MEPs voted in favor, 63 against, and 81 abstained",
+    ]:
+        expected = [{"FOR": 400, "AGAINST": 63, "ABSTENTION": 81, "DID_NOT_VOTE": 0}]
+        actual = extract_vote_results(example)
+        assert actual == expected
+
+    expected = [{"FOR": 500, "AGAINST": 143, "ABSTENTION": 9, "DID_NOT_VOTE": 0}]
+    actual = extract_vote_results("500 votes in favour, 143 against, and nine abstentions")
+    assert actual == expected
+
+    expected = [{"FOR": 1, "AGAINST": 1, "ABSTENTION": 1, "DID_NOT_VOTE": 0}]
+    actual = extract_vote_results("one vote in favour, one against, and one abstention")
+    assert actual == expected
+
+    expected = [{"FOR": 455, "AGAINST": 85, "ABSTENTION": 105, "DID_NOT_VOTE": 0}]
+    actual = extract_vote_results("adopted with 455 votes to 85 and 105 abstentions")
+    assert actual == expected

--- a/backend/tests/analysis/test_press_releases.py
+++ b/backend/tests/analysis/test_press_releases.py
@@ -1,0 +1,74 @@
+from howtheyvote.analysis.press_releases import VotePositionCountsAnalyzer
+from howtheyvote.models import Fragment
+
+from ..helpers import record_to_dict
+
+
+def test_vote_position_counts_analyzer():
+    analyzer = VotePositionCountsAnalyzer(
+        release_id="20250204IPR26689",
+        text="The text was adopted by 400 votes in favour, 63 against with 81 abstentions.",
+    )
+    expected = Fragment(
+        model="PressRelease",
+        source_id="20250204IPR26689",
+        source_name="VotePositionCountsAnalyzer",
+        group_key="20250204IPR26689",
+        data={
+            "position_counts": [
+                {
+                    "FOR": 400,
+                    "AGAINST": 63,
+                    "ABSTENTION": 81,
+                    "DID_NOT_VOTE": 0,
+                },
+            ],
+        },
+    )
+    assert record_to_dict(analyzer.run()) == record_to_dict(expected)
+
+
+def test_vote_position_counts_analyzer_multiple_counts():
+    analyzer = VotePositionCountsAnalyzer(
+        release_id="20190711IPR56828",
+        text="The text was adopted with 458 votes in favour, 80 against and 89 abstentions. The text was adopted with 330 votes in favour, 252 against and 55 abstentions",
+    )
+    expected = Fragment(
+        model="PressRelease",
+        source_id="20190711IPR56828",
+        source_name="VotePositionCountsAnalyzer",
+        group_key="20190711IPR56828",
+        data={
+            "position_counts": [
+                {
+                    "FOR": 458,
+                    "AGAINST": 80,
+                    "ABSTENTION": 89,
+                    "DID_NOT_VOTE": 0,
+                },
+                {
+                    "FOR": 330,
+                    "AGAINST": 252,
+                    "ABSTENTION": 55,
+                    "DID_NOT_VOTE": 0,
+                },
+            ],
+        },
+    )
+    assert record_to_dict(analyzer.run()) == record_to_dict(expected)
+
+
+def test_vote_position_counts_analyzer_no_text():
+    analyzer = VotePositionCountsAnalyzer(
+        release_id="20250219IPR26999",
+        text=None,
+    )
+    assert analyzer.run() is None
+
+
+def test_vote_position_counts_analyzer_no_counts():
+    analyzer = VotePositionCountsAnalyzer(
+        release_id="20250219IPR26999",
+        text="EU and Ukrainian flags will be flown at the European Parliament’s three sites from Sunday 23 February to Tuesday 25 February, marking three years since Russia’s invasion.",
+    )
+    assert analyzer.run() is None

--- a/backend/tests/analysis/test_votes.py
+++ b/backend/tests/analysis/test_votes.py
@@ -1,5 +1,5 @@
-from howtheyvote.analysis.votes import MainVoteAnalyzer
-from howtheyvote.models.common import Fragment
+from howtheyvote.analysis.votes import MainVoteAnalyzer, PressReleaseAnalyzer
+from howtheyvote.models import Fragment, PressRelease, Vote
 
 from ..helpers import record_to_dict
 
@@ -62,3 +62,57 @@ def test_main_vote_analyzer_title():
         title="Élection de la Commission",
     )
     assert record_to_dict(analyzer.run()) == record_to_dict(expected)
+
+
+def test_press_release_analyzer_by_reference():
+    press_releases = [
+        PressRelease(id="20240223IPR18077", references=["A9-0051/2024"]),
+        PressRelease(id="20240223IPR18074", references=[]),
+    ]
+
+    votes = [
+        Vote(id="1", reference=None, is_main=True),
+        Vote(id="2", reference="A9-0051/2024", is_main=True),
+        Vote(id="3", reference="A9-0051/2024", is_main=False),
+    ]
+
+    analyzer = PressReleaseAnalyzer(votes, press_releases)
+    fragments = list(analyzer.run())
+
+    expected = Fragment(
+        model="Vote",
+        source_id="2:20240223IPR18077",
+        source_name="PressReleaseAnalyzer",
+        group_key="2",
+        data={"press_release": "20240223IPR18077"},
+    )
+
+    assert len(fragments) == 1
+    assert record_to_dict(fragments[0]) == record_to_dict(expected)
+
+
+def test_press_release_analyzer_by_procedure_reference():
+    press_releases = [
+        PressRelease(id="20241111IPR25339", procedure_references=["2024/2718(RSP)"]),
+        PressRelease(id="20241111IPR25341", procedure_references=[]),
+    ]
+
+    votes = [
+        Vote(id="1", procedure_reference=None, is_main=True),
+        Vote(id="2", procedure_reference="2024/2718(RSP)", is_main=True),
+        Vote(id="3", procedure_reference="2024/2718(RSP)", is_main=False),
+    ]
+
+    analyzer = PressReleaseAnalyzer(votes, press_releases)
+    fragments = list(analyzer.run())
+
+    expected = Fragment(
+        model="Vote",
+        source_id="2:20241111IPR25339",
+        source_name="PressReleaseAnalyzer",
+        group_key="2",
+        data={"press_release": "20241111IPR25339"},
+    )
+
+    assert len(fragments) == 1
+    assert record_to_dict(fragments[0]) == record_to_dict(expected)

--- a/backend/tests/analysis/test_votes.py
+++ b/backend/tests/analysis/test_votes.py
@@ -1,5 +1,7 @@
+import datetime
+
 from howtheyvote.analysis.votes import MainVoteAnalyzer, PressReleaseAnalyzer
-from howtheyvote.models import Fragment, PressRelease, Vote
+from howtheyvote.models import Fragment, MemberVote, PressRelease, Vote, VotePosition
 
 from ..helpers import record_to_dict
 
@@ -66,14 +68,40 @@ def test_main_vote_analyzer_title():
 
 def test_press_release_analyzer_by_reference():
     press_releases = [
-        PressRelease(id="20240223IPR18077", references=["A9-0051/2024"]),
-        PressRelease(id="20240223IPR18074", references=[]),
+        PressRelease(
+            id="20240223IPR18077",
+            published_at=datetime.datetime(2024, 2, 27, 12, 51, 0),
+            references=["A9-0051/2024"],
+        ),
+        PressRelease(
+            id="20240223IPR18074",
+            published_at=datetime.datetime(2024, 2, 27, 12, 27, 0),
+            references=[],
+        ),
     ]
 
     votes = [
-        Vote(id="1", reference=None, is_main=True),
-        Vote(id="2", reference="A9-0051/2024", is_main=True),
-        Vote(id="3", reference="A9-0051/2024", is_main=False),
+        Vote(
+            id="1",
+            timestamp=datetime.datetime(2024, 2, 27, 0, 0, 0),
+            reference=None,
+            is_main=True,
+            member_votes=[],
+        ),
+        Vote(
+            id="2",
+            timestamp=datetime.datetime(2024, 2, 27, 0, 0, 0),
+            reference="A9-0051/2024",
+            is_main=True,
+            member_votes=[],
+        ),
+        Vote(
+            id="3",
+            timestamp=datetime.datetime(2024, 2, 27, 0, 0, 0),
+            reference="A9-0051/2024",
+            is_main=False,
+            member_votes=[],
+        ),
     ]
 
     analyzer = PressReleaseAnalyzer(votes, press_releases)
@@ -93,14 +121,40 @@ def test_press_release_analyzer_by_reference():
 
 def test_press_release_analyzer_by_procedure_reference():
     press_releases = [
-        PressRelease(id="20241111IPR25339", procedure_references=["2024/2718(RSP)"]),
-        PressRelease(id="20241111IPR25341", procedure_references=[]),
+        PressRelease(
+            id="20241111IPR25339",
+            published_at=datetime.datetime(2024, 11, 14, 11, 55, 0),
+            procedure_references=["2024/2718(RSP)"],
+        ),
+        PressRelease(
+            id="20241111IPR25341",
+            published_at=datetime.datetime(2024, 11, 14, 12, 2, 0),
+            procedure_references=[],
+        ),
     ]
 
     votes = [
-        Vote(id="1", procedure_reference=None, is_main=True),
-        Vote(id="2", procedure_reference="2024/2718(RSP)", is_main=True),
-        Vote(id="3", procedure_reference="2024/2718(RSP)", is_main=False),
+        Vote(
+            id="1",
+            timestamp=datetime.datetime(2024, 11, 14, 0, 0, 0),
+            procedure_reference=None,
+            is_main=True,
+            member_votes=[],
+        ),
+        Vote(
+            id="2",
+            timestamp=datetime.datetime(2024, 11, 14, 0, 0, 0),
+            procedure_reference="2024/2718(RSP)",
+            is_main=True,
+            member_votes=[],
+        ),
+        Vote(
+            id="3",
+            timestamp=datetime.datetime(2024, 11, 14, 0, 0, 0),
+            procedure_reference="2024/2718(RSP)",
+            is_main=False,
+            member_votes=[],
+        ),
     ]
 
     analyzer = PressReleaseAnalyzer(votes, press_releases)
@@ -116,3 +170,172 @@ def test_press_release_analyzer_by_procedure_reference():
 
     assert len(fragments) == 1
     assert record_to_dict(fragments[0]) == record_to_dict(expected)
+
+
+def _make_member_votes(for_: int, against: int, abstention: int) -> list[MemberVote]:
+    member_votes = []
+    member_id = 0
+
+    for _ in range(for_):
+        member_id += 1
+        member_votes.append(
+            MemberVote(web_id=member_id, position=VotePosition.FOR),
+        )
+
+    for _ in range(against):
+        member_id += 1
+        member_votes.append(
+            MemberVote(web_id=member_id, position=VotePosition.AGAINST),
+        )
+
+    for _ in range(abstention):
+        member_id += 1
+        member_votes.append(
+            MemberVote(web_id=member_id, position=VotePosition.ABSTENTION),
+        )
+
+    return member_votes
+
+
+def test_press_release_analyzer_by_position_counts():
+    press_releases = [
+        PressRelease(
+            id="20250204IPR26689",
+            published_at=datetime.datetime(2025, 2, 13, 12, 47, 0),
+            position_counts=[
+                {"FOR": 400, "AGAINST": 63, "ABSTENTION": 81, "DID_NOT_VOTE": 0},
+            ],
+        ),
+        PressRelease(id="20250213IPR26920", position_counts=[]),
+        PressRelease(
+            id="20250206IPR26752",
+            published_at=datetime.datetime(2025, 2, 13, 12, 59, 0),
+            position_counts=[
+                {"FOR": 443, "AGAINST": 4, "ABSTENTION": 48, "DID_NOT_VOTE": 0},
+            ],
+        ),
+    ]
+
+    votes = [
+        Vote(
+            id="1",
+            timestamp=datetime.datetime(2025, 2, 13, 0, 0, 0),
+            is_main=True,
+            member_votes=_make_member_votes(398, 65, 81),
+        ),
+        Vote(
+            id="2",
+            timestamp=datetime.datetime(2025, 2, 13, 0, 0, 0),
+            is_main=True,
+            member_votes=_make_member_votes(400, 63, 81),
+        ),
+    ]
+
+    analyzer = PressReleaseAnalyzer(votes, press_releases)
+    fragments = list(analyzer.run())
+
+    expected = Fragment(
+        model="Vote",
+        source_id="2:20250204IPR26689",
+        source_name="PressReleaseAnalyzer",
+        group_key="2",
+        data={"press_release": "20250204IPR26689"},
+    )
+
+    assert len(fragments) == 1
+    assert record_to_dict(fragments[0]) == record_to_dict(expected)
+
+
+def test_press_release_analyzer_by_position_counts_multiple_counts():
+    # If a press release contains multiple vote results, don't try to match it
+    # to votes as it might be about multiple unrelated votes.
+    press_releases = [
+        PressRelease(
+            id="20250116IPR26326",
+            position_counts=[
+                {"FOR": 556, "AGAINST": 6, "ABSTENTION": 42, "DID_NOT_VOTE": 0},
+                {"FOR": 533, "AGAINST": 24, "ABSTENTION": 48, "DID_NOT_VOTE": 0},
+            ],
+        )
+    ]
+
+    votes = [
+        Vote(
+            id="1",
+            timestamp=datetime.datetime(2025, 1, 23, 0, 0, 0),
+            is_main=True,
+            member_votes=_make_member_votes(556, 6, 42),
+        ),
+        Vote(
+            id="2",
+            timestamp=datetime.datetime(2025, 1, 23, 0, 0, 0),
+            is_main=True,
+            member_votes=_make_member_votes(533, 24, 48),
+        ),
+    ]
+
+    analyzer = PressReleaseAnalyzer(votes, press_releases)
+    fragments = list(analyzer.run())
+
+    assert fragments == []
+
+
+def test_press_release_analyzer_by_position_counts_multiple_votes():
+    # If there are multiple votes with the same number of votes for/against/abstention,
+    # don’t try to match it as it is ambiguous.
+    press_releases = [
+        PressRelease(
+            id="abc",
+            published_at=datetime.datetime(2025, 1, 1, 0, 0, 0),
+            position_counts=[
+                {"FOR": 200, "AGAINST": 200, "ABSTENTION": 200, "DID_NOT_VOTE": 0},
+            ],
+        )
+    ]
+
+    votes = [
+        Vote(
+            id="1",
+            timestamp=datetime.datetime(2025, 1, 1, 0, 0, 0),
+            is_main=True,
+            member_votes=_make_member_votes(200, 200, 200),
+        ),
+        Vote(
+            id="2",
+            timestamp=datetime.datetime(2025, 1, 1, 0, 0, 0),
+            is_main=True,
+            member_votes=_make_member_votes(200, 200, 200),
+        ),
+    ]
+
+    analyzer = PressReleaseAnalyzer(votes, press_releases)
+    fragments = list(analyzer.run())
+
+    assert fragments == []
+
+
+def test_press_release_analyzer_by_position_counts_different_dates():
+    # Do not match press releases and votes with same position counts but different dates
+    press_releases = [
+        PressRelease(
+            id="abc",
+            published_at=datetime.datetime(2025, 1, 1, 0, 0, 0),
+            position_counts=[
+                {"FOR": 200, "AGAINST": 200, "ABSTENTION": 200, "DID_NOT_VOTE": 0},
+            ],
+        )
+    ]
+
+    votes = [
+        Vote(
+            id="1",
+            is_main=True,
+            timestamp=datetime.datetime(2025, 1, 2, 0, 0, 0),
+            member_votes=_make_member_votes(200, 200, 200),
+        ),
+    ]
+
+    analyzer = PressReleaseAnalyzer(votes, press_releases)
+    fragments = list(analyzer.run())
+
+    assert fragments == []

--- a/backend/tests/scrapers/data/press_releases/press-release_20190712IPR56948.html
+++ b/backend/tests/scrapers/data/press_releases/press-release_20190712IPR56948.html
@@ -1,0 +1,2089 @@
+<!DOCTYPE html>
+<html lang="en">
+
+    
+    <head>
+
+    
+    
+        
+
+    
+
+    <title>Venezuela: European Parliament calls for additional sanctions  | News | European Parliament</title>
+    <meta property="og:title" content="Venezuela: European Parliament calls for additional sanctions  | News | European Parliament"/>
+    <meta property="twitter:title" content="Venezuela: European Parliament calls for additional sanctions  | News | European Parliament"/>
+    <meta itemprop="name" content="Venezuela: European Parliament calls for additional sanctions  | News | European Parliament"/>
+    <meta name="description" content="For the third time this year, the European Parliament adopted a resolution on the situation in Venezuela, expressing its deep concern at the severe state of emergency"/>
+    <meta property="og:description" content="For the third time this year, the European Parliament adopted a resolution on the situation in Venezuela, expressing its deep concern at the severe state of emergency"/>
+    <meta property="twitter:description" content="For the third time this year, the European Parliament adopted a resolution on the situation in Venezuela, expressing its deep concern at the severe state of emergency"/>
+    <meta itemprop="description" content="For the third time this year, the European Parliament adopted a resolution on the situation in Venezuela, expressing its deep concern at the severe state of emergency"/>
+    <meta charset="UTF-8"/>
+
+    
+    <meta name="available" content="18-07-2019"/>
+
+    <meta http-equiv="last-modified" content="2019-07-18 11:37:00.0"/>
+
+    <meta name="language" content="en"/>
+    <meta name="planet" content="news"/>
+    <link rel="canonical" href="https://www.europarl.europa.eu/news/en/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"/>
+    <meta property="og:url" content="https://www.europarl.europa.eu/news/en/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"/>
+    
+        
+        
+            <meta name="robots" content="index, follow, noodp, noydir, notranslate, noarchive"/>
+        
+    
+    <meta property="og:type" content="article"/>
+
+    
+    
+    
+        <meta property="og:image" content="https://www.europarl.europa.eu/news/img/meta-facebook.jpg"/>
+        <meta property="twitter:image" content="https://www.europarl.europa.eu/news/img/meta-twitter.jpg"/>
+    
+
+
+
+    
+        <meta name="keywords" content="productType:PRESS_RELEASE,plenaryDate:15-07-2019"/>
+    
+    <meta name="routes" content="productSubType:PLENARY_SESSION"/>
+
+
+    
+    
+
+    
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+
+    <link rel="stylesheet" type="text/css" href="/news/css/header-ep.css"/>
+
+    
+        
+    <link rel="stylesheet" type="text/css" href="/news/css/atomicdesign.css"/>
+    <link rel="stylesheet" type="text/css" href="/news/css/components-ep.css"/>
+    <link rel="stylesheet" type="text/css" href="/news/css/structure.css"/>
+    <noscript>
+        <link rel="stylesheet" type="text/css" href="/news/css/no-js.css" />
+    </noscript>
+
+    
+
+    <noscript>
+        <link rel="stylesheet" type="text/css" href="/news/css/header-ep-nojs.css"/>
+    </noscript>
+    
+
+    <script type="text/javascript" defer data-tracker-name="ATInternet"
+            data-value="/website/webanalytics/ati-news.js"
+            src="/website/privacy-policy/privacy-policy.js"></script>
+
+    
+        <script>
+            /*<![CDATA[*/
+            // AMD define stub: delay handling of define calls until our amd dependency
+            // manager has been loaded (from behaviour.js)
+
+            var __amd$delayedDefines = []
+            function define() {
+                var args = Array.prototype.slice.call(arguments)
+                window.__amd$delayedDefines.push(function () {
+                    window.define.apply(window, args)
+                })
+            }
+            define.amd = {}
+            define('eng-scripts',
+                {
+                    'weekly-agenda-widget': { url: "\/news\/js\/weekly-agenda-widget.js", fetched: false }
+                    , 'weekly-agenda': { url: "\/news\/js\/weekly-agenda.js", fetched: false }
+                    , 'week-selector': { url: "\/news\/js\/week-selector.js", fetched: false }
+                    , 'tst-continuous-loading': { url: "\/news\/js\/tst-continuous-loading.js", fetched: false }
+                    , 'slideshow': { url: "\/news\/js\/slideshow.js", fetched: false }
+                    , 'load-more': { url: "\/news\/js\/load-more.js", fetched: false }
+                    , 'infographic': { url: "\/news\/js\/infographic.js", fetched: false }
+                    , 'filter-form': { url: "\/news\/js\/filter-form.js", fetched: false }
+                    , 'datepicker': { url: "\/news\/js\/datepicker.js", fetched: false }
+                    , 'video-player': { url: "\/news\/js\/video-player.js", fetched: false }
+                    , 'election-results': { url: "\/website\/election-results\/js\/ep_electionresults_app.js", fetched: false }
+                    , 'ec-sml-loader': { url: "\/news\/js\/ec-sml-loader.js", fetched: false }
+                    , 'quiz-loader': { url: "https:\/\/quizweb.europarl.europa.eu\/embed\/js\/ep-ee19-quiz.js", fetched: false }
+                    , 'timeline': { url: "\/news\/js\/timeline.js", fetched: false }
+                }
+            )
+            define( 'global', { document: window.document, window: window } )
+            /*]]>*/
+        </script>
+
+        <script async="async" type="text/javascript" src="/news/js/behaviour.js"></script>
+
+        <script type="text/javascript">
+            define('change-language', [ 'behaviour.js'], function moduleFactory() {
+                Select.updateparams('language-select', {cb_beforesubmit: function() {
+                        window.location.href = document.getElementById('language-select').value;
+                        return false;
+                    }})
+            })
+        </script>
+    
+
+
+    
+    <script defer type="text/javascript" src="/news/js/bundle.js"></script>
+
+
+    
+
+    
+    
+        
+    
+
+    
+    
+        
+    
+
+
+
+</head>
+
+    
+    <body lang="en">
+
+    
+    <input type="hidden" value="https://www.europarl.europa.eu/news/en/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions" id="dev_product_url"/>
+
+    
+    <div id="website">
+
+        
+        
+            
+
+    
+    
+    
+    
+
+    <div id="website-header" class="ep-header">
+        <!-- COMPOSANT "WAI SHORTCUTS" -->
+        <nav class="wai-shortcut" aria-label="Shortcuts">
+            <ul id="waimenu">
+                <li><a href="#website-body"><span class="label">Access to page content (press &quot;Enter&quot;)</span></a></li>
+                <li><a href="#language-select"><span class="label">Direct access to language menu (press &quot;Enter&quot;)</span></a></li>
+                <li><a href="#search-field"><span class="label">Direct access to search menu (press &quot;Enter&quot;)</span></a></li>
+            </ul>
+        </nav>
+
+        <!-- START OF REFACTORING -->
+
+        <!-- COMPOSANT "TOOLBAR" TOP -->
+        <div class="toolbar toolbar_top">
+            <div class="toolbar-grid m-column no-padding-m">
+                <!-- COMPOSANT "LANGUAGE MENU" -->
+                <div class="dropdown-lang" id="language-select">
+                    <!-- Select language no js -->
+                    <noscript>
+                        <div class="dropdown">
+                            <div class="dropdown-lang no-js">
+                                <div class="wrapper-dropdown-lang">
+                                    <form method="get" action="/news/changeLanguage" aria-label="Navigation">
+                                        <div class="select">
+                                            <label for="change_language_nojs" class="sr-only">Change the navigation language</label>
+                                            <select id="change_language_nojs" name="url" required>
+                                                <!-- // TODO : values need to be set by -->
+                                                <option
+                                                        lang="bg"
+                                                        value="/news/bg/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >BG - български</option>
+                                                <option
+                                                        lang="es"
+                                                        value="/news/es/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >ES - español</option>
+                                                <option
+                                                        lang="cs"
+                                                        value="/news/cs/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >CS - čeština</option>
+                                                <option
+                                                        lang="da"
+                                                        value="/news/da/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >DA - dansk</option>
+                                                <option
+                                                        lang="de"
+                                                        value="/news/de/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >DE - Deutsch</option>
+                                                <option
+                                                        lang="et"
+                                                        value="/news/et/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >ET - eesti keel</option>
+                                                <option
+                                                        lang="el"
+                                                        value="/news/el/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >EL - ελληνικά</option>
+                                                <option
+                                                        lang="en"
+                                                        value="/news/en/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >EN - English</option>
+                                                <option
+                                                        lang="fr"
+                                                        value="/news/fr/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >FR - français</option>
+                                                <option
+                                                        lang="ga"
+                                                        value="/news/ga/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >GA - Gaeilge</option>
+                                                <option
+                                                        lang="hr"
+                                                        value="/news/hr/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >HR - hrvatski</option>
+                                                <option
+                                                        lang="it"
+                                                        value="/news/it/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >IT - italiano</option>
+                                                <option
+                                                        lang="lv"
+                                                        value="/news/lv/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >LV - latviešu valoda</option>
+                                                <option
+                                                        lang="lt"
+                                                        value="/news/lt/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >LT - lietuvių kalba</option>
+                                                <option
+                                                        lang="hu"
+                                                        value="/news/hu/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >HU - magyar</option>
+                                                <option
+                                                        lang="mt"
+                                                        value="/news/mt/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >MT - Malti</option>
+                                                <option
+                                                        lang="nl"
+                                                        value="/news/nl/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >NL - Nederlands</option>
+                                                <option
+                                                        lang="pl"
+                                                        value="/news/pl/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >PL - polski</option>
+                                                <option
+                                                        lang="pt"
+                                                        value="/news/pt/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >PT - português</option>
+                                                <option
+                                                        lang="ro"
+                                                        value="/news/ro/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >RO - română</option>
+                                                <option
+                                                        lang="sk"
+                                                        value="/news/sk/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >SK - slovenčina</option>
+                                                <option
+                                                        lang="sl"
+                                                        value="/news/sl/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >SL - slovenščina</option>
+                                                <option
+                                                        lang="fi"
+                                                        value="/news/fi/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >FI - suomi</option>
+                                                <option
+                                                        lang="sv"
+                                                        value="/news/sv/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions"
+                                                >SV - svenska</option>
+                                            </select>
+                                        </div>
+                                        <button type="submit" class="btn">Change the navigation language</button>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </noscript>
+                    <!-- End Select language no js -->
+                    <nav class="custom-select dropdown" aria-label="Change the navigation language">
+                        <button id="dropdown" class="btn lang_select" type="submit" aria-haspopup="true" aria-expanded="false">EN - English</button>
+                        <ul class="no-display menu-content">
+
+                            <li>
+                                <a
+                                   lang="bg"
+                                   hreflang="bg"
+                                   href="/news/bg/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">BG - български</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="es"
+                                   hreflang="es"
+                                   href="/news/es/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">ES - español</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="cs"
+                                   hreflang="cs"
+                                   href="/news/cs/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">CS - čeština</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="da"
+                                   hreflang="da"
+                                   href="/news/da/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">DA - dansk</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="de"
+                                   hreflang="de"
+                                   href="/news/de/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">DE - Deutsch</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="et"
+                                   hreflang="et"
+                                   href="/news/et/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">ET - eesti keel</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="el"
+                                   hreflang="el"
+                                   href="/news/el/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">EL - ελληνικά</span></span>
+                                </a>
+                            </li>
+
+                            <li class="current" aria-current="true">
+                                <a
+                                   lang="en"
+                                   hreflang="en"
+                                   href="/news/en/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">EN - English</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="fr"
+                                   hreflang="fr"
+                                   href="/news/fr/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">FR - français</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="ga"
+                                   hreflang="ga"
+                                   href="/news/ga/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">GA - Gaeilge</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="hr"
+                                   hreflang="hr"
+                                   href="/news/hr/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">HR - hrvatski</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="it"
+                                   hreflang="it"
+                                   href="/news/it/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">IT - italiano</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="lv"
+                                   hreflang="lv"
+                                   href="/news/lv/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">LV - latviešu valoda</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="lt"
+                                   hreflang="lt"
+                                   href="/news/lt/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">LT - lietuvių kalba</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="hu"
+                                   hreflang="hu"
+                                   href="/news/hu/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">HU - magyar</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="mt"
+                                   hreflang="mt"
+                                   href="/news/mt/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">MT - Malti</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="nl"
+                                   hreflang="nl"
+                                   href="/news/nl/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">NL - Nederlands</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="pl"
+                                   hreflang="pl"
+                                   href="/news/pl/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">PL - polski</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="pt"
+                                   hreflang="pt"
+                                   href="/news/pt/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">PT - português</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="ro"
+                                   hreflang="ro"
+                                   href="/news/ro/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">RO - română</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="sk"
+                                   hreflang="sk"
+                                   href="/news/sk/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">SK - slovenčina</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="sl"
+                                   hreflang="sl"
+                                   href="/news/sl/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">SL - slovenščina</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="fi"
+                                   hreflang="fi"
+                                   href="/news/fi/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">FI - suomi</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="sv"
+                                   hreflang="sv"
+                                   href="/news/sv/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions">
+                                    <span class="wrapper-label"><span class="label">SV - svenska</span></span>
+                                </a>
+                            </li>
+                        </ul>
+                    </nav>
+                </div>
+                <!-- COMPOSANT "OTHER TOOLS LINKS" -->
+                <nav class="navigation-menu nav-top" aria-label="Navigation">
+                    <div class="menu-container">
+                        <div class="focusable">
+                            <!--href ?  -->
+                            <a role="button" class="btn-open-menu" aria-haspopup="true" aria-expanded="false" tabindex="0">View other websites</a>
+                            <ul class="menu-level-0" aria-label="View menu: News">
+                                <li class="level-0">
+                                    <a class="" href="/news/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">News</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/topics/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">Topics</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/meps/en/home" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">MEPs</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/about-parliament/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">About Parliament</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/plenary/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">Plenary</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/committees/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">Committees</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0 nopadding-right">
+                                    <a class="" href="/delegations/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">Delegations</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0 nopadding-right">
+                                    <a class="" href="https://elections.europa.eu/en">
+                          <span class="content">
+
+                            <span class="label">Elections</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0 has-menu-dropdown">
+                                    <a role="button" class="icon-arrow-dropdown" id="otherWebsitesLink" aria-haspopup="true" aria-expanded="false" tabindex="0">
+                                      <span class="content">
+                                          <span class="sr-only">View submenu:</span>
+                                          <span class="label">Other websites</span>
+                                      </span>
+                                    </a>
+                                    <ul class="menu-level-1">
+                                        <li class="level-1">
+                                            <a href="https://multimedia.europarl.europa.eu/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Multimedia Centre</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/the-president/en/" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">President’s website</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/the-secretary-general/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Secretariat-general</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/thinktank/en/home.html" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Think tank</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="https://www.epnewshub.eu" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">EP Newshub</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/at-your-service/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">At your service</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/visiting/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Visits</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/legislative-train" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Legislative train</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/contracts-and-grants/en/" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Contracts and Grants</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/RegistreWeb/home/welcome.htm?language=en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Register</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="https://data.europarl.europa.eu/en/home" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Open Data Portal</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="https://liaison-offices.europarl.europa.eu/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Liaison offices</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </div>
+                        <!--<input class="menu-btn" type="checkbox" id="menu-btn-navigationtop" aria-label="Click to open the other websites menu" />
+                        <label class="menu-icon" for="menu-btn-navigationtop">View other websites</label>-->
+                    </div>
+                </nav>
+            </div>
+        </div>
+        <!-- LOGO + TITLE -->
+        <header class="header">
+            <div class="header-wrapper no-padding">
+                <!--<a class="grid" href="https://www.europarl.europa.eu/portal/en">
+                  <span class="sr-only">Go back to the Europarl portal</span>
+                  <img src="../europarl/img/ep-logo.svg" alt="" class="ep_logo" />
+                </a>-->
+                <div class="grid">
+				<span class="title-wrapper">
+					
+					<a href="/news/en" class="title"><span class="labeltxt">News</span></a>
+					<a href="/portal/en" class="subtitle">
+                      <span class="labeltxt">European Parliament</span>
+                      <span class="logo"></span>
+                    </a>
+				</span>
+                </div>
+            </div>
+        </header>
+        <!-- COMPOSANT "TOOLBAR" BOTTOM -->
+        <div class="toolbar toolbar_bottom sticky">
+            <div class="toolbar-grid no-padding flex-end">
+                <!-- COMPOSANT "NAVIGATION MENU" -->
+                <nav class="navigation-menu nav-main" aria-label="Main navigation">
+                    <div class="menu-container">
+                        <!--<input class="menu-btn" type="checkbox" id="menu-btn-navigationmain" aria-label="Click to open the main menu" />
+                        <label class="menu-icon" for="menu-btn-navigationmain"><span class="nav-icon"></span></label>-->
+                        <a role="button" class="menu-icon" tabindex="0">
+                            <span class="label">Menu</span>
+                            <span class="nav-icon"></span>
+                        </a>
+                        <ul class="menu-level-0">
+
+                            <li class="level-0">
+                                <a class="" href="/news/en" aria-haspopup="true">
+                                  <span class="content">
+                                    <span class="label">Homepage</span>
+                                    <span class="current-element"></span>
+                                  </span>
+                                </a>
+                            </li>
+
+                            <li class="level-0 current has-menu-dropdown">
+                                <a role="button" class="icon-arrow-dropdown" aria-current="true" aria-haspopup="true" tabindex="0">
+                                  <span class="content">
+                                    <span class="label">Press room</span>
+                                    <span class="current-element"></span>
+                                  </span>
+                                </a>
+                                <ul class="menu-level-1" aria-label="View submenu">
+                                    
+                                        <li class="level-1">
+                                            <a href="https://www.europarl.europa.eu/news/en/press-room/accreditation">
+                                                <span class="content">
+
+                                                  <span class="label">Accreditation</span>
+                                                </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="https://www.europarl.europa.eu/news/en/press-room/press-tool-kit">
+                                                <span class="content">
+
+                                                  <span class="label">Press Tool Kit</span>
+                                                </span>
+                                            </a>
+                                        </li>
+                                    
+                                    
+
+                                    <li class="level-1">
+                                        <a href="/news/en/press-room/contacts">
+                                            <span class="content">
+
+                                              <span class="label">Contacts</span>
+                                            </span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </li>
+
+
+                            <li class="level-0 has-menu-dropdown">
+                                <a role="button" class="icon-arrow-dropdown" aria-haspopup="true" tabindex="0">
+                                  <span class="content">
+                                    <span class="label">Agenda</span>
+                                    <span class="current-element"></span>
+                                  </span>
+                                </a>
+                                <ul class="menu-level-1" aria-label="View submenu">
+                                    <li class="level-1">
+                                        <a href="/news/en/agenda">
+                                            <span class="content">
+
+                                              <span class="label">Highlights</span>
+                                            </span>
+                                        </a>
+                                    </li>
+                                    <li class="level-1">
+                                        <a href="/news/en/agenda/weekly-agenda">
+                                            <span class="content">
+
+                                              <span class="label">Weekly agenda</span>
+                                            </span>
+                                        </a>
+                                    </li>
+                                    <li class="level-1">
+                                        <a href="/news/en/agenda/briefing">
+                                            <span class="content">
+
+                                              <span class="label">Briefing</span>
+                                            </span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li class="level-0">
+                                <a class="" href="/news/en/faq" aria-haspopup="true">
+                                  <span class="content">
+                                    <span class="label">FAQ</span>
+                                    <span class="current-element"></span>
+                                  </span>
+                                </a>
+                            </li>
+
+                            
+
+                            <li class="level-0 current">
+                                <a href="/news/en/press-room/press-tool-kit">
+                                    <span class="content">
+
+                                      <span class="label">Press Kit</span>
+                                    </span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </nav>
+                
+                    <!-- COMPOSANT "SEARCH MENU" -->
+
+                    <nav class="search-global-form" aria-label="Click to open the search component">
+                        <!-- Add class 'active' to change the style of the <a> -->
+                        <a href="#" class="search-icon" aria-haspopup="true" aria-expanded="false">
+                            <span class="sr-only">Access to search field</span>
+                            <span class="icon"></span>
+                        </a>
+                    </nav>
+                    <!-- Remove class 'posinit' to display the input search -->
+                    <form class="form-field-search" id="search" action="/news/en/search" method="get" role="search" aria-label="Search">
+                        <div class="field-wrapper">
+                            <div class="field">
+                                <input class="ep_field" type="text" id="search-field" name="searchQuery" value="" aria-label="Please fill out this field" title="Please fill out this field" placeholder="Search" required/>
+                                <button class="btn-send active" type="submit" aria-label="Launch the search" disabled>
+                                    <span class="sr-only">Launch the search</span>
+                                    <span class="icon">&nbsp;</span>
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                    <!-- TITLE ON SCROLL -->
+                    <span class="title-toolbar" aria-hidden="true"><span class="label">European Parliament</span></span>
+                
+            </div>
+
+        </div>
+        <!-- COMPOSANT "BREADCRUMB" -->
+        <nav id="website-breadcrumb" class="ep_breadcrumb" aria-label="You are here:">
+    <div class="ep_fulllist">
+        <span class="ep_mandatory">
+            
+    
+        <a class="ep_item" href="/news/en/press-room">
+            <span class="ep_hidden">Go back to page : Press room</span>
+            <span class="ep_name">Press room</span>
+            <span class="ep_icon">&nbsp;</span></a>
+        <span class="ep_separator"></span>
+    
+    
+
+        </span>
+
+        
+    <span class="ep_mandatory" aria-current="page">
+        <span class="ep_item">
+            <span class="ep_hidden">Current page:</span>
+            <span class="ep_name">Venezuela: European Parliament calls for additional sanctions </span>
+            <span class="ep_icon">&nbsp;</span>
+        </span>
+    </span>
+
+    </div>
+    <div class="ep_previouslink">
+        
+    
+        <a class="ep_item" href="/news/en/press-room">
+            <span class="ep_hidden">Go back to page : Press room</span>
+            <span class="ep_name">Press room</span>
+            <span class="ep_icon">&nbsp;</span></a>
+        <span class="ep_separator"></span>
+    
+    
+
+    </div>
+</nav>
+    </div>
+    <!-- END OF REFACTORING -->
+
+        
+        
+
+        
+        <article id="website-body" role="main">
+
+    
+    
+    
+        
+            <input type="hidden" id="webanalytic-id_chapters" value="press-room"/>
+        
+            <input type="hidden" id="webanalytic-id_sub-chapters" value="pressroom"/>
+        
+            <input type="hidden" id="webanalytic-id_sub-sub-chapters" value="external-relations~humanitarian-aid~external-relations"/>
+        
+            <input type="hidden" id="webanalytic-id_pages" value="situation-in-venezuela"/>
+        
+            <input type="hidden" id="webanalytic-id_type" value=""/>
+        
+            <input type="hidden" id="webanalytic-ep_bodies" value="plenary~15.07.2019~18.07.2019"/>
+        
+            <input type="hidden" id="webanalytics-topics_by_weeks" value=""/>
+        
+            <input type="hidden" id="webanalytics-priority_category" value=""/>
+        
+            <input type="hidden" id="webanalytics-priority_wordlink" value=""/>
+        
+            <input type="hidden" id="webanalytics-reference" value=""/>
+        
+            <input type="hidden" id="webanalytics-language" value=""/>
+        
+    
+
+
+    
+    <div class="ep_gridrow ep-o_product">
+        <div class="ep_gridrow-content">
+            <div class="ep_gridcolumn" data-view1200="2" data-view1020="2" data-view750="1" data-view640="1" data-view480="0" data-view320="0">
+                <div class="ep_gridcolumn-content">&nbsp;</div>
+            </div>
+            <div class="ep_gridcolumn ep-m_header" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                <div class="ep_gridcolumn-content">
+                    <div class="ep-a_heading ep-layout_level1">
+                        <h1 class="ep_title">
+                            <div class="ep-p_text"><span class="ep_name">Venezuela: European Parliament calls for additional sanctions </span><span class="ep_icon">&nbsp;</span></div>
+                        </h1>
+                        <div class="ep_subtitle">
+
+                            <div class="ep-p_text ep-layout_category"><span class="ep_name">Press Releases</span><span class="ep_icon">&nbsp;</span></div>
+
+                            
+
+                            
+
+    
+        <div class="ep-p_text ep-layout_contenttype ep-layout_plenary">
+            <a href="/news/en?contentType=plenary" >
+                <span class="ep_name">Plenary session</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+        
+    
+
+    
+
+    
+
+
+
+                            
+    
+        
+        
+            
+    <div class="ep-p_text ep-layout_date">
+        <span class="ep_name">
+            
+    
+    
+        <time itemprop="datePublished"
+              datetime="2019-07-18T11:37:00">18-07-2019 - 11:37</time>
+    
+
+        </span><span class="ep_icon">&nbsp;</span>
+    </div>
+
+        
+
+    
+
+    
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    
+    <div class="ep_gridrow ep-o_product">
+        <div class="ep_gridrow-content">
+            <div class="ep_gridcolumn" data-view1200="1" data-view1020="1" data-view750="0" data-view640="0" data-view480="0" data-view320="0">
+                <div class="ep_gridcolumn-content">&nbsp;</div>
+            </div>
+
+            
+            
+                
+
+    <div class="ep_gridcolumn ep-m_product ep-layout_followingscroll" data-view1200="1" data-view1020="1" data-view750="1" data-view640="1" data-view480="0" data-view320="0">
+        <div class="ep_gridcolumn-content">
+            <div class="ep-a_share ep-layout_socialnetwok">
+                <div>
+                    
+
+    <div class="ep_share">
+        <h2 class="ep_title">
+            <div class="ep-p_text"><span class="ep_name">Share this page:</span><span class="ep_icon">&nbsp;</span></div>
+        </h2>
+        <ul>
+            <li>
+                <div class="ep-p_text ep-layout_facebook">
+                    <a href="https://www.facebook.com/share.php?u=https://www.europarl.europa.eu/news/en/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Bfacebook%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Bsituation-in-venezuela%5D-" title="Share this page on Facebook" target="_blank" ><span class="ep_name">Facebook</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+            <li>
+                <div class="ep-p_text ep-layout_twitter">
+                    <a href="https://twitter.com/intent/tweet?text=Venezuela:%20European%20Parliament%20calls%20for%20additional%20sanctions%20&amp;url=https://www.europarl.europa.eu/news/en/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Btwitter%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Bsituation-in-venezuela%5D-&amp;via=Europarl_EN" title="Share this page on Twitter" target="_blank"><span class="ep_name">Twitter</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+            <li>
+                <div class="ep-p_text ep-layout_linkedin">
+                    <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https://www.europarl.europa.eu/news/en/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Blinkedin%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Bsituation-in-venezuela%5D%26&amp;title=European%20Parliament&amp;summary=&amp;source=" title="Share this page on LinkedIn" target="_blank" ><span class="ep_name">LinkedIn</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+
+            <li>
+                <div class="ep-p_text ep-layout_whatsapp">
+                    <a href="https://api.whatsapp.com/send?text=https://www.europarl.europa.eu/news/en/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Bwhatsapp%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Bsituation-in-venezuela%5D%26" title="Share this page on WhatsApp" target="_blank"><span class="ep_name">WhatsApp</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+        </ul>
+    </div>
+
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+            
+
+            
+            <div class="ep_gridcolumn" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                <div class="ep_gridrow">
+                    <div class="ep_gridrow-content">
+
+                        
+                        
+                        
+
+    
+        
+            
+            
+            
+            
+            
+                
+
+    <!-- Fact list -->
+    <div class="ep_gridcolumn ep-m_product" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content">
+            <div class="ep-a_facts">
+                <div>
+                    
+                    <ul class="ep_list">
+                        
+                            
+    <li><div class="ep-p_text"><span class="ep_name">Full support “for legitimate interim president Juan Guaidó”</span><span class="ep_icon">&nbsp;</span></div></li>
+
+                        
+                            
+    <li><div class="ep-p_text"><span class="ep_name">Nicolás Maduro should be held directly responsible for indiscriminate use of violence</span><span class="ep_icon">&nbsp;</span></div></li>
+
+                        
+                            
+    <li><div class="ep-p_text"><span class="ep_name">Restrict movements, freeze the assets of those responsible for the crisis</span><span class="ep_icon">&nbsp;</span></div></li>
+
+                        
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+        
+            
+            
+                
+
+    <div class="ep_gridcolumn ep-m_product" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content">
+            <div class="ep-a_text ep-layout_chapo">
+                <p>For the third time this year, the European Parliament adopted a resolution on the situation in Venezuela, expressing its deep concern at the severe state of emergency</p>
+            </div>
+        </div>
+    </div>
+
+
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+        
+            
+            
+            
+            
+                
+
+    <!-- Text content -->
+    <div class="ep_gridcolumn ep-m_product" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content" >
+            <div class="ep-a_text"><p>In accordance with the <a href="https://www.ohchr.org/en/NewsEvents/Pages/DisplayNews.aspx?NewsID=24788&amp;LangID=E" target="_blank">latest report</a> of the UN High Commissioner for Human Rights, MEPs hold Nicolás Maduro directly responsible, “as well as the armed and intelligence forces in the service of his illegitimate regime, for the indiscriminate use of violence to repress the process of democratic transition and the restoration of the rule of law in Venezuela.”</p>
+<p>In the resolution, adopted with 455 votes to 85 and 105 abstentions, they reiterate their full support “for legitimate interim president Juan Guaidó”.</p>
+<p><strong>Additional sanctions</strong></p>
+<p>MEPs call on the Council to adopt additional sanctions targeting state authorities responsible for human rights violations and repression. EU authorities must restrict the movements of these individuals, freeze their assets and suspend visas, as well as those of their closest relatives.</p>
+<p>They support the ongoing facilitated process led by Norway to find a way out of the current impasse and welcome the agreement of both sides to engage in a peace dialogue which should create the conditions for free, transparent and credible presidential elections.</p>
+<p>In her <a href="https://www.consilium.europa.eu/en/press/press-releases/2019/07/16/declaration-by-the-high-representative-on-behalf-of-the-eu-on-venezuela/?utm_source=dsms-auto&amp;utm_medium=email&amp;utm_campaign=Declaration+by+the+High+Representative+on+behalf+of+the+EU+on+Venezuela" target="_blank">declaration on behalf of the EU on Venezuela</a>, High Representative Federica Mogherini warned that the EU will further expand its targeted measures against the responsible authorities if there are no concrete results from the ongoing negotiations.</p>
+<p><strong>Arbitrary detentions, torture and extrajudicial killings</strong></p>
+<p>MEPs denounce the abuse perpetrated by law enforcement and the brutal repression by security forces. They condemn the use of arbitrary detention, torture and extrajudicial killings and reiterate their support for the International Criminal Court’s investigation into the extensive crimes perpetrated by the Venezuelan regime.</p>
+<p><strong>Humanitarian and migration crisis</strong></p>
+<p>More than 7 million people in Venezuela are in need of humanitarian assistance, 94 % of the population lives below the poverty line and 70 % of children are out of school, MEPs warn. They also point to the migration crisis in the region as, to date, more than 3.4 million Venezuelans have had to flee the country. Parliament praises the efforts and solidarity shown by neighbouring countries, in particular Colombia, Ecuador and Peru and ask the Commission to continue cooperating with these countries.</p></div>
+        </div>
+    </div>
+
+
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+        
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+
+
+
+
+                        
+                        
+
+    <!-- Contact -->
+    
+    <div class="ep_gridcolumn ep-m_product" role="region" aria-labelledby="asideregion667782" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content">
+            <div class="ep-a_contacts">
+                <h2 class="ep_title" id="asideregion667782">
+                    <div class="ep-p_text"><span class="ep_name">Contacts:</span><span class="ep_icon">&nbsp;</span></div>
+                </h2>
+                <ul>
+                    
+                        <li class="ep_item">
+                            <div class="ep_card">
+                                <h3 class="ep_name">
+                                    <span class="ep-p_text"><span class="ep_name">Snježana KOBEŠĆAK SMODIŠ</span><span class="ep_icon">&nbsp;</span></span>
+                                </h3>
+                                
+                                
+                                    <div class="ep_information">
+                                        <span class="ep-p_text"><span class="ep_name">Press Officer</span><span class="ep_icon">&nbsp;</span></span>
+                                    </div>
+                                
+                                <div class="ep_data">
+                                    <div class="ep-p_text ep_hidden"><span class="ep_name">Contact data:</span><span class="ep_icon">&nbsp;</span></div>
+                                    <ul>
+                                        
+                                            
+                                                
+                                                    <li class="ep_phone">
+                                                        <a href="tel:(+32) 2 28 32547" class="ep-p_text"><span class="ep_name" title="Phone number"><span class="ep_hidden">Phone number: </span>(+32) 2 28 32547<abbr class="ep_location" title="Brussels"> (BXL)</abbr></span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                    <li class="ep_phone">
+                                                        <a href="tel:+33 3 881 74007" class="ep-p_text"><span class="ep_name" title="Phone number"><span class="ep_hidden">Phone number: </span>+33 3 881 74007<abbr class="ep_location" title="Strasbourg"> (STR)</abbr></span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_portable">
+                                                        <a href="tel:(+32) 470 96 08 19" class="ep-p_text"><span class="ep_name" title="Mobile number"><span class="ep_hidden">Mobile number: </span>(+32) 470 96 08 19</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_mail">
+                                                        <a href="mailto:snjezana.kobescak@europarl.europa.eu" class="ep-p_text" title="E-mail: snjezana.kobescak@europarl.europa.eu"><span class="ep_name"><span class="ep_hidden">E-mail:  </span>snjezana.kobescak@europarl.europa.eu</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                            
+                                        
+                                    </ul>
+                                </div>
+                            </div>
+                            
+                        </li>
+                    
+                        <li class="ep_item">
+                            <div class="ep_card">
+                                <h3 class="ep_name">
+                                    <span class="ep-p_text"><span class="ep_name">Viktor ALMQVIST</span><span class="ep_icon">&nbsp;</span></span>
+                                </h3>
+                                
+                                
+                                    <div class="ep_information">
+                                        <span class="ep-p_text"><span class="ep_name">Press Officer</span><span class="ep_icon">&nbsp;</span></span>
+                                    </div>
+                                
+                                <div class="ep_data">
+                                    <div class="ep-p_text ep_hidden"><span class="ep_name">Contact data:</span><span class="ep_icon">&nbsp;</span></div>
+                                    <ul>
+                                        
+                                            
+                                                
+                                                    <li class="ep_phone">
+                                                        <a href="tel:(+32) 2 28 31834" class="ep-p_text"><span class="ep_name" title="Phone number"><span class="ep_hidden">Phone number: </span>(+32) 2 28 31834<abbr class="ep_location" title="Brussels"> (BXL)</abbr></span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                    <li class="ep_phone">
+                                                        <a href="tel:(+33) 3 881 72420" class="ep-p_text"><span class="ep_name" title="Phone number"><span class="ep_hidden">Phone number: </span>(+33) 3 881 72420<abbr class="ep_location" title="Strasbourg"> (STR)</abbr></span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_portable">
+                                                        <a href="tel:(+32) 470 88 29 42" class="ep-p_text"><span class="ep_name" title="Mobile number"><span class="ep_hidden">Mobile number: </span>(+32) 470 88 29 42</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_mail">
+                                                        <a href="mailto:viktor.almqvist@europarl.europa.eu" class="ep-p_text" title="E-mail: viktor.almqvist@europarl.europa.eu"><span class="ep_name"><span class="ep_hidden">E-mail:  </span>viktor.almqvist@europarl.europa.eu</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                            
+                                        
+                                    </ul>
+                                </div>
+                            </div>
+                            
+                        </li>
+                    
+                </ul>
+            </div>
+        </div>
+    </div>
+
+
+
+                    </div>
+                </div>
+            </div>
+            <!-- ADDITIONAL LINKS COLUMN -->
+            <section class="ep_gridcolumn ep-layout_followingscroll" data-view1200="3" data-view1020="3" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
+                <div class="ep_gridrow">
+                    <div class="ep_gridrow-content">
+                        <div class="ep_gridcolumn" data-view1200="0" data-view1020="0" data-view750="1" data-view640="1" data-view480="0" data-view320="0">
+                            <div class="ep_gridcolumn-content">&nbsp;</div>
+                        </div>
+                        <div class="ep_gridcolumn" data-view1200="3" data-view1020="3" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                            <div class="ep_gridrow">
+                                <div class="ep_gridrow-content">
+
+                                    
+                                    
+
+                                    
+                                    
+                                        
+                                            
+                                        
+                                    
+                                        
+                                            
+                                        
+                                    
+                                        
+                                            
+                                        
+                                    
+                                        
+                                            
+                                                
+    <!-- List of links -->
+    <div class="ep_gridcolumn ep-m_product" data-layout1200="border" data-layout1020="border" data-view1200="3" data-view1020="3" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        
+    <div class="ep_gridcolumn-content">
+        <div class="ep-a_links">
+            <h2 class="ep_title">
+                <div class="ep-p_text"><span class="ep_name">Further information</span><span class="ep_icon">&nbsp;</span></div>
+            </h2>
+            <ul class="ep_list">
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" target="_blank" href="http://www.europarl.europa.eu/plenary/en/texts-adopted.html"><span class="ep_name">Adopted text will be published here (18.07.2019)</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" target="_blank" href="http://www.europarl.europa.eu/streaming/?event=20190716-0900-PLENARY&amp;start=2019-07-16T18:52:43Z&amp;end=2019-07-16T19:48:57Z&amp;language=en"><span class="ep_name">Video-recording of the debate (16.07.2019)</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" target="_blank" href="http://www.europarl.europa.eu/doceo/document/TA-8-2019-0327_EN.html"><span class="ep_name">EP Resolution: Emergency situation in Venezuela (28.03.2019)</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" target="_blank" href="http://www.europarl.europa.eu/doceo/document/TA-8-2019-0061_EN.html"><span class="ep_name">EP Resolution: Situation in Venezuela (31.01.2019)</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_pdf">
+            <a title="Read the PDF document" target="_blank" href="http://www.europarl.europa.eu/RegData/etudes/ATAG/2019/637928/EPRS_ATA(2019)637928_EN.pdf">
+                <span class="ep_name">EPRS (European Parliament Think Thank): Venezuela: The standoff continue (12.04.2019) </span>
+                <span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+
+            
+
+            
+
+            
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" target="_blank" href="https://multimedia.europarl.europa.eu/en/eu-venezuela_7402_pk"><span class="ep_name">EP Multimedia Centre: EU-Venezuela</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+            </ul>
+        </div>
+    </div>
+
+    </div>
+
+                                            
+                                        
+                                    
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Product reference -->
+            <div class="ep_gridcolumn" data-view1200="12" data-view1020="12" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
+                <div class="ep_gridrow">
+                    <div class="ep_gridrow-content">
+                        <div class="ep_gridcolumn" data-view1200="2" data-view1020="2" data-view750="1" data-view640="1" data-view480="0" data-view320="0">
+                            <div class="ep_gridcolumn-content">&nbsp;</div>
+                        </div>
+                        <div class="ep_gridcolumn" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                            <div class="ep_gridrow">
+                                <div class="ep_gridrow-content">
+                                    <div class="ep_gridcolumn ep-m_footer" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                                        <div class="ep_gridcolumn-content">
+                                            <h2 class="ep-a_heading ep_hidden">
+                                                <div class="ep_title">
+                                                    <div class="ep-p_text"><span class="ep_name">Product information</span><span class="ep_icon">&nbsp;</span></div>
+                                                </div>
+                                            </h2>
+                                            <div class="ep-a_reference">
+                                                <div class="ep_reference">
+                                                    <span class="ep-p_text"><span class="ep_name"><abbr title="Product reference">Ref.:</abbr></span><span class="ep_icon">&nbsp;</span></span>
+                                                    <span class="ep-p_text"><span class="ep_name">20190712IPR56948</span><span class="ep_icon">&nbsp;</span></span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+    
+    
+        
+
+    <div class="ep_gridrow ep-o_footerpage">
+        <div class="ep_gridrow-content">
+            <div class="ep_gridcolumn ep-m_product" data-view1200="12" data-view1020="12" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
+                <div class="ep_gridcolumn-content">
+                    <div class="ep-a_share">
+                        <div>
+                            
+
+    <div class="ep_share">
+        <h2 class="ep_title">
+            <div class="ep-p_text"><span class="ep_name">Share this page:</span><span class="ep_icon">&nbsp;</span></div>
+        </h2>
+        <ul>
+            <li>
+                <div class="ep-p_text ep-layout_facebook">
+                    <a href="https://www.facebook.com/share.php?u=https://www.europarl.europa.eu/news/en/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Bfacebook%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Bsituation-in-venezuela%5D-" title="Share this page on Facebook" target="_blank" ><span class="ep_name">Facebook</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+            <li>
+                <div class="ep-p_text ep-layout_twitter">
+                    <a href="https://twitter.com/intent/tweet?text=Venezuela:%20European%20Parliament%20calls%20for%20additional%20sanctions%20&amp;url=https://www.europarl.europa.eu/news/en/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Btwitter%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Bsituation-in-venezuela%5D-&amp;via=Europarl_EN" title="Share this page on Twitter" target="_blank"><span class="ep_name">Twitter</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+            <li>
+                <div class="ep-p_text ep-layout_linkedin">
+                    <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https://www.europarl.europa.eu/news/en/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Blinkedin%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Bsituation-in-venezuela%5D%26&amp;title=European%20Parliament&amp;summary=&amp;source=" title="Share this page on LinkedIn" target="_blank" ><span class="ep_name">LinkedIn</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+
+            <li>
+                <div class="ep-p_text ep-layout_whatsapp">
+                    <a href="https://api.whatsapp.com/send?text=https://www.europarl.europa.eu/news/en/press-room/20190712IPR56948/venezuela-european-parliament-calls-for-additional-sanctions?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Bwhatsapp%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Bsituation-in-venezuela%5D%26" title="Share this page on WhatsApp" target="_blank"><span class="ep_name">WhatsApp</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+        </ul>
+    </div>
+
+
+                            <div class="ep_links">
+                                <div class="ep-p_text ep-layout_mail"><a href="/subscription/en"><span class="ep_name">Sign up for mail updates</span></a></div>
+
+                                
+                                <div class="ep-p_text ep-layout_pdf"><a href="/pdfs/news/expert/2019/7/press_release/20190712IPR56948/20190712IPR56948_en.pdf"><span class="ep_name">PDF version</span><span class="ep_icon">&nbsp;</span></a></div>
+
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+    
+
+
+</article>
+
+        
+        
+            
+
+    <footer id="website-footer" role="contentinfo">
+        
+        <div class="ep_footer-relatedlinks">
+            <div class="ep_websitelinks" id="website-links">
+                <h2 class="ep_title" id="website-links-title">
+                    <span class="ep_name">News</span>
+                    <span class="ep_icon">&nbsp;</span>
+                </h2>
+                <div class="ep_menu-access ep_openaccess" id="website-links-access" aria-controls="website-links-content" role="tab">
+                    <a href="#website-links">
+                        <span class="ep_name">View menu: News</span>
+                        <span class="ep_icon">&nbsp;</span></a>
+                </div>
+                <div class="ep_list ep-layout_category" id="website-links-content">
+                    <div>
+                        <div class="ep_category">
+                            <h3 class="ep_subtitle" id="website-links-category1-title">
+                                <span class="ep_name">Parliament in your country</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </h3>
+                            
+                                <ul aria-labelledby="website-links-category1-title">
+                                    
+                                        <li class="ep_item">
+                                            <a href="/unitedkingdom" class="ep_button" target="_blank" >
+                                                <span class="ep_hidden">Open in a new page</span>
+                                                <span class="ep_name">London</span>
+                                            </a>
+                                        </li>
+                                    
+                                        <li class="ep_item">
+                                            <a href="/ireland" class="ep_button" target="_blank" >
+                                                <span class="ep_hidden">Open in a new page</span>
+                                                <span class="ep_name">Dublin</span>
+                                            </a>
+                                        </li>
+                                    
+                                        <li class="ep_item">
+                                            <a href="/malta" class="ep_button" target="_blank" >
+                                                <span class="ep_hidden">Open in a new page</span>
+                                                <span class="ep_name">Valletta</span>
+                                            </a>
+                                        </li>
+                                    
+                                        <li class="ep_item">
+                                            <a href="/unitedstates" class="ep_button" target="_blank" >
+                                                <span class="ep_hidden">Open in a new page</span>
+                                                <span class="ep_name">Washington</span>
+                                            </a>
+                                        </li>
+                                    
+                                </ul>
+                            
+                        </div>
+                        <div class="ep_category">
+                            <h3 class="ep_subtitle" id="website-links-category2-title">
+                                <span class="ep_name">Tools</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </h3>
+                            <ul aria-labelledby="website-links-category2-title">
+                                <li class="ep_item">
+                                    <a href="/oeil/home/home.do" class="ep_button">
+                                        <span class="ep_hidden">Open in a new page</span>
+                                        <span class="ep_name">Legislative Observatory</span>
+                                    </a>
+                                </li>
+                                <li class="ep_item">
+                                    <a href="https://multimedia.europarl.europa.eu/en" class="ep_button" target="_blank" >
+                                        <span class="ep_hidden">Open in a new page</span>
+                                        <span class="ep_name">Multimedia Centre</span>
+                                    </a>
+                                </li>
+                                <li class="ep_item">
+                                    <a href="https://ec.europa.eu/avservices/ebs/schedule.cfm?sitelang=en"  class="ep_button" target="_blank" >
+                                        <span class="ep_hidden">Open in a new page</span>
+                                        <span class="ep_name">EbS</span>
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="ep_category">
+                            <h3 class="ep_subtitle" id="website-links-category3-title">
+                                <span class="ep_name">The President of the European Parliament</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </h3>
+                            <ul aria-labelledby="website-links-category3-title">
+                                <li class="ep_item">
+                                    <a href="/the-president/en/" class="ep_button">
+                                        <span class="ep_hidden">Open in a new page</span>
+                                        <span class="ep_name">European Parliament President’s website</span>
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="ep_menu-access ep_closeaccess">
+                    <a href="#website-links-access" title="Hide menu">
+                        <span class="ep_name">Hide menu: News</span>
+                        <span class="ep_icon">&nbsp;</span>
+                    </a>
+                </div>
+            </div>
+            <div class="ep_europarllinks" id="europarl-links">
+                <h2 class="ep_title" id="europarl-links-title">
+                    <span class="ep_name">European Parliament</span>
+                    <span class="ep_icon">&nbsp;</span>
+                </h2>
+                <div class="ep_menu-access ep_openaccess" id="europarl-links-access" aria-controls="europarl-links-content" role="tab">
+                    <a href="#europarl-links" >
+                        <span class="ep_name">View menu: European Parliament</span>
+                        <span class="ep_icon">&nbsp;</span>
+                    </a>
+                </div>
+                <div class="ep_list">
+                    <ul id="europarl-links-content" aria-labelledby="europarl-links-title">
+                        <li class="ep_item">
+                            <a class="ep_button" href="/news/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">News</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/topics/en" >
+                                <span class="ep_name">Topics</span><span class="icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/meps/en/home" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">MEPs</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/about-parliament/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">About Parliament</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/plenary/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">Plenary</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/committees/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">Committees</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/delegations/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">Delegations</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="https://elections.europa.eu/en" >
+                                <span class="ep_name">Elections</span><span class="icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                    </ul>
+                </div>
+                <div class="ep_menu-access ep_closeaccess">
+                    <a href="#europarl-links-access" title="Hide menu"><span class="ep_name">Hide menu: European Parliament</span><span class="ep_icon">&nbsp;</span></a></div>
+            </div>
+        </div>
+        <span class="ep_footer-separator">&nbsp;</span>
+        <div class="ep_footer-otherlinks">
+            
+            <div class="ep_sociallinks" id="socialmedia">
+                <h2 class="ep_hidden" id="socialmedia-title">
+                    <span class="ep_name">The Parliament on social media</span>
+                    <span class="ep_icon">&nbsp;</span>
+                </h2>
+                <div class="ep_list">
+                    <ul aria-labelledby="socialmedia-title">
+                        <li class="ep_item">
+                            <a href="https://www.facebook.com/europeanparliament"  class="ep_button ep_facebook" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Facebook</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://twitter.com/Europarl_en" class="ep_button ep_twitter" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Twitter</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.flickr.com/photos/european_parliament/" class="ep_button ep_flickr"	target="_blank" >
+                                <span class="ep_name">Check out Parliament on Flickr</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.linkedin.com/company/european-parliament" class="ep_button ep_linkedin" target="_blank" >
+                                <span class="ep_name">Check out Parliament on LinkedIn</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.youtube.com/user/EuropeanParliament" class="ep_button ep_youtube" target="_blank" >
+                                <span class="ep_name">Check out Parliament on YouTube</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://instagram.com/europeanparliament" class="ep_button ep_instagram" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Instagram</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.pinterest.com/epinfographics/" class="ep_button ep_pinterest" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Pinterest</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.snapchat.com/add/europarl" class="ep_button ep_snapchat" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Snapchat</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.reddit.com/r/europeanparliament/" class="ep_button ep_reddit" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Reddit</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <!-- COMPOSANT "MANDATORY LINKS" -->
+            <div class="ep_mandatorylinks" id="informationlinks">
+                <h2 class="ep_hidden" id="informationlinks-title"><span class="ep_name">Information links</span><span class="ep_icon">&nbsp;</span></h2>
+                <div class="ep_list">
+                    <ul aria-labelledby="informationlinks-title">
+                        <li class="ep_item"><a href="/portal/en/contact"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Contact</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/at-your-service/en/stay-informed/rss-feeds"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">RSS</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/portal/en/sitemap"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Sitemap</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/legal-notice/en"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Legal notice</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/privacy-policy/en/"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Privacy policy</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/portal/en/accessibility"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Accessibility</span><span class="ep_icon">&nbsp;</span></a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+
+        
+    </div>
+
+    <!-- Backdrop / Gray Overlay for compact menu opening-->
+    <div class="back-overlay"></div>
+
+    
+    
+
+    
+    
+        <script>
+            (function rewriteUrlIfNeeded() {
+                function getHash(url) {
+                    return url.hash !== '' && document.getElementById(url.hash.slice(1)) ?
+                        url.hash :
+                        '';
+                }
+
+                function rewriteUrl(currentUrl, baseUrl) {
+                    // ensure that hash is present only if it actually exists
+                    const url = new URL(currentUrl);
+                    return `${baseUrl}${url.search}${getHash(url)}`;
+                }
+
+                // pre-condition: #dev_product_url ALWAYS exists see <input ...> above.
+                const productUrl = document.getElementById('dev_product_url').value;
+
+                if (productUrl === '') {
+                    return;
+                }
+
+                const newUrl = rewriteUrl(window.location.href, productUrl);
+
+                if (newUrl !== window.location.href) {
+                    window.history.replaceState(null, '', newUrl)
+                }
+            }())
+        </script>
+    
+
+        <script type="text/javascript">
+            // safari blinking workaround. Cf jira ENG-32999 & ENG-33001
+        </script>
+    </body>
+
+</html>

--- a/backend/tests/scrapers/data/press_releases/press-release_20250204IPR26689.html
+++ b/backend/tests/scrapers/data/press_releases/press-release_20250204IPR26689.html
@@ -1,0 +1,1896 @@
+<!DOCTYPE html>
+<html lang="en">
+
+    
+    <head>
+
+    
+    
+        
+
+    
+
+    <title>MEPs: Georgia’s self-proclaimed authorities have no legitimacy | News | European Parliament</title>
+    <meta property="og:title" content="MEPs: Georgia’s self-proclaimed authorities have no legitimacy | News | European Parliament"/>
+    <meta property="twitter:title" content="MEPs: Georgia’s self-proclaimed authorities have no legitimacy | News | European Parliament"/>
+    <meta itemprop="name" content="MEPs: Georgia’s self-proclaimed authorities have no legitimacy | News | European Parliament"/>
+    <meta name="description" content="MEPs call on the international community to join the boycott of Georgia’s self-proclaimed authorities, who they accuse of eroding the country’s democracy and cracking down on dissents."/>
+    <meta property="og:description" content="MEPs call on the international community to join the boycott of Georgia’s self-proclaimed authorities, who they accuse of eroding the country’s democracy and cracking down on dissents."/>
+    <meta property="twitter:description" content="MEPs call on the international community to join the boycott of Georgia’s self-proclaimed authorities, who they accuse of eroding the country’s democracy and cracking down on dissents."/>
+    <meta itemprop="description" content="MEPs call on the international community to join the boycott of Georgia’s self-proclaimed authorities, who they accuse of eroding the country’s democracy and cracking down on dissents."/>
+    <meta charset="UTF-8"/>
+
+    
+    <meta name="available" content="13-02-2025"/>
+
+    <meta http-equiv="last-modified" content="2025-02-13 12:47:00.0"/>
+
+    <meta name="language" content="en"/>
+    <meta name="planet" content="news"/>
+    <link rel="canonical" href="https://www.europarl.europa.eu/news/en/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"/>
+    <meta property="og:url" content="https://www.europarl.europa.eu/news/en/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"/>
+    
+        
+        
+            <meta name="robots" content="index, follow, noodp, noydir, notranslate, noarchive"/>
+        
+    
+    <meta property="og:type" content="article"/>
+
+    
+    
+    
+        <meta property="og:image" content="https://www.europarl.europa.eu/news/img/meta-facebook.jpg"/>
+        <meta property="twitter:image" content="https://www.europarl.europa.eu/news/img/meta-twitter.jpg"/>
+    
+
+
+
+    
+        <meta name="keywords" content="productType:PRESS_RELEASE,com:AFET,plenaryDate:10-02-2025"/>
+    
+    <meta name="routes" content="productSubType:PLENARY_SESSION"/>
+
+
+    
+    
+
+    
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+
+    <link rel="stylesheet" type="text/css" href="/news/css/header-ep.css"/>
+
+    
+        
+    <link rel="stylesheet" type="text/css" href="/news/css/atomicdesign.css"/>
+    <link rel="stylesheet" type="text/css" href="/news/css/components-ep.css"/>
+    <link rel="stylesheet" type="text/css" href="/news/css/structure.css"/>
+    <noscript>
+        <link rel="stylesheet" type="text/css" href="/news/css/no-js.css" />
+    </noscript>
+
+    
+
+    <noscript>
+        <link rel="stylesheet" type="text/css" href="/news/css/header-ep-nojs.css"/>
+    </noscript>
+    
+
+    <script type="text/javascript" defer data-tracker-name="ATInternet"
+            data-value="/website/webanalytics/ati-news.js"
+            src="/website/privacy-policy/privacy-policy.js"></script>
+
+    
+        <script>
+            /*<![CDATA[*/
+            // AMD define stub: delay handling of define calls until our amd dependency
+            // manager has been loaded (from behaviour.js)
+
+            var __amd$delayedDefines = []
+            function define() {
+                var args = Array.prototype.slice.call(arguments)
+                window.__amd$delayedDefines.push(function () {
+                    window.define.apply(window, args)
+                })
+            }
+            define.amd = {}
+            define('eng-scripts',
+                {
+                    'weekly-agenda-widget': { url: "\/news\/js\/weekly-agenda-widget.js", fetched: false }
+                    , 'weekly-agenda': { url: "\/news\/js\/weekly-agenda.js", fetched: false }
+                    , 'week-selector': { url: "\/news\/js\/week-selector.js", fetched: false }
+                    , 'tst-continuous-loading': { url: "\/news\/js\/tst-continuous-loading.js", fetched: false }
+                    , 'slideshow': { url: "\/news\/js\/slideshow.js", fetched: false }
+                    , 'load-more': { url: "\/news\/js\/load-more.js", fetched: false }
+                    , 'infographic': { url: "\/news\/js\/infographic.js", fetched: false }
+                    , 'filter-form': { url: "\/news\/js\/filter-form.js", fetched: false }
+                    , 'datepicker': { url: "\/news\/js\/datepicker.js", fetched: false }
+                    , 'video-player': { url: "\/news\/js\/video-player.js", fetched: false }
+                    , 'election-results': { url: "\/website\/election-results\/js\/ep_electionresults_app.js", fetched: false }
+                    , 'ec-sml-loader': { url: "\/news\/js\/ec-sml-loader.js", fetched: false }
+                    , 'quiz-loader': { url: "https:\/\/quizweb.europarl.europa.eu\/embed\/js\/ep-ee19-quiz.js", fetched: false }
+                    , 'timeline': { url: "\/news\/js\/timeline.js", fetched: false }
+                }
+            )
+            define( 'global', { document: window.document, window: window } )
+            /*]]>*/
+        </script>
+
+        <script async="async" type="text/javascript" src="/news/js/behaviour.js"></script>
+
+        <script type="text/javascript">
+            define('change-language', [ 'behaviour.js'], function moduleFactory() {
+                Select.updateparams('language-select', {cb_beforesubmit: function() {
+                        window.location.href = document.getElementById('language-select').value;
+                        return false;
+                    }})
+            })
+        </script>
+    
+
+
+    
+    <script defer type="text/javascript" src="/news/js/bundle.js"></script>
+
+
+    
+
+    
+    
+        
+    
+
+    
+    
+        
+    
+
+
+
+</head>
+
+    
+    <body lang="en">
+
+    
+    <input type="hidden" value="https://www.europarl.europa.eu/news/en/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy" id="dev_product_url"/>
+
+    
+    <div id="website">
+
+        
+        
+            
+
+    
+    
+    
+    
+
+    <div id="website-header" class="ep-header">
+        <!-- COMPOSANT "WAI SHORTCUTS" -->
+        <nav class="wai-shortcut" aria-label="Shortcuts">
+            <ul id="waimenu">
+                <li><a href="#website-body"><span class="label">Access to page content (press &quot;Enter&quot;)</span></a></li>
+                <li><a href="#language-select"><span class="label">Direct access to language menu (press &quot;Enter&quot;)</span></a></li>
+                <li><a href="#search-field"><span class="label">Direct access to search menu (press &quot;Enter&quot;)</span></a></li>
+            </ul>
+        </nav>
+
+        <!-- START OF REFACTORING -->
+
+        <!-- COMPOSANT "TOOLBAR" TOP -->
+        <div class="toolbar toolbar_top">
+            <div class="toolbar-grid m-column no-padding-m">
+                <!-- COMPOSANT "LANGUAGE MENU" -->
+                <div class="dropdown-lang" id="language-select">
+                    <!-- Select language no js -->
+                    <noscript>
+                        <div class="dropdown">
+                            <div class="dropdown-lang no-js">
+                                <div class="wrapper-dropdown-lang">
+                                    <form method="get" action="/news/changeLanguage" aria-label="Navigation">
+                                        <div class="select">
+                                            <label for="change_language_nojs" class="sr-only">Change the navigation language</label>
+                                            <select id="change_language_nojs" name="url" required>
+                                                <!-- // TODO : values need to be set by -->
+                                                <option
+                                                        lang="bg"
+                                                        value="/news/bg/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >BG - български</option>
+                                                <option
+                                                        lang="es"
+                                                        value="/news/es/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >ES - español</option>
+                                                <option
+                                                        lang="cs"
+                                                        value="/news/cs/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >CS - čeština</option>
+                                                <option
+                                                        lang="da"
+                                                        value="/news/da/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >DA - dansk</option>
+                                                <option
+                                                        lang="de"
+                                                        value="/news/de/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >DE - Deutsch</option>
+                                                <option
+                                                        lang="et"
+                                                        value="/news/et/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >ET - eesti keel</option>
+                                                <option
+                                                        lang="el"
+                                                        value="/news/el/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >EL - ελληνικά</option>
+                                                <option
+                                                        lang="en"
+                                                        value="/news/en/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >EN - English</option>
+                                                <option
+                                                        lang="fr"
+                                                        value="/news/fr/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >FR - français</option>
+                                                <option
+                                                        lang="ga"
+                                                        value="/news/ga/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >GA - Gaeilge</option>
+                                                <option
+                                                        lang="hr"
+                                                        value="/news/hr/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >HR - hrvatski</option>
+                                                <option
+                                                        lang="it"
+                                                        value="/news/it/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >IT - italiano</option>
+                                                <option
+                                                        lang="lv"
+                                                        value="/news/lv/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >LV - latviešu valoda</option>
+                                                <option
+                                                        lang="lt"
+                                                        value="/news/lt/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >LT - lietuvių kalba</option>
+                                                <option
+                                                        lang="hu"
+                                                        value="/news/hu/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >HU - magyar</option>
+                                                <option
+                                                        lang="mt"
+                                                        value="/news/mt/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >MT - Malti</option>
+                                                <option
+                                                        lang="nl"
+                                                        value="/news/nl/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >NL - Nederlands</option>
+                                                <option
+                                                        lang="pl"
+                                                        value="/news/pl/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >PL - polski</option>
+                                                <option
+                                                        lang="pt"
+                                                        value="/news/pt/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >PT - português</option>
+                                                <option
+                                                        lang="ro"
+                                                        value="/news/ro/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >RO - română</option>
+                                                <option
+                                                        lang="sk"
+                                                        value="/news/sk/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >SK - slovenčina</option>
+                                                <option
+                                                        lang="sl"
+                                                        value="/news/sl/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >SL - slovenščina</option>
+                                                <option
+                                                        lang="fi"
+                                                        value="/news/fi/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >FI - suomi</option>
+                                                <option
+                                                        lang="sv"
+                                                        value="/news/sv/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy"
+                                                >SV - svenska</option>
+                                            </select>
+                                        </div>
+                                        <button type="submit" class="btn">Change the navigation language</button>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </noscript>
+                    <!-- End Select language no js -->
+                    <nav class="custom-select dropdown" aria-label="Change the navigation language">
+                        <button id="dropdown" class="btn lang_select" type="submit" aria-haspopup="true" aria-expanded="false">EN - English</button>
+                        <ul class="no-display menu-content">
+
+                            <li>
+                                <a
+                                   lang="bg"
+                                   hreflang="bg"
+                                   href="/news/bg/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">BG - български</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="es"
+                                   hreflang="es"
+                                   href="/news/es/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">ES - español</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="cs"
+                                   hreflang="cs"
+                                   href="/news/cs/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">CS - čeština</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="da"
+                                   hreflang="da"
+                                   href="/news/da/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">DA - dansk</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="de"
+                                   hreflang="de"
+                                   href="/news/de/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">DE - Deutsch</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="et"
+                                   hreflang="et"
+                                   href="/news/et/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">ET - eesti keel</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="el"
+                                   hreflang="el"
+                                   href="/news/el/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">EL - ελληνικά</span></span>
+                                </a>
+                            </li>
+
+                            <li class="current" aria-current="true">
+                                <a
+                                   lang="en"
+                                   hreflang="en"
+                                   href="/news/en/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">EN - English</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="fr"
+                                   hreflang="fr"
+                                   href="/news/fr/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">FR - français</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="ga"
+                                   hreflang="ga"
+                                   href="/news/ga/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">GA - Gaeilge</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="hr"
+                                   hreflang="hr"
+                                   href="/news/hr/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">HR - hrvatski</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="it"
+                                   hreflang="it"
+                                   href="/news/it/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">IT - italiano</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="lv"
+                                   hreflang="lv"
+                                   href="/news/lv/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">LV - latviešu valoda</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="lt"
+                                   hreflang="lt"
+                                   href="/news/lt/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">LT - lietuvių kalba</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="hu"
+                                   hreflang="hu"
+                                   href="/news/hu/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">HU - magyar</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="mt"
+                                   hreflang="mt"
+                                   href="/news/mt/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">MT - Malti</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="nl"
+                                   hreflang="nl"
+                                   href="/news/nl/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">NL - Nederlands</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="pl"
+                                   hreflang="pl"
+                                   href="/news/pl/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">PL - polski</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="pt"
+                                   hreflang="pt"
+                                   href="/news/pt/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">PT - português</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="ro"
+                                   hreflang="ro"
+                                   href="/news/ro/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">RO - română</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="sk"
+                                   hreflang="sk"
+                                   href="/news/sk/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">SK - slovenčina</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="sl"
+                                   hreflang="sl"
+                                   href="/news/sl/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">SL - slovenščina</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="fi"
+                                   hreflang="fi"
+                                   href="/news/fi/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">FI - suomi</span></span>
+                                </a>
+                            </li>
+
+                            <li>
+                                <a
+                                   lang="sv"
+                                   hreflang="sv"
+                                   href="/news/sv/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy">
+                                    <span class="wrapper-label"><span class="label">SV - svenska</span></span>
+                                </a>
+                            </li>
+                        </ul>
+                    </nav>
+                </div>
+                <!-- COMPOSANT "OTHER TOOLS LINKS" -->
+                <nav class="navigation-menu nav-top" aria-label="Navigation">
+                    <div class="menu-container">
+                        <div class="focusable">
+                            <!--href ?  -->
+                            <a role="button" class="btn-open-menu" aria-haspopup="true" aria-expanded="false" tabindex="0">View other websites</a>
+                            <ul class="menu-level-0" aria-label="View menu: News">
+                                <li class="level-0">
+                                    <a class="" href="/news/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">News</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/topics/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">Topics</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/meps/en/home" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">MEPs</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/about-parliament/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">About Parliament</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/plenary/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">Plenary</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0">
+                                    <a class="" href="/committees/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">Committees</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0 nopadding-right">
+                                    <a class="" href="/delegations/en" tabindex="0">
+                          <span class="content">
+
+                            <span class="label">Delegations</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0 nopadding-right">
+                                    <a class="" href="https://elections.europa.eu/en">
+                          <span class="content">
+
+                            <span class="label">Elections</span>
+                          </span>
+                                    </a>
+                                </li>
+                                <li class="level-0 has-menu-dropdown">
+                                    <a role="button" class="icon-arrow-dropdown" id="otherWebsitesLink" aria-haspopup="true" aria-expanded="false" tabindex="0">
+                                      <span class="content">
+                                          <span class="sr-only">View submenu:</span>
+                                          <span class="label">Other websites</span>
+                                      </span>
+                                    </a>
+                                    <ul class="menu-level-1">
+                                        <li class="level-1">
+                                            <a href="https://multimedia.europarl.europa.eu/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Multimedia Centre</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/the-president/en/" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">President’s website</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/the-secretary-general/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Secretariat-general</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/thinktank/en/home.html" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Think tank</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="https://www.epnewshub.eu" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">EP Newshub</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/at-your-service/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">At your service</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/visiting/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Visits</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/legislative-train" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Legislative train</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/contracts-and-grants/en/" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Contracts and Grants</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="/RegistreWeb/home/welcome.htm?language=en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Register</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="https://data.europarl.europa.eu/en/home" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Open Data Portal</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="https://liaison-offices.europarl.europa.eu/en" tabindex="0">
+                              <span class="content">
+
+                                <span class="label">Liaison offices</span>
+                              </span>
+                                            </a>
+                                        </li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </div>
+                        <!--<input class="menu-btn" type="checkbox" id="menu-btn-navigationtop" aria-label="Click to open the other websites menu" />
+                        <label class="menu-icon" for="menu-btn-navigationtop">View other websites</label>-->
+                    </div>
+                </nav>
+            </div>
+        </div>
+        <!-- LOGO + TITLE -->
+        <header class="header">
+            <div class="header-wrapper no-padding">
+                <!--<a class="grid" href="https://www.europarl.europa.eu/portal/en">
+                  <span class="sr-only">Go back to the Europarl portal</span>
+                  <img src="../europarl/img/ep-logo.svg" alt="" class="ep_logo" />
+                </a>-->
+                <div class="grid">
+				<span class="title-wrapper">
+					
+					<a href="/news/en" class="title"><span class="labeltxt">News</span></a>
+					<a href="/portal/en" class="subtitle">
+                      <span class="labeltxt">European Parliament</span>
+                      <span class="logo"></span>
+                    </a>
+				</span>
+                </div>
+            </div>
+        </header>
+        <!-- COMPOSANT "TOOLBAR" BOTTOM -->
+        <div class="toolbar toolbar_bottom sticky">
+            <div class="toolbar-grid no-padding flex-end">
+                <!-- COMPOSANT "NAVIGATION MENU" -->
+                <nav class="navigation-menu nav-main" aria-label="Main navigation">
+                    <div class="menu-container">
+                        <!--<input class="menu-btn" type="checkbox" id="menu-btn-navigationmain" aria-label="Click to open the main menu" />
+                        <label class="menu-icon" for="menu-btn-navigationmain"><span class="nav-icon"></span></label>-->
+                        <a role="button" class="menu-icon" tabindex="0">
+                            <span class="label">Menu</span>
+                            <span class="nav-icon"></span>
+                        </a>
+                        <ul class="menu-level-0">
+
+                            <li class="level-0">
+                                <a class="" href="/news/en" aria-haspopup="true">
+                                  <span class="content">
+                                    <span class="label">Homepage</span>
+                                    <span class="current-element"></span>
+                                  </span>
+                                </a>
+                            </li>
+
+                            <li class="level-0 current has-menu-dropdown">
+                                <a role="button" class="icon-arrow-dropdown" aria-current="true" aria-haspopup="true" tabindex="0">
+                                  <span class="content">
+                                    <span class="label">Press room</span>
+                                    <span class="current-element"></span>
+                                  </span>
+                                </a>
+                                <ul class="menu-level-1" aria-label="View submenu">
+                                    
+                                        <li class="level-1">
+                                            <a href="https://www.europarl.europa.eu/news/en/press-room/accreditation">
+                                                <span class="content">
+
+                                                  <span class="label">Accreditation</span>
+                                                </span>
+                                            </a>
+                                        </li>
+                                        <li class="level-1">
+                                            <a href="https://www.europarl.europa.eu/news/en/press-room/press-tool-kit">
+                                                <span class="content">
+
+                                                  <span class="label">Press Tool Kit</span>
+                                                </span>
+                                            </a>
+                                        </li>
+                                    
+                                    
+
+                                    <li class="level-1">
+                                        <a href="/news/en/press-room/contacts">
+                                            <span class="content">
+
+                                              <span class="label">Contacts</span>
+                                            </span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </li>
+
+
+                            <li class="level-0 has-menu-dropdown">
+                                <a role="button" class="icon-arrow-dropdown" aria-haspopup="true" tabindex="0">
+                                  <span class="content">
+                                    <span class="label">Agenda</span>
+                                    <span class="current-element"></span>
+                                  </span>
+                                </a>
+                                <ul class="menu-level-1" aria-label="View submenu">
+                                    <li class="level-1">
+                                        <a href="/news/en/agenda">
+                                            <span class="content">
+
+                                              <span class="label">Highlights</span>
+                                            </span>
+                                        </a>
+                                    </li>
+                                    <li class="level-1">
+                                        <a href="/news/en/agenda/weekly-agenda">
+                                            <span class="content">
+
+                                              <span class="label">Weekly agenda</span>
+                                            </span>
+                                        </a>
+                                    </li>
+                                    <li class="level-1">
+                                        <a href="/news/en/agenda/briefing">
+                                            <span class="content">
+
+                                              <span class="label">Briefing</span>
+                                            </span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li class="level-0">
+                                <a class="" href="/news/en/faq" aria-haspopup="true">
+                                  <span class="content">
+                                    <span class="label">FAQ</span>
+                                    <span class="current-element"></span>
+                                  </span>
+                                </a>
+                            </li>
+
+                            
+
+                            <li class="level-0 current">
+                                <a href="/news/en/press-room/press-tool-kit">
+                                    <span class="content">
+
+                                      <span class="label">Press Kit</span>
+                                    </span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </nav>
+                
+                    <!-- COMPOSANT "SEARCH MENU" -->
+
+                    <nav class="search-global-form" aria-label="Click to open the search component">
+                        <!-- Add class 'active' to change the style of the <a> -->
+                        <a href="#" class="search-icon" aria-haspopup="true" aria-expanded="false">
+                            <span class="sr-only">Access to search field</span>
+                            <span class="icon"></span>
+                        </a>
+                    </nav>
+                    <!-- Remove class 'posinit' to display the input search -->
+                    <form class="form-field-search" id="search" action="/news/en/search" method="get" role="search" aria-label="Search">
+                        <div class="field-wrapper">
+                            <div class="field">
+                                <input class="ep_field" type="text" id="search-field" name="searchQuery" value="" aria-label="Please fill out this field" title="Please fill out this field" placeholder="Search" required/>
+                                <button class="btn-send active" type="submit" aria-label="Launch the search" disabled>
+                                    <span class="sr-only">Launch the search</span>
+                                    <span class="icon">&nbsp;</span>
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                    <!-- TITLE ON SCROLL -->
+                    <span class="title-toolbar" aria-hidden="true"><span class="label">European Parliament</span></span>
+                
+            </div>
+
+        </div>
+        <!-- COMPOSANT "BREADCRUMB" -->
+        <nav id="website-breadcrumb" class="ep_breadcrumb" aria-label="You are here:">
+    <div class="ep_fulllist">
+        <span class="ep_mandatory">
+            
+    
+        <a class="ep_item" href="/news/en/press-room">
+            <span class="ep_hidden">Go back to page : Press room</span>
+            <span class="ep_name">Press room</span>
+            <span class="ep_icon">&nbsp;</span></a>
+        <span class="ep_separator"></span>
+    
+    
+
+        </span>
+
+        
+    <span class="ep_mandatory" aria-current="page">
+        <span class="ep_item">
+            <span class="ep_hidden">Current page:</span>
+            <span class="ep_name">MEPs: Georgia’s self-proclaimed authorities have no legitimacy</span>
+            <span class="ep_icon">&nbsp;</span>
+        </span>
+    </span>
+
+    </div>
+    <div class="ep_previouslink">
+        
+    
+        <a class="ep_item" href="/news/en/press-room">
+            <span class="ep_hidden">Go back to page : Press room</span>
+            <span class="ep_name">Press room</span>
+            <span class="ep_icon">&nbsp;</span></a>
+        <span class="ep_separator"></span>
+    
+    
+
+    </div>
+</nav>
+    </div>
+    <!-- END OF REFACTORING -->
+
+        
+        
+
+        
+        <article id="website-body" role="main">
+
+    
+    
+    
+        
+            <input type="hidden" id="webanalytic-id_chapters" value="press-room"/>
+        
+            <input type="hidden" id="webanalytic-id_sub-chapters" value="pressroom"/>
+        
+            <input type="hidden" id="webanalytic-id_sub-sub-chapters" value="the-eu-and-its-institutions~institutions"/>
+        
+            <input type="hidden" id="webanalytic-id_pages" value="georgia-resolution"/>
+        
+            <input type="hidden" id="webanalytic-id_type" value=""/>
+        
+            <input type="hidden" id="webanalytic-ep_bodies" value="plenary~10.02.2025~13.02.2025/committees~afet"/>
+        
+            <input type="hidden" id="webanalytics-topics_by_weeks" value=""/>
+        
+            <input type="hidden" id="webanalytics-priority_category" value=""/>
+        
+            <input type="hidden" id="webanalytics-priority_wordlink" value=""/>
+        
+            <input type="hidden" id="webanalytics-reference" value=""/>
+        
+            <input type="hidden" id="webanalytics-language" value=""/>
+        
+    
+
+
+    
+    <div class="ep_gridrow ep-o_product">
+        <div class="ep_gridrow-content">
+            <div class="ep_gridcolumn" data-view1200="2" data-view1020="2" data-view750="1" data-view640="1" data-view480="0" data-view320="0">
+                <div class="ep_gridcolumn-content">&nbsp;</div>
+            </div>
+            <div class="ep_gridcolumn ep-m_header" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                <div class="ep_gridcolumn-content">
+                    <div class="ep-a_heading ep-layout_level1">
+                        <h1 class="ep_title">
+                            <div class="ep-p_text"><span class="ep_name">MEPs: Georgia’s self-proclaimed authorities have no legitimacy</span><span class="ep_icon">&nbsp;</span></div>
+                        </h1>
+                        <div class="ep_subtitle">
+
+                            <div class="ep-p_text ep-layout_category"><span class="ep_name">Press Releases</span><span class="ep_icon">&nbsp;</span></div>
+
+                            
+
+                            
+
+    
+        <div class="ep-p_text ep-layout_contenttype ep-layout_plenary">
+            <a href="/news/en?contentType=plenary" >
+                <span class="ep_name">Plenary session</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+        
+    <div class="ep-p_text ep-layout_contenttype ep-layout_committee">
+        <a href="/news/en?contentType=committee&amp;keywordValue=AFET" >
+            <span class="ep_name"><abbr title="Foreign Affairs">AFET</abbr></span><span class="ep_icon">&nbsp;</span>
+        </a>
+    </div>
+
+    
+
+    
+
+
+
+                            
+    
+        
+        
+            
+    <div class="ep-p_text ep-layout_date">
+        <span class="ep_name">
+            
+    
+    
+        <time itemprop="datePublished"
+              datetime="2025-02-13T12:47:00">13-02-2025 - 12:47</time>
+    
+
+        </span><span class="ep_icon">&nbsp;</span>
+    </div>
+
+        
+
+    
+
+    
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    
+    <div class="ep_gridrow ep-o_product">
+        <div class="ep_gridrow-content">
+            <div class="ep_gridcolumn" data-view1200="1" data-view1020="1" data-view750="0" data-view640="0" data-view480="0" data-view320="0">
+                <div class="ep_gridcolumn-content">&nbsp;</div>
+            </div>
+
+            
+            
+                
+
+    <div class="ep_gridcolumn ep-m_product ep-layout_followingscroll" data-view1200="1" data-view1020="1" data-view750="1" data-view640="1" data-view480="0" data-view320="0">
+        <div class="ep_gridcolumn-content">
+            <div class="ep-a_share ep-layout_socialnetwok">
+                <div>
+                    
+
+    <div class="ep_share">
+        <h2 class="ep_title">
+            <div class="ep-p_text"><span class="ep_name">Share this page:</span><span class="ep_icon">&nbsp;</span></div>
+        </h2>
+        <ul>
+            <li>
+                <div class="ep-p_text ep-layout_facebook">
+                    <a href="https://www.facebook.com/share.php?u=https://www.europarl.europa.eu/news/en/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Bfacebook%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Bgeorgia-resolution%5D-" title="Share this page on Facebook" target="_blank" ><span class="ep_name">Facebook</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+            <li>
+                <div class="ep-p_text ep-layout_twitter">
+                    <a href="https://twitter.com/intent/tweet?text=MEPs:%20Georgia%E2%80%99s%20self-proclaimed%20authorities%20have%20no%20legitimacy&amp;url=https://www.europarl.europa.eu/news/en/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Btwitter%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Bgeorgia-resolution%5D-&amp;via=Europarl_EN" title="Share this page on Twitter" target="_blank"><span class="ep_name">Twitter</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+            <li>
+                <div class="ep-p_text ep-layout_linkedin">
+                    <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https://www.europarl.europa.eu/news/en/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Blinkedin%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Bgeorgia-resolution%5D%26&amp;title=European%20Parliament&amp;summary=&amp;source=" title="Share this page on LinkedIn" target="_blank" ><span class="ep_name">LinkedIn</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+
+            <li>
+                <div class="ep-p_text ep-layout_whatsapp">
+                    <a href="https://api.whatsapp.com/send?text=https://www.europarl.europa.eu/news/en/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Bwhatsapp%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Bgeorgia-resolution%5D%26" title="Share this page on WhatsApp" target="_blank"><span class="ep_name">WhatsApp</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+        </ul>
+    </div>
+
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+            
+
+            
+            <div class="ep_gridcolumn" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                <div class="ep_gridrow">
+                    <div class="ep_gridrow-content">
+
+                        
+                        
+                        
+
+    
+        
+            
+            
+            
+            
+            
+                
+
+    <!-- Fact list -->
+    <div class="ep_gridcolumn ep-m_product" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content">
+            <div class="ep-a_facts">
+                <div>
+                    
+                    <ul class="ep_list">
+                        
+                            
+    <li><div class="ep-p_text"><span class="ep_name">Parliament recognises Salome Zourabichvili as Georgia’s legitimate president</span><span class="ep_icon">&nbsp;</span></div></li>
+
+                        
+                            
+    <li><div class="ep-p_text"><span class="ep_name">Call for EU sanctions against leading Georgian politicians</span><span class="ep_icon">&nbsp;</span></div></li>
+
+                        
+                            
+    <li><div class="ep-p_text"><span class="ep_name">New elections are only way out of the current political crisis in Georgia </span><span class="ep_icon">&nbsp;</span></div></li>
+
+                        
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+        
+            
+            
+                
+
+    <div class="ep_gridcolumn ep-m_product" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content">
+            <div class="ep-a_text ep-layout_chapo">
+                <p>MEPs call on the international community to join the boycott of Georgia’s self-proclaimed authorities, who they accuse of eroding the country’s democracy and cracking down on dissents.</p>
+            </div>
+        </div>
+    </div>
+
+
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+        
+            
+            
+            
+            
+                
+
+    <!-- Text content -->
+    <div class="ep_gridcolumn ep-m_product" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content" >
+            <div class="ep-a_text"><p class="ep-wysiwig_paragraph">In a resolution adopted on Thursday, Parliament refuses to recognise the self-proclaimed authorities of the ruling Georgian Dream party following the rigged parliamentary elections on 26 October 2024, including the newly appointed President Mikheil Kavelashvili, and calls for the international community to join the boycott of Georgia’s ruling elite. MEPs continue to recognise Salome Zourabichvili as Georgia’s legitimate president and call on the President of the European Council António Costa to invite her to represent the country at upcoming meetings of the European Council and the European Political Community.</p>
+<p class="ep-wysiwig_paragraph">In the aftermath of the disputed elections, which plunged Georgia into a political and constitutional crisis, the country has witnessed ongoing peaceful mass anti-government protests, which have been met by a violent and repressive crackdown by police and law enforcement authorities. As a result, MEPs want the Council and EU member states to impose personal sanctions on the officials and political leaders in Georgia responsible for democratic backsliding, electoral fraud, human rights violations and the persecution of political opponents and activists. This includes, among others, the prominent oligarch Bidzina Ivanishvili, Prime Minister Irakli Kobakhidze, Parliamentary Speaker Shalva Papuashvili, as well as judges passing politically motivated sentences and media representatives spreading disinformation.</p>
+<p class="ep-wysiwig_paragraph"><strong>New elections needed </strong></p>
+<p class="ep-wysiwig_paragraph">The resolution also restates the only solution to the current crisis in Georgia is holding new parliamentary elections which, according to MEPs, should take place within the next few months, be conducted in an improved electoral environment and overseen by an independent and impartial election administration and monitored by international observers. Deeply regretting the ruling Georgian Dream party’s abandonment of its path toward European integration and NATO membership, Parliament reiterates its unwavering support for the Georgian people’s legitimate European aspirations.</p>
+<p class="ep-wysiwig_paragraph">The text was adopted by 400 votes in favour, 63 against with 81 abstentions. For all the details, it will be available in full <a href="https://www.europarl.europa.eu/plenary/en/texts-adopted.html" target="_blank" rel="noopener">here</a> (13.02.2025). <a href="https://www.europarl.europa.eu/plenary/en/votes.html?tab=votes#banner_session_live" target="_blank" rel="noopener">Find out how each MEP voted</a>.</p>
+<p class="ep-wysiwig_paragraph"><strong>Background</strong></p>
+<p class="ep-wysiwig_paragraph">Georgia was granted EU candidate status in December 2023. The country’s most recent parliamentary elections, however, were deemed neither free nor fair by the European Parliament, <a href="https://www.europarl.europa.eu/news/sv/press-room/20241121IPR25549/parliament-calls-for-new-elections-in-georgia" target="_blank" rel="noopener">with MEPs calling for a re-run of the elections within the next year</a>.</p></div>
+        </div>
+    </div>
+
+
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+        
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+        
+    
+
+
+
+
+                        
+                        
+
+    <!-- Contact -->
+    
+    <div class="ep_gridcolumn ep-m_product" role="region" aria-labelledby="asideregion584987" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        <div class="ep_gridcolumn-content">
+            <div class="ep-a_contacts">
+                <h2 class="ep_title" id="asideregion584987">
+                    <div class="ep-p_text"><span class="ep_name">Contacts:</span><span class="ep_icon">&nbsp;</span></div>
+                </h2>
+                <ul>
+                    
+                        <li class="ep_item">
+                            <div class="ep_card">
+                                <h3 class="ep_name">
+                                    <span class="ep-p_text"><span class="ep_name">Viktor ALMQVIST</span><span class="ep_icon">&nbsp;</span></span>
+                                </h3>
+                                
+                                
+                                    <div class="ep_information">
+                                        <span class="ep-p_text"><span class="ep_name">Press Officer</span><span class="ep_icon">&nbsp;</span></span>
+                                    </div>
+                                
+                                <div class="ep_data">
+                                    <div class="ep-p_text ep_hidden"><span class="ep_name">Contact data:</span><span class="ep_icon">&nbsp;</span></div>
+                                    <ul>
+                                        
+                                            
+                                                
+                                                    <li class="ep_phone">
+                                                        <a href="tel:(+32) 2 28 31834" class="ep-p_text"><span class="ep_name" title="Phone number"><span class="ep_hidden">Phone number: </span>(+32) 2 28 31834<abbr class="ep_location" title="Brussels"> (BXL)</abbr></span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_portable">
+                                                        <a href="tel:(+32) 470 88 29 42" class="ep-p_text"><span class="ep_name" title="Mobile number"><span class="ep_hidden">Mobile number: </span>(+32) 470 88 29 42</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_mail">
+                                                        <a href="mailto:viktor.almqvist@europarl.europa.eu" class="ep-p_text" title="E-mail: viktor.almqvist@europarl.europa.eu"><span class="ep_name"><span class="ep_hidden">E-mail:  </span>viktor.almqvist@europarl.europa.eu</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_mail">
+                                                        <a href="mailto:foreign-press@europarl.europa.eu" class="ep-p_text" title="E-mail: foreign-press@europarl.europa.eu"><span class="ep_name"><span class="ep_hidden">E-mail:  </span>foreign-press@europarl.europa.eu</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                
+                                                    <li class="ep_twitter">
+                                                        <a href="http://twitter.com/EP_ForeignAff" class="ep-p_text" title="Open a Twitter account in a new window" target="_blank"><span class="ep_name"><span class="ep_hidden">Twitter account: </span>@EP_ForeignAff</span><span class="ep_icon">&nbsp;</span></a>
+                                                    </li>
+                                                
+                                                
+                                            
+                                        
+                                    </ul>
+                                </div>
+                            </div>
+                            
+                        </li>
+                    
+                </ul>
+            </div>
+        </div>
+    </div>
+
+
+
+                    </div>
+                </div>
+            </div>
+            <!-- ADDITIONAL LINKS COLUMN -->
+            <section class="ep_gridcolumn ep-layout_followingscroll" data-view1200="3" data-view1020="3" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
+                <div class="ep_gridrow">
+                    <div class="ep_gridrow-content">
+                        <div class="ep_gridcolumn" data-view1200="0" data-view1020="0" data-view750="1" data-view640="1" data-view480="0" data-view320="0">
+                            <div class="ep_gridcolumn-content">&nbsp;</div>
+                        </div>
+                        <div class="ep_gridcolumn" data-view1200="3" data-view1020="3" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                            <div class="ep_gridrow">
+                                <div class="ep_gridrow-content">
+
+                                    
+                                    
+
+                                    
+                                    
+                                        
+                                            
+                                        
+                                    
+                                        
+                                            
+                                        
+                                    
+                                        
+                                            
+                                        
+                                    
+                                        
+                                            
+                                                
+    <!-- List of links -->
+    <div class="ep_gridcolumn ep-m_product" data-layout1200="border" data-layout1020="border" data-view1200="3" data-view1020="3" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+        
+    <div class="ep_gridcolumn-content">
+        <div class="ep-a_links">
+            <h2 class="ep_title">
+                <div class="ep-p_text"><span class="ep_name">Further information</span><span class="ep_icon">&nbsp;</span></div>
+            </h2>
+            <ul class="ep_list">
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" href="/plenary/en/vod.html?mode=chapter&amp;vodLanguage=EN&amp;playerStartTime=20250121-19:49:05&amp;playerEndTime=20250121-20:34:12"><span class="ep_name">Watch a video recording of the plenary debate (21.01.2025)</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+                    
+
+    
+
+        
+        
+
+            
+
+            
+
+            
+
+            
+            
+                
+    <li>
+        <div class="ep-p_text ep-layout_page">
+            <a title="Open in a new page" target="_blank" href="https://multimedia.europarl.europa.eu/en"><span class="ep_name">EP Multimedia Centre: free photos, video and audio material</span><span class="ep_icon">&nbsp;</span>
+            </a>
+        </div>
+    </li>
+
+            
+        
+
+    
+
+
+                
+            </ul>
+        </div>
+    </div>
+
+    </div>
+
+                                            
+                                        
+                                    
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Product reference -->
+            <div class="ep_gridcolumn" data-view1200="12" data-view1020="12" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
+                <div class="ep_gridrow">
+                    <div class="ep_gridrow-content">
+                        <div class="ep_gridcolumn" data-view1200="2" data-view1020="2" data-view750="1" data-view640="1" data-view480="0" data-view320="0">
+                            <div class="ep_gridcolumn-content">&nbsp;</div>
+                        </div>
+                        <div class="ep_gridcolumn" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                            <div class="ep_gridrow">
+                                <div class="ep_gridrow-content">
+                                    <div class="ep_gridcolumn ep-m_footer" data-view1200="6" data-view1020="6" data-view750="10" data-view640="6" data-view480="8" data-view320="4">
+                                        <div class="ep_gridcolumn-content">
+                                            <h2 class="ep-a_heading ep_hidden">
+                                                <div class="ep_title">
+                                                    <div class="ep-p_text"><span class="ep_name">Product information</span><span class="ep_icon">&nbsp;</span></div>
+                                                </div>
+                                            </h2>
+                                            <div class="ep-a_reference">
+                                                <div class="ep_reference">
+                                                    <span class="ep-p_text"><span class="ep_name"><abbr title="Product reference">Ref.:</abbr></span><span class="ep_icon">&nbsp;</span></span>
+                                                    <span class="ep-p_text"><span class="ep_name">20250204IPR26689</span><span class="ep_icon">&nbsp;</span></span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+    
+    
+        
+
+    <div class="ep_gridrow ep-o_footerpage">
+        <div class="ep_gridrow-content">
+            <div class="ep_gridcolumn ep-m_product" data-view1200="12" data-view1020="12" data-view750="12" data-view640="8" data-view480="8" data-view320="4">
+                <div class="ep_gridcolumn-content">
+                    <div class="ep-a_share">
+                        <div>
+                            
+
+    <div class="ep_share">
+        <h2 class="ep_title">
+            <div class="ep-p_text"><span class="ep_name">Share this page:</span><span class="ep_icon">&nbsp;</span></div>
+        </h2>
+        <ul>
+            <li>
+                <div class="ep-p_text ep-layout_facebook">
+                    <a href="https://www.facebook.com/share.php?u=https://www.europarl.europa.eu/news/en/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Bfacebook%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Bgeorgia-resolution%5D-" title="Share this page on Facebook" target="_blank" ><span class="ep_name">Facebook</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+            <li>
+                <div class="ep-p_text ep-layout_twitter">
+                    <a href="https://twitter.com/intent/tweet?text=MEPs:%20Georgia%E2%80%99s%20self-proclaimed%20authorities%20have%20no%20legitimacy&amp;url=https://www.europarl.europa.eu/news/en/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Btwitter%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Bgeorgia-resolution%5D-&amp;via=Europarl_EN" title="Share this page on Twitter" target="_blank"><span class="ep_name">Twitter</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+            <li>
+                <div class="ep-p_text ep-layout_linkedin">
+                    <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https://www.europarl.europa.eu/news/en/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Blinkedin%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Bgeorgia-resolution%5D%26&amp;title=European%20Parliament&amp;summary=&amp;source=" title="Share this page on LinkedIn" target="_blank" ><span class="ep_name">LinkedIn</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+
+            <li>
+                <div class="ep-p_text ep-layout_whatsapp">
+                    <a href="https://api.whatsapp.com/send?text=https://www.europarl.europa.eu/news/en/press-room/20250204IPR26689/meps-georgia-s-self-proclaimed-authorities-have-no-legitimacy?xtor%3DAD-78-%5BSocial_share_buttons%5D-%5Bwhatsapp%5D-%5Ben%5D-%5Bnews%5D-%5Bpressroom%5D-%5Bgeorgia-resolution%5D%26" title="Share this page on WhatsApp" target="_blank"><span class="ep_name">WhatsApp</span><span class="ep_icon">&nbsp;</span></a>
+                </div>
+            </li>
+        </ul>
+    </div>
+
+
+                            <div class="ep_links">
+                                <div class="ep-p_text ep-layout_mail"><a href="/subscription/en"><span class="ep_name">Sign up for mail updates</span></a></div>
+
+                                
+                                <div class="ep-p_text ep-layout_pdf"><a href="/pdfs/news/expert/2025/2/press_release/20250204IPR26689/20250204IPR26689_en.pdf"><span class="ep_name">PDF version</span><span class="ep_icon">&nbsp;</span></a></div>
+
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+    
+
+
+</article>
+
+        
+        
+            
+
+    <footer id="website-footer" role="contentinfo">
+        
+        <div class="ep_footer-relatedlinks">
+            <div class="ep_websitelinks" id="website-links">
+                <h2 class="ep_title" id="website-links-title">
+                    <span class="ep_name">News</span>
+                    <span class="ep_icon">&nbsp;</span>
+                </h2>
+                <div class="ep_menu-access ep_openaccess" id="website-links-access" aria-controls="website-links-content" role="tab">
+                    <a href="#website-links">
+                        <span class="ep_name">View menu: News</span>
+                        <span class="ep_icon">&nbsp;</span></a>
+                </div>
+                <div class="ep_list ep-layout_category" id="website-links-content">
+                    <div>
+                        <div class="ep_category">
+                            <h3 class="ep_subtitle" id="website-links-category1-title">
+                                <span class="ep_name">Parliament in your country</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </h3>
+                            
+                                <ul aria-labelledby="website-links-category1-title">
+                                    
+                                        <li class="ep_item">
+                                            <a href="/unitedkingdom" class="ep_button" target="_blank" >
+                                                <span class="ep_hidden">Open in a new page</span>
+                                                <span class="ep_name">London</span>
+                                            </a>
+                                        </li>
+                                    
+                                        <li class="ep_item">
+                                            <a href="/ireland" class="ep_button" target="_blank" >
+                                                <span class="ep_hidden">Open in a new page</span>
+                                                <span class="ep_name">Dublin</span>
+                                            </a>
+                                        </li>
+                                    
+                                        <li class="ep_item">
+                                            <a href="/malta" class="ep_button" target="_blank" >
+                                                <span class="ep_hidden">Open in a new page</span>
+                                                <span class="ep_name">Valletta</span>
+                                            </a>
+                                        </li>
+                                    
+                                        <li class="ep_item">
+                                            <a href="/unitedstates" class="ep_button" target="_blank" >
+                                                <span class="ep_hidden">Open in a new page</span>
+                                                <span class="ep_name">Washington</span>
+                                            </a>
+                                        </li>
+                                    
+                                </ul>
+                            
+                        </div>
+                        <div class="ep_category">
+                            <h3 class="ep_subtitle" id="website-links-category2-title">
+                                <span class="ep_name">Tools</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </h3>
+                            <ul aria-labelledby="website-links-category2-title">
+                                <li class="ep_item">
+                                    <a href="/oeil/home/home.do" class="ep_button">
+                                        <span class="ep_hidden">Open in a new page</span>
+                                        <span class="ep_name">Legislative Observatory</span>
+                                    </a>
+                                </li>
+                                <li class="ep_item">
+                                    <a href="https://multimedia.europarl.europa.eu/en" class="ep_button" target="_blank" >
+                                        <span class="ep_hidden">Open in a new page</span>
+                                        <span class="ep_name">Multimedia Centre</span>
+                                    </a>
+                                </li>
+                                <li class="ep_item">
+                                    <a href="https://ec.europa.eu/avservices/ebs/schedule.cfm?sitelang=en"  class="ep_button" target="_blank" >
+                                        <span class="ep_hidden">Open in a new page</span>
+                                        <span class="ep_name">EbS</span>
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="ep_category">
+                            <h3 class="ep_subtitle" id="website-links-category3-title">
+                                <span class="ep_name">The President of the European Parliament</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </h3>
+                            <ul aria-labelledby="website-links-category3-title">
+                                <li class="ep_item">
+                                    <a href="/the-president/en/" class="ep_button">
+                                        <span class="ep_hidden">Open in a new page</span>
+                                        <span class="ep_name">European Parliament President’s website</span>
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="ep_menu-access ep_closeaccess">
+                    <a href="#website-links-access" title="Hide menu">
+                        <span class="ep_name">Hide menu: News</span>
+                        <span class="ep_icon">&nbsp;</span>
+                    </a>
+                </div>
+            </div>
+            <div class="ep_europarllinks" id="europarl-links">
+                <h2 class="ep_title" id="europarl-links-title">
+                    <span class="ep_name">European Parliament</span>
+                    <span class="ep_icon">&nbsp;</span>
+                </h2>
+                <div class="ep_menu-access ep_openaccess" id="europarl-links-access" aria-controls="europarl-links-content" role="tab">
+                    <a href="#europarl-links" >
+                        <span class="ep_name">View menu: European Parliament</span>
+                        <span class="ep_icon">&nbsp;</span>
+                    </a>
+                </div>
+                <div class="ep_list">
+                    <ul id="europarl-links-content" aria-labelledby="europarl-links-title">
+                        <li class="ep_item">
+                            <a class="ep_button" href="/news/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">News</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/topics/en" >
+                                <span class="ep_name">Topics</span><span class="icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/meps/en/home" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">MEPs</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/about-parliament/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">About Parliament</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/plenary/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">Plenary</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/committees/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">Committees</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="/delegations/en" >
+                                <span class="ep_hidden">Open in a new page</span>
+                                <span class="ep_name">Delegations</span><span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                        <li class="ep_item">
+                            <a class="ep_button" href="https://elections.europa.eu/en" >
+                                <span class="ep_name">Elections</span><span class="icon">&nbsp;</span>
+                            </a>
+                        </li>
+
+                    </ul>
+                </div>
+                <div class="ep_menu-access ep_closeaccess">
+                    <a href="#europarl-links-access" title="Hide menu"><span class="ep_name">Hide menu: European Parliament</span><span class="ep_icon">&nbsp;</span></a></div>
+            </div>
+        </div>
+        <span class="ep_footer-separator">&nbsp;</span>
+        <div class="ep_footer-otherlinks">
+            
+            <div class="ep_sociallinks" id="socialmedia">
+                <h2 class="ep_hidden" id="socialmedia-title">
+                    <span class="ep_name">The Parliament on social media</span>
+                    <span class="ep_icon">&nbsp;</span>
+                </h2>
+                <div class="ep_list">
+                    <ul aria-labelledby="socialmedia-title">
+                        <li class="ep_item">
+                            <a href="https://www.facebook.com/europeanparliament"  class="ep_button ep_facebook" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Facebook</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://twitter.com/Europarl_en" class="ep_button ep_twitter" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Twitter</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.flickr.com/photos/european_parliament/" class="ep_button ep_flickr"	target="_blank" >
+                                <span class="ep_name">Check out Parliament on Flickr</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.linkedin.com/company/european-parliament" class="ep_button ep_linkedin" target="_blank" >
+                                <span class="ep_name">Check out Parliament on LinkedIn</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.youtube.com/user/EuropeanParliament" class="ep_button ep_youtube" target="_blank" >
+                                <span class="ep_name">Check out Parliament on YouTube</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://instagram.com/europeanparliament" class="ep_button ep_instagram" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Instagram</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.pinterest.com/epinfographics/" class="ep_button ep_pinterest" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Pinterest</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.snapchat.com/add/europarl" class="ep_button ep_snapchat" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Snapchat</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                        <li class="ep_item">
+                            <a href="https://www.reddit.com/r/europeanparliament/" class="ep_button ep_reddit" target="_blank" >
+                                <span class="ep_name">Check out Parliament on Reddit</span>
+                                <span class="ep_icon">&nbsp;</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <!-- COMPOSANT "MANDATORY LINKS" -->
+            <div class="ep_mandatorylinks" id="informationlinks">
+                <h2 class="ep_hidden" id="informationlinks-title"><span class="ep_name">Information links</span><span class="ep_icon">&nbsp;</span></h2>
+                <div class="ep_list">
+                    <ul aria-labelledby="informationlinks-title">
+                        <li class="ep_item"><a href="/portal/en/contact"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Contact</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/at-your-service/en/stay-informed/rss-feeds"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">RSS</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/portal/en/sitemap"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Sitemap</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/legal-notice/en"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Legal notice</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/privacy-policy/en/"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Privacy policy</span><span class="ep_icon">&nbsp;</span></a></li>
+                        <li class="ep_item"><a href="/portal/en/accessibility"  class="ep_button"><span class="ep_hidden">Open in a new page</span><span class="ep_name">Accessibility</span><span class="ep_icon">&nbsp;</span></a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+
+        
+    </div>
+
+    <!-- Backdrop / Gray Overlay for compact menu opening-->
+    <div class="back-overlay"></div>
+
+    
+    
+
+    
+    
+        <script>
+            (function rewriteUrlIfNeeded() {
+                function getHash(url) {
+                    return url.hash !== '' && document.getElementById(url.hash.slice(1)) ?
+                        url.hash :
+                        '';
+                }
+
+                function rewriteUrl(currentUrl, baseUrl) {
+                    // ensure that hash is present only if it actually exists
+                    const url = new URL(currentUrl);
+                    return `${baseUrl}${url.search}${getHash(url)}`;
+                }
+
+                // pre-condition: #dev_product_url ALWAYS exists see <input ...> above.
+                const productUrl = document.getElementById('dev_product_url').value;
+
+                if (productUrl === '') {
+                    return;
+                }
+
+                const newUrl = rewriteUrl(window.location.href, productUrl);
+
+                if (newUrl !== window.location.href) {
+                    window.history.replaceState(null, '', newUrl)
+                }
+            }())
+        </script>
+    
+
+        <script type="text/javascript">
+            // safari blinking workaround. Cf jira ENG-32999 & ENG-33001
+        </script>
+    </body>
+
+</html>

--- a/backend/tests/scrapers/test_press_releases.py
+++ b/backend/tests/scrapers/test_press_releases.py
@@ -26,6 +26,12 @@ def test_press_release_scraper(responses):
         fragment.data.get("facts")
         == "<ul><li>Faster roll-out of recharging stations needed on main EU roads</li><li>Easy to use and affordable recharging/refuelling</li><li>Fewer emissions in the maritime sector</li></ul>"
     )
+    assert fragment.data.get("text").startswith(
+        "To help the EU become climate neutral, MEPs want car-recharging stations every 60 km, hydrogen refuelling stations every 100 km and fewer emissions from ships."
+    )
+    assert fragment.data.get("text").endswith(
+        "Parliament is now ready to start negotiations with member states."
+    )
 
 
 def test_press_release_scraper_new_procedure_urls(responses):
@@ -37,3 +43,19 @@ def test_press_release_scraper_new_procedure_urls(responses):
     scraper = PressReleaseScraper(release_id="20241212IPR25960")
     fragment = scraper.run()
     assert fragment.data.get("procedure_reference") == ["2024/0275(COD)", "2024/0274(COD)"]
+
+
+def test_press_releases_scraper_old_text_selector(responses):
+    responses.get(
+        "https://www.europarl.europa.eu/news/en/press-room/20190712IPR56948",
+        body=load_fixture("scrapers/data/press_releases/press-release_20190712IPR56948.html"),
+    )
+
+    scraper = PressReleaseScraper(release_id="20190712IPR56948")
+    fragment = scraper.run()
+    assert fragment.data.get("text").startswith(
+        "For the third time this year, the European Parliament adopted a resolution on the situation in Venezuela, expressing its deep concern at the severe state of emergency"
+    )
+    assert fragment.data.get("text").endswith(
+        "Parliament praises the efforts and solidarity shown by neighbouring countries, in particular Colombia, Ecuador and Peru and ask the Commission to continue cooperating with these countries."
+    )

--- a/backend/tests/test_query.py
+++ b/backend/tests/test_query.py
@@ -8,14 +8,12 @@ from howtheyvote.models import (
     GroupMembership,
     Member,
     PlenarySession,
-    PressRelease,
     Vote,
 )
 from howtheyvote.query import (
     fragments_for_records,
     member_active_at,
     member_has_term,
-    press_release_references_vote,
     session_is_current_at,
 )
 
@@ -122,90 +120,6 @@ def test_session_is_current_at(db_session):
     query = select(PlenarySession.id).where(session_is_current_at(datetime.date(2023, 1, 5)))
     ids = set(db_session.execute(query).scalars())
     assert ids == set()
-
-
-def test_press_release_references_vote(db_session):
-    timestamp = datetime.datetime(2023, 1, 1, 0, 0, 0)
-
-    vote = Vote(
-        id=12345,
-        reference="A9-1234/2023",
-        timestamp=timestamp,
-    )
-
-    press_release_1 = PressRelease(
-        id="1",
-        references=["A9-5678/2023"],
-        published_at=timestamp,
-    )
-
-    press_release_2 = PressRelease(
-        id="2",
-        references=["A9-1234/2023"],
-        published_at=timestamp,
-    )
-
-    press_release_3 = PressRelease(
-        id="3",
-        references=["A9-1234/2023", "A9-5678/2023"],
-        published_at=timestamp,
-    )
-
-    press_release_4 = PressRelease(
-        id="4",
-        references=["A9-1234/2023"],
-        published_at=timestamp + datetime.timedelta(days=1),
-    )
-
-    db_session.add(vote)
-    db_session.add_all([press_release_1, press_release_2, press_release_3, press_release_4])
-    db_session.commit()
-
-    query = select(PressRelease.id).where(press_release_references_vote(vote))
-    ids = set(db_session.execute(query).scalars())
-    assert ids == {"2", "3"}
-
-
-def test_press_release_references_vote_procedure(db_session):
-    timestamp = datetime.datetime(2023, 1, 1, 0, 0, 0)
-
-    vote = Vote(
-        id=12345,
-        procedure_reference="2023/1234(COD)",
-        timestamp=timestamp,
-    )
-
-    press_release_1 = PressRelease(
-        id="1",
-        procedure_references=["2023/5678(COD)"],
-        published_at=timestamp,
-    )
-
-    press_release_2 = PressRelease(
-        id="2",
-        procedure_references=["2023/1234(COD)"],
-        published_at=timestamp,
-    )
-
-    press_release_3 = PressRelease(
-        id="3",
-        procedure_references=["2023/1234(COD)", "2023/5678(COD)"],
-        published_at=timestamp,
-    )
-
-    press_release_4 = PressRelease(
-        id="4",
-        procedure_references=["2023/1234(COD)"],
-        published_at=timestamp + datetime.timedelta(days=1),
-    )
-
-    db_session.add(vote)
-    db_session.add_all([press_release_1, press_release_2, press_release_3, press_release_4])
-    db_session.commit()
-
-    query = select(PressRelease.id).where(press_release_references_vote(vote))
-    ids = set(db_session.execute(query).scalars())
-    assert ids == {"2", "3"}
 
 
 def test_fragments_for_record(db_session):

--- a/backend/tests/test_vote_stats.py
+++ b/backend/tests/test_vote_stats.py
@@ -1,0 +1,69 @@
+from howtheyvote.models import MemberVote, VotePosition
+from howtheyvote.vote_stats import count_vote_positions, count_vote_positions_by_group
+
+
+def test_count_vote_positions():
+    assert count_vote_positions([]) == {
+        "FOR": 0,
+        "AGAINST": 0,
+        "ABSTENTION": 0,
+        "DID_NOT_VOTE": 0,
+    }
+
+    member_votes = [
+        MemberVote(web_id=1, position=VotePosition.FOR),
+        MemberVote(web_id=2, position=VotePosition.FOR),
+        MemberVote(web_id=3, position=VotePosition.DID_NOT_VOTE),
+        MemberVote(web_id=4, position=VotePosition.ABSTENTION),
+    ]
+
+    assert count_vote_positions(member_votes) == {
+        "FOR": 2,
+        "AGAINST": 0,
+        "ABSTENTION": 1,
+        "DID_NOT_VOTE": 1,
+    }
+
+
+def test_count_vote_positions_by_group():
+    member_countries = {
+        1: "FRA",
+        2: "DEU",
+        3: "ITA",
+        4: "DEU",
+    }
+
+    member_votes = [
+        MemberVote(web_id=1, position=VotePosition.FOR),
+        MemberVote(web_id=2, position=VotePosition.FOR),
+        MemberVote(web_id=3, position=VotePosition.ABSTENTION),
+        MemberVote(web_id=4, position=VotePosition.DID_NOT_VOTE),
+    ]
+
+    grouped_counts = count_vote_positions_by_group(
+        member_votes=member_votes, group_by=lambda mv: member_countries[mv.web_id]
+    )
+
+    expected = {
+        "DEU": {
+            "FOR": 1,
+            "AGAINST": 0,
+            "ABSTENTION": 0,
+            "DID_NOT_VOTE": 1,
+        },
+        "FRA": {
+            "FOR": 1,
+            "AGAINST": 0,
+            "ABSTENTION": 0,
+            "DID_NOT_VOTE": 0,
+        },
+        "ITA": {
+            "FOR": 0,
+            "AGAINST": 0,
+            "ABSTENTION": 1,
+            "DID_NOT_VOTE": 0,
+        },
+    }
+
+    assert grouped_counts == expected
+    assert list(grouped_counts.keys()) == ["DEU", "FRA", "ITA"]  # Sorted by group size


### PR DESCRIPTION
We can currently only match press releases with votes if the press release references a report or procedure. For non-legislative procedures, this is usually not the case. However, even press releases about non-legislative procedures usually mention the vote results (how many MEPs voted for/against/abstained). If there is exactly one vote with the same result on the day of the press release, we can use that info to match the press release to the vote.

I’ve implemented this as follows:

* As a first step, we now scrape the full text of a press release and try to extract vote results ("the text was adopted with x votes in favour, y against, and z abstentions" and similar wordings).

* Previously, we matched press releases to votes "on the fly" based on document and procedure references (which is fairly simple). Now, as the matching is getting a bit more complex, we do the matching as part of the `PressReleasesPipeline` and store the result in the database. Every vote now has a reference to the corresponding press release (if there is one).

* In order to match press releases to votes, we take document and procedure references (as before) as well as the vote results into account (new).

**Post deployment:**
* Run `htv press-releases` to re-scrape and match all press releases.
* Run `htv aggregate votes`

**To do:**

- [x] Scrape full text of press releases
- [x] Extract mentioned vote results from press release text
- [x] Persist matching of press releases and votes to database
- [x] Match press releases and votes based on vote result
- [x] Add CLI command to rerun press release scraper and analyzer for all existing press releases and votes
- [ ] ~Remove `is_featured` from database?~