### PR TITLE
Fix installing Python dependencies in Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,10 +21,9 @@ RUN pip install poetry
 
 WORKDIR /howtheyvote/backend
 
-# Copy dependencies required to install dependencies
-COPY pyproject.toml pyproject.toml
-COPY poetry.toml poetry.toml
-COPY poetry.lock poetry.lock
+# Copy files required to install dependencies
+COPY pyproject.toml poetry.toml poetry.lock .
+
 RUN poetry env use python3.12
 
 # Install only dependencies, but not the package itself (because that

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,12 +26,16 @@ COPY pyproject.toml pyproject.toml
 COPY poetry.toml poetry.toml
 COPY poetry.lock poetry.lock
 RUN poetry env use python3.12
-RUN poetry install
+
+# Install only dependencies, but not the package itself (because that
+# would fail because we haven't yet copied the code at this point)
+RUN poetry install --no-root
 
 COPY . .
 
-# Install again in order to make the `htv` CLI script available
-RUN poetry install
+# Install again in order to make the `htv` CLI script available, this
+# time without the dependencies (which have been installed before)
+RUN poetry install --only-root
 
 ENV TZ=UTC
 ENV ALEMBIC_CONFIG=./howtheyvote/alembic/alembic.ini

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,13 +2,9 @@ FROM node:22-alpine3.19 as dev
 
 WORKDIR /howtheyvote/frontend
 
-RUN apk add make bash
+RUN apk add make bash entr
 
-# File watcher for development
-RUN apk add entr
-
-COPY package.json package.json
-COPY package-lock.json package-lock.json
+COPY package.json package-lock.json .
 RUN npm ci
 
 COPY . .


### PR DESCRIPTION
Follow up to 9f243166c95f80c3252b231cd9e0a37baefe968a. I’ve also sneaked in a small change to reduce the number of Docker layers for the backend and frontend images.