### PR TITLE
Add EuroVoc concepts, geographic areas to CSV export

### DIFF
--- a/backend/howtheyvote/alembic/versions/7c9e86276c6d_remove_is_featured_column_from_votes_.py
+++ b/backend/howtheyvote/alembic/versions/7c9e86276c6d_remove_is_featured_column_from_votes_.py
@@ -1,0 +1,24 @@
+"""Remove is_featured column from votes table
+
+Revision ID: 7c9e86276c6d
+Revises: 848ef24718dd
+Create Date: 2025-03-14 22:46:51.712125
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "7c9e86276c6d"
+down_revision = "848ef24718dd"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("votes", "is_featured")
+
+
+def downgrade() -> None:
+    op.add_column("votes", sa.Column("is_featured", sa.Boolean))

--- a/backend/howtheyvote/api/query.py
+++ b/backend/howtheyvote/api/query.py
@@ -318,7 +318,7 @@ class SearchQuery(Query[T]):
             query = XapianQuery(
                 XapianQuery.OP_AND_MAYBE,
                 query,
-                self._xapian_featured_subquery(),
+                self._xapian_press_release_subquery(),
             )
 
             query = XapianQuery(
@@ -384,11 +384,12 @@ class SearchQuery(Query[T]):
             self.BOOST_PHRASE,
         )
 
-    def _xapian_featured_subquery(self) -> XapianQuery:
-        # This subquery assigns a constant weight to featured votes and 0 otherwise.
+    def _xapian_press_release_subquery(self) -> XapianQuery:
+        # This subquery assigns a constant weight to votes with a press release and
+        # 0 otherwise.
         return XapianQuery(
             XapianQuery.OP_SCALE_WEIGHT,
-            XapianQuery(ValueWeightPostingSource(field_to_slot("is_featured"))),
+            XapianQuery(ValueWeightPostingSource(field_to_slot("has_press_release"))),
             self.BOOST_FEATURED,
         )
 

--- a/backend/howtheyvote/api/serializers.py
+++ b/backend/howtheyvote/api/serializers.py
@@ -246,11 +246,6 @@ class BaseVoteDict(TypedDict):
     description: Annotated[str | None, "Commission proposal"]
     """Description of the vote as published in the roll-call vote results"""
 
-    is_featured: bool
-    """Whether this vote is featured. Currently, a vote is featured when we have found an
-    official press release about the vote published by the European Parliament Newsroom.
-    However, this is subject to change."""
-
     geo_areas: list[CountryDict]
     """Countries or territories related to this vote"""
 
@@ -275,7 +270,6 @@ def serialize_base_vote(vote: Vote) -> BaseVoteDict:
         "display_title": vote.display_title,
         "description": vote.description,
         "reference": vote.reference,
-        "is_featured": vote.is_featured,
         "geo_areas": geo_areas,
         "eurovoc_concepts": eurovoc_concepts,
         "responsible_committee": responsible_committee,

--- a/backend/howtheyvote/export/__init__.py
+++ b/backend/howtheyvote/export/__init__.py
@@ -497,7 +497,11 @@ class Export:
             concept_ids = Session.execute(query).scalars()
 
             for concept_id in concept_ids:
-                concept = EurovocConcept[concept_id]
+                # `if True else None` is a hack to make mypy treat this as a normal value
+                # expression and not as a type expression. If this keeps causing type checking
+                # issues we might want to reconsider the use of metaclasses for this purpose.
+                # See: https://github.com/python/mypy/issues/15107
+                concept = EurovocConcept[concept_id] if True else None
                 eurovoc_concepts.write_row({"id": concept.id, "label": concept.label})
 
     def export_geo_areas(self) -> None:
@@ -511,7 +515,11 @@ class Export:
             geo_area_codes = Session.execute(query).scalars()
 
             for geo_area_code in geo_area_codes:
-                geo_area = Country[geo_area_code]
+                # `if True else None` is a hack to make mypy treat this as a normal value
+                # expression and not as a type expression. If this keeps causing type checking
+                # issues we might want to reconsider the use of metaclasses for this purpose.
+                # See: https://github.com/python/mypy/issues/15107
+                geo_area = Country[geo_area_code] if True else None
                 geo_areas.write_row(
                     {
                         "code": geo_area.code,

--- a/backend/howtheyvote/export/__init__.py
+++ b/backend/howtheyvote/export/__init__.py
@@ -133,11 +133,6 @@ class VoteRow(TypedDict):
     votes. This is not an official classification by the European Parliament and there may
     be false negatives."""
 
-    is_featured: bool
-    """Whether this vote is featured. Currently, a vote is featured when we have found an
-    official press release about the vote published by the European Parliament Newsroom.
-    However, this is subject to change."""
-
     procedure_reference: str | None
     """Procedure reference as listed in the Legislative Observatory"""
 
@@ -365,7 +360,6 @@ class Export:
                         "reference": vote.reference,
                         "description": vote.description,
                         "is_main": vote.is_main,
-                        "is_featured": vote.is_featured,
                         "procedure_reference": vote.procedure_reference,
                         "procedure_title": vote.procedure_title,
                         "responsible_committee_code": responsible_committee_code,

--- a/backend/howtheyvote/metrics.py
+++ b/backend/howtheyvote/metrics.py
@@ -37,15 +37,13 @@ class DataCollector(Collector):
         gauge = GaugeMetricFamily(
             "htv_votes",
             "Total number of votes",
-            labels=["year", "is_main", "is_featured"],
+            labels=["year", "is_main"],
         )
         year = func.strftime("%Y", Vote.timestamp)
-        query = select(Vote.is_main, Vote.is_featured, year, func.count()).group_by(
-            Vote.is_main, Vote.is_featured, year
-        )
+        query = select(Vote.is_main, year, func.count()).group_by(Vote.is_main, year)
 
-        for is_main, is_featured, year, count in Session.execute(query):
-            gauge.add_metric(value=count, labels=[str(year), str(is_main), str(is_featured)])
+        for is_main, year, count in Session.execute(query):
+            gauge.add_metric(value=count, labels=[str(year), str(is_main)])
 
         return gauge
 

--- a/backend/howtheyvote/models/vote.py
+++ b/backend/howtheyvote/models/vote.py
@@ -90,7 +90,6 @@ class Vote(BaseWithId):
     reference: Mapped[str | None] = mapped_column(sa.Unicode)
     description: Mapped[str | None] = mapped_column(sa.Unicode)
     is_main: Mapped[bool] = mapped_column(sa.Boolean, default=False)
-    is_featured: Mapped[bool] = mapped_column(sa.Boolean, default=False)
     group_key: Mapped[str | None] = mapped_column(sa.Unicode)
     member_votes: Mapped[list[MemberVote]] = mapped_column(ListType(MemberVoteType()))
     geo_areas: Mapped[list[Country]] = mapped_column(ListType(CountryType()))

--- a/backend/howtheyvote/search.py
+++ b/backend/howtheyvote/search.py
@@ -37,7 +37,6 @@ FIELD_TO_PREFIX_MAPPING = {
     "rapporteur": "XRA",
     "reference": "XR",
     "procedure_reference": "XPR",
-    "is_featured": "XF",
 }
 
 # Each document can have a set of values associated with it. Values are similar to DocValues
@@ -48,7 +47,7 @@ FIELD_TO_PREFIX_MAPPING = {
 # See: https://getting-started-with-xapian.readthedocs.io/en/latest/concepts/indexing/values.html
 FIELD_TO_SLOT_MAPPING = {
     "timestamp": 0,
-    "is_featured": 1,
+    "has_press_release": 1,
 }
 
 # Some document fields are more important than others. The following factors are applied

--- a/backend/howtheyvote/store/index.py
+++ b/backend/howtheyvote/store/index.py
@@ -134,16 +134,12 @@ def _serialize_vote(vote: Vote, generator: TermGenerator) -> Document:
     if vote.rapporteur:
         generator.index_text(vote.rapporteur, 1, field_to_prefix("rapporteur"))
 
-    # Store timestamp and is_featured as sortable values for ranking
+    # Store timestamp and press release as sortable values for ranking
     timestamp = sortable_serialise(vote.timestamp.timestamp())
     doc.add_value(field_to_slot("timestamp"), timestamp)
 
-    is_featured = sortable_serialise(int(vote.is_featured))
-    doc.add_value(field_to_slot("is_featured"), is_featured)
-
-    # Also store is_featured as boolean term for filtering
-    term = boolean_term("is_featured", vote.is_featured)
-    doc.add_boolean_term(term)
+    has_press_release = sortable_serialise(int(vote.press_release is not None))
+    doc.add_value(field_to_slot("has_press_release"), has_press_release)
 
     # Store document and procedure references as boolean terms. Boolean terms
     # aren’t searchable, but can be used for filtering.

--- a/backend/howtheyvote/store/mappings.py
+++ b/backend/howtheyvote/store/mappings.py
@@ -63,7 +63,6 @@ def map_vote(record: CompositeRecord) -> Vote:
     responsible_committee = Committee.get(record.first("responsible_committee"))
 
     press_release = record.first("press_release")
-    is_featured = record.first("is_featured") or press_release is not None
 
     return Vote(
         id=record.group_key,
@@ -77,7 +76,6 @@ def map_vote(record: CompositeRecord) -> Vote:
         procedure_title=record.first("procedure_title"),
         procedure_reference=record.first("procedure_reference"),
         is_main=record.first("is_main") or False,
-        is_featured=is_featured,
         group_key=record.first("group_key"),
         member_votes=member_votes,
         geo_areas=geo_areas,

--- a/backend/tests/api/test_votes_api.py
+++ b/backend/tests/api/test_votes_api.py
@@ -414,7 +414,6 @@ def test_votes_api_show(records, db_session, api):
         "timestamp": "2023-01-01T00:00:00",
         "reference": None,
         "description": "Am 123",
-        "is_featured": False,
         "procedure": None,
         "facts": None,
         "sharepic_url": None,

--- a/backend/tests/export/test_init.py
+++ b/backend/tests/export/test_init.py
@@ -138,8 +138,8 @@ def test_export_votes(db_session, tmp_path):
     votes_meta = tmp_path.joinpath("votes.csv-metadata.json")
 
     expected = (
-        "id,timestamp,display_title,reference,description,is_main,is_featured,procedure_reference,procedure_title,responsible_committee_code,count_for,count_against,count_abstention,count_did_not_vote\n"
-        "123456,2024-01-01 00:00:00,Lorem Ipsum,,,False,False,,,,1,0,0,0\n"
+        "id,timestamp,display_title,reference,description,is_main,procedure_reference,procedure_title,responsible_committee_code,count_for,count_against,count_abstention,count_did_not_vote\n"
+        "123456,2024-01-01 00:00:00,Lorem Ipsum,,,False,,,,1,0,0,0\n"
     )
 
     assert votes_csv.read_text() == expected

--- a/backend/tests/export/test_init.py
+++ b/backend/tests/export/test_init.py
@@ -131,6 +131,10 @@ def test_export_votes(db_session, tmp_path):
             EurovocConcept["4057"],
             EurovocConcept["1460"],
         ],
+        geo_areas=[
+            Country["MDA"],
+            Country["RUS"],
+        ],
     )
 
     db_session.add_all([member, vote])
@@ -173,6 +177,22 @@ def test_export_votes(db_session, tmp_path):
 
     assert eurovoc_concepts_csv.read_text() == expected
     assert eurovoc_concepts_meta.is_file()
+
+    geo_area_votes_csv = tmp_path.joinpath("geo_area_votes.csv")
+    geo_area_votes_meta = tmp_path.joinpath("geo_area_votes.csv-metadata.json")
+
+    expected = "vote_id,geo_area_code\n123456,MDA\n123456,RUS\n"
+
+    assert geo_area_votes_csv.read_text() == expected
+    assert geo_area_votes_meta.is_file()
+
+    geo_areas_csv = tmp_path.joinpath("geo_areas.csv")
+    geo_areas_meta = tmp_path.joinpath("geo_areas.csv-metadata.json")
+
+    expected = "code,label,iso_alpha_2\nMDA,Moldova,MD\nRUS,Russia,RU\n"
+
+    assert geo_areas_csv.read_text() == expected
+    assert geo_areas_meta.is_file()
 
 
 def test_export_votes_country_group(db_session, tmp_path):

--- a/backend/tests/export/test_init.py
+++ b/backend/tests/export/test_init.py
@@ -6,6 +6,7 @@ import time_machine
 from howtheyvote.export import Export
 from howtheyvote.models import (
     Country,
+    EurovocConcept,
     Group,
     GroupMembership,
     Member,
@@ -126,6 +127,10 @@ def test_export_votes(db_session, tmp_path):
                 position=VotePosition.FOR,
             ),
         ],
+        eurovoc_concepts=[
+            EurovocConcept["4057"],
+            EurovocConcept["1460"],
+        ],
     )
 
     db_session.add_all([member, vote])
@@ -152,6 +157,22 @@ def test_export_votes(db_session, tmp_path):
 
     assert member_votes_csv.read_text() == expected
     assert member_votes_meta.is_file()
+
+    eurovoc_concept_votes_csv = tmp_path.joinpath("eurovoc_concept_votes.csv")
+    eurovoc_concept_votes_meta = tmp_path.joinpath("eurovoc_concept_votes.csv-metadata.json")
+
+    expected = "vote_id,eurovoc_concept_id\n123456,4057\n123456,1460\n"
+
+    assert eurovoc_concept_votes_csv.read_text() == expected
+    assert eurovoc_concept_votes_meta.is_file()
+
+    eurovoc_concepts_csv = tmp_path.joinpath("eurovoc_concepts.csv")
+    eurovoc_concepts_meta = tmp_path.joinpath("eurovoc_concepts.csv-metadata.json")
+
+    expected = "id,label\n1460,EU financial instrument\n4057,enlargement of the Union\n"
+
+    assert eurovoc_concepts_csv.read_text() == expected
+    assert eurovoc_concepts_meta.is_file()
 
 
 def test_export_votes_country_group(db_session, tmp_path):

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -24,12 +24,6 @@ export type BaseVote = {
      */
     description?: string;
     /**
-     * Whether this vote is featured. Currently, a vote is featured when we have found an
-     * official press release about the vote published by the European Parliament Newsroom.
-     * However, this is subject to change.
-     */
-    is_featured: boolean;
-    /**
      * Countries or territories related to this vote
      */
     geo_areas: Array<Country>;
@@ -38,6 +32,28 @@ export type BaseVote = {
      * that are related to this vote
      */
     eurovoc_concepts: Array<EurovocConcept>;
+    /**
+     * Committee responsible for the legislative procedure
+     */
+    responsible_committee?: Committee;
+};
+
+/**
+ * Committee of the European Parliament
+ */
+export type Committee = {
+    /**
+     * Unique identifier for the committee
+     */
+    code: string;
+    /**
+     * Name of the committee
+     */
+    label: string;
+    /**
+     * Abbreviation
+     */
+    abbreviation?: string;
 };
 
 /**


### PR DESCRIPTION
This PR includes three changes to the CSV export:

**Remove `is_featured` column**

Discussed before, closes #1117. This removes the column everywhere (including from the API and exports). Whether a vote has a corresponding press release is still a ranking factor, but it’s now named `has_press_release` in the search index which should be more obvious (but isn’t exposed publicly).

**Include EuroVoc concepts**
While exposed via the API, we haven’t included the EuroVoc concepts in the export so far. This adds `eurovoc_concepts.csv` and `eurovoc_concept_votes.csv` to the export.

**Include geographic areas**
We already have `countries.csv` which includes data about the EU member states and is referenced by the MEPs export. This adds a separate table `geo_areas.csv` for the geographic areas referenced by votes. I’m not really sure about this being a separate table though. Maybe we should just have a single reference table `geo_areas.csv` that is referenced by the MEPs export and the votes export?


