### PR TITLE
Configure Flask app logger

### DIFF
--- a/backend/howtheyvote/__init__.py
+++ b/backend/howtheyvote/__init__.py
@@ -11,6 +11,7 @@ logging.basicConfig(
 
 structlog.configure(
     processors=[
+        structlog.contextvars.merge_contextvars,
         structlog.stdlib.filter_by_level,
         structlog.stdlib.add_logger_name,
         structlog.processors.add_log_level,


### PR DESCRIPTION
We use structlog for logging and set it up to emit JSON formatted logs. Flask also emits some logs by default, e.g. in case of an unhandled exception. These were logged using a standard library logger so far (i.e. not as JSON).

I’ve now configured Flask to use a structlog logger. In addition, matched endpoint, request path and query string are added to all logs to ease debugging. Here’s what the logs look like in case of an unhandled exception:

```json
 {
   "event": "Exception on /api/votes/search [GET]",
   "endpoint": "api.votes_api.search",
   "path": "/api/votes/search",
   "query_string": "q=lorem%20ipsum",
   "logger": "howtheyvote.wsgi",
   "level": "error",
   "timestamp": "2025-03-14T21:40:52.732049Z",
   "exception": "Traceback (most recent..."
}
```

To test this, Flask has to run in production mode. One way to achieve that is by uncommenting the `command: make dev` line in `docker-compose.override.yml`. 