### PR TITLE
Handle votes with joint responsible committees

### DIFF
--- a/backend/howtheyvote/alembic/versions/8d1995cb0bed_make_responsible_committee_column_json_.py
+++ b/backend/howtheyvote/alembic/versions/8d1995cb0bed_make_responsible_committee_column_json_.py
@@ -1,0 +1,26 @@
+"""Make responsible_committee column JSON in votes table
+
+Revision ID: 8d1995cb0bed
+Revises: 064daf473f9a
+Create Date: 2025-03-16 17:13:08.000602
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "8d1995cb0bed"
+down_revision = "064daf473f9a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("votes", "responsible_committee")
+    op.add_column("votes", sa.Column("responsible_committees", sa.JSON))
+
+
+def downgrade() -> None:
+    op.drop_column("votes", "responsible_committees")
+    op.add_column("votes", sa.Column("responsible_committee", sa.Unicode))

--- a/backend/howtheyvote/api/serializers.py
+++ b/backend/howtheyvote/api/serializers.py
@@ -263,8 +263,8 @@ class BaseVoteDict(TypedDict):
     """Concepts from the [EuroVoc](https://eur-lex.europa.eu/browse/eurovoc.html) thesaurus
     that are related to this vote"""
 
-    responsible_committee: CommitteeDict | None
-    """Committee responsible for the legislative procedure"""
+    responsible_committees: list[CommitteeDict] | None
+    """Committees responsible for the legislative procedure"""
 
     result: VoteResult | None
     """Vote result. This field is only available for votes starting in 2024."""
@@ -273,9 +273,9 @@ class BaseVoteDict(TypedDict):
 def serialize_base_vote(vote: Vote) -> BaseVoteDict:
     geo_areas = [serialize_country(geo_area) for geo_area in vote.geo_areas]
     eurovoc_concepts = [serialize_eurovoc_concept(ec) for ec in vote.eurovoc_concepts]
-    responsible_committee = (
-        serialize_committee(vote.responsible_committee) if vote.responsible_committee else None
-    )
+    responsible_committees = [
+        serialize_committee(committee) for committee in vote.responsible_committees
+    ]
 
     return {
         "id": vote.id,
@@ -285,7 +285,7 @@ def serialize_base_vote(vote: Vote) -> BaseVoteDict:
         "reference": vote.reference,
         "geo_areas": geo_areas,
         "eurovoc_concepts": eurovoc_concepts,
-        "responsible_committee": responsible_committee,
+        "responsible_committees": responsible_committees,
         "result": vote.result,
     }
 

--- a/backend/howtheyvote/models/vote.py
+++ b/backend/howtheyvote/models/vote.py
@@ -146,7 +146,7 @@ class Vote(BaseWithId):
     eurovoc_concepts: Mapped[list[EurovocConcept]] = mapped_column(
         ListType(EurovocConceptType())
     )
-    responsible_committee: Mapped[Committee] = mapped_column(CommitteeType())
+    responsible_committees: Mapped[list[Committee]] = mapped_column(ListType(CommitteeType()))
     press_release: Mapped[str | None] = mapped_column(sa.Unicode)
     issues: Mapped[list[DataIssue]] = mapped_column(ListType(sa.Enum(DataIssue)))
 

--- a/backend/howtheyvote/store/mappings.py
+++ b/backend/howtheyvote/store/mappings.py
@@ -62,7 +62,9 @@ def map_vote(record: CompositeRecord) -> Vote:
     member_votes = [deserialize_member_vote(mv) for mv in record.first("member_votes")]
     geo_areas = {Country[code] for code in record.chain("geo_areas")}
     eurovoc_concepts = {EurovocConcept[id_] for id_ in record.chain("eurovoc_concepts")}
-    responsible_committee = Committee.get(record.first("responsible_committee"))
+    responsible_committees = {
+        Committee[code] for code in record.chain("responsible_committees")
+    }
     result = VoteResult[record.first("result")] if record.first("result") else None
     procedure_stage = (
         ProcedureStage[record.first("procedure_stage")]
@@ -91,7 +93,7 @@ def map_vote(record: CompositeRecord) -> Vote:
         member_votes=member_votes,
         geo_areas=geo_areas,
         eurovoc_concepts=eurovoc_concepts,
-        responsible_committee=responsible_committee,
+        responsible_committees=responsible_committees,
         press_release=press_release,
         issues=record.chain("issues"),
     )

--- a/backend/tests/api/test_votes_api.py
+++ b/backend/tests/api/test_votes_api.py
@@ -548,7 +548,7 @@ def test_votes_api_show(records, db_session, api):
         "result": "ADOPTED",
         "geo_areas": [],
         "eurovoc_concepts": [],
-        "responsible_committee": None,
+        "responsible_committees": [],
         "related": [],
         "sources": [
             {

--- a/backend/tests/export/test_init.py
+++ b/backend/tests/export/test_init.py
@@ -5,6 +5,7 @@ import time_machine
 
 from howtheyvote.export import Export
 from howtheyvote.models import (
+    Committee,
     Country,
     EurovocConcept,
     Group,
@@ -140,6 +141,7 @@ def test_export_votes(db_session, tmp_path):
             Country["MDA"],
             Country["RUS"],
         ],
+        responsible_committees=[Committee["AFET"]],
         result=VoteResult.ADOPTED,
     )
 
@@ -153,8 +155,8 @@ def test_export_votes(db_session, tmp_path):
     votes_meta = tmp_path.joinpath("votes.csv-metadata.json")
 
     expected = (
-        "id,timestamp,display_title,reference,description,is_main,procedure_reference,procedure_title,procedure_type,procedure_stage,responsible_committee_code,count_for,count_against,count_abstention,count_did_not_vote,result\n"
-        "123456,2024-01-01 00:00:00,Lorem Ipsum,,,False,2025/1234(COD),Lorem Ipsum,COD,OLP_FIRST_READING,,1,0,0,0,ADOPTED\n"
+        "id,timestamp,display_title,reference,description,is_main,procedure_reference,procedure_title,procedure_type,procedure_stage,count_for,count_against,count_abstention,count_did_not_vote,result\n"
+        "123456,2024-01-01 00:00:00,Lorem Ipsum,,,False,2025/1234(COD),Lorem Ipsum,COD,OLP_FIRST_READING,1,0,0,0,ADOPTED\n"
     )
 
     assert votes_csv.read_text() == expected
@@ -199,6 +201,24 @@ def test_export_votes(db_session, tmp_path):
 
     assert geo_areas_csv.read_text() == expected
     assert geo_areas_meta.is_file()
+
+    responsible_committee_votes_csv = tmp_path.joinpath("responsible_committee_votes.csv")
+    responsible_committee_votes_meta = tmp_path.joinpath(
+        "responsible_committee_votes.csv-metadata.json"
+    )
+
+    expected = "vote_id,committee_code\n123456,AFET\n"
+
+    assert responsible_committee_votes_csv.read_text() == expected
+    assert responsible_committee_votes_meta.is_file()
+
+    committees_csv = tmp_path.joinpath("committees.csv")
+    committees_meta = tmp_path.joinpath("committees.csv-metadata.json")
+
+    expected = "code,label,abbreviation\nAFET,Committee on Foreign Affairs,AFET\n"
+
+    assert committees_csv.read_text() == expected
+    assert committees_meta.is_file()
 
 
 def test_export_votes_country_group(db_session, tmp_path):

--- a/backend/tests/scrapers/data/votes/oeil-procedure-file_2024-0258-cod.html
+++ b/backend/tests/scrapers/data/votes/oeil-procedure-file_2024-0258-cod.html
@@ -1,0 +1,2538 @@
+<!doctype html>
+<html lang="en">
+
+
+<head>
+
+    
+    <title>Procedure File: 2024/0258(COD) | Legislative Observatory | European Parliament</title>
+
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta content="@project.version@" name="project_version"/>
+    <meta content="@build.number@" name="build_number"/>
+    <meta content="@build.time@" name="build_time"/>
+
+    <!-- Commons meta tags -->
+    <meta content="https://www.europarl.europa.eu">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta content="IE=edge" http-equiv="X-UA-Compatible">
+    <meta content="no-cache" http-equiv="cache-control">
+    <meta content="-1" http-equiv="expires">
+    <meta content="no-cache" http-equiv="pragma">
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+    <meta content="en" name="language">
+    <meta content="en" http-equiv="Content-Language">
+    <meta content="European Parliament Legislative Observatory Procedure" name="description">
+    <meta content="index, follow, noodp, noydir, notranslate, noarchive" name="robots">
+    <meta content="European Union, 2025 - Source: European Parliament" name="copyright">
+    <meta content="Legislative Observatory" name="planet">
+    <meta content="16-03-2025" name="available">
+
+    <!-- Dynamics meta tags -->
+    
+        <meta content="OEIL, Legislative Observatory, Observatoire législatif, 2024/0258(COD), MIKSER Sven, S&amp;D, MUREŞAN Siegfried, EPP, ZDROJEWSKI Bogdan Andrzej, EPP, SJÖSTEDT Jonas, The Left, 6.30.02 Financial and technical cooperation and assistance, 6.40.02 Relations with central and eastern Europe, 8.20.01 Candidate countries, 8.20.04 Pre-accession and partnership, COM(2024)0469, A10-0006/2025" name="keywords">
+    
+
+    <!-- HTML <link> tags -->
+    <link rel="icon" href="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/assets/img/favicon.ico">
+
+    
+    <link href="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/dist/css/evostrap.css" rel="stylesheet">
+    <link href="https://www.europarl.europa.eu/commonFrontResources/evostrap-oeil/1.0.0//dist/css/oeil.css" rel="stylesheet">
+</head>
+
+<body id="main-content" data-app-context="/oeil/">
+
+    <header class="erpl_header">
+    <nav class="erpl_wai-access" aria-label="Shortcuts">
+        <ul>
+            <li> <a href="#website-body" class="erpl_smooth-scroll"> <span class="btn btn-primary">Access to page content (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#languageSelectorDropdownButton" class="erpl_smooth-scroll"> <span class="btn btn-primary">Direct access to language menu (press &quot;Enter&quot;)</span> </a> </li>
+
+            <li> <a href="#mainSearch" class="erpl_smooth-scroll"> <span class="btn btn-primary">Direct access to search menu (press &quot;Enter&quot;)</span> </a> </li>
+        </ul>
+    </nav>
+
+    
+    <div class="erpl_header-top border-bottom mb-3 mb-xl-4 a-i">
+        <div class="container">
+            <div class="row no-gutters">
+                <div class="col-auto"><div class="erpl_header-language-selector">
+    <div class="erpl_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute"
+         data-content-width="auto">
+        <button class="erpl_dropdown-btn input-group collapsed" type="button" data-toggle="collapse"
+                id="languageSelectorDropdownButton"
+                data-target="#languageSelectorDropdownContent"
+                aria-expanded="false"
+                aria-controls="languageSelectorDropdownContent">
+            <span class="value form-control">EN - English</span>
+            
+            <span class="input-group-append">
+                <span class="input-group-icon">
+                    <svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false">
+                        <use xlink:href="#es_icon-arrow"></use>
+                    </svg>
+                    <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-flip-y text-primary"
+                         data-show-expanded="true">
+                        <use xlink:href="#es_icon-arrow"></use>
+                    </svg>
+                </span>
+            </span>
+        </button>
+
+        <div>
+            <div class="erpl_dropdown-content collapse" id="languageSelectorDropdownContent">
+                <div class="border border-light">
+                    <div>
+                        <ul class="erpl_topbar-list list-unstyled erpl_dropdown-menu">
+                            <li class="t-x-block" data-selected="true">
+                                <!-- localized version URL is here -->
+                                <a class="erpl_dropdown-menu-item"
+                                   lang="en"
+                                   href="https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2024/0258(COD)">
+                                    <span class="t-item">EN - English</span>
+                                    
+                                </a>
+                            </li>
+                            <li class="t-x-block" data-selected="false">
+                                <!-- localized version URL is here -->
+                                <a class="erpl_dropdown-menu-item"
+                                   lang="fr"
+                                   href="https://oeil.secure.europarl.europa.eu/oeil/fr/procedure-file?reference=2024/0258(COD)">
+                                    
+                                    <span class="t-item">FR - français</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div></div>
+                <div class="col">
+                    <nav class="erpl_header-other-websites d-flex justify-content-end align-items-center" aria-label="Other websites">
+                        <ul class="d-flex list-unstyled">
+
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/news/en">
+                                    <span class="t-item">News</span>
+                                </a>
+                            </li>
+
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/topics/en">
+                                    <span class="t-item">Topics</span>
+                                </a>
+                            </li>
+
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/meps/en">
+                                    <span class="t-item">MEPs</span>
+                                </a>
+                            </li>
+
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/about-parliament/en">
+                                    <span class="t-item">About Parliament</span>
+                                </a>
+                            </li>
+
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/plenary/en">
+                                    <span class="t-item">Plenary</span>
+                                </a>
+                            </li>
+
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/committees/en">
+                                    <span class="t-item">Committees</span>
+                                </a>
+                            </li>
+
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/delegations/en">
+                                    <span class="t-item">Delegations</span>
+                                </a>
+                            </li>
+
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://elections.europa.eu/en/">
+                                    <span class="t-item">Elections</span>
+                                </a>
+                            </li>
+
+
+                            <li class="erpl_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute">
+                               <button class="erpl_dropdown-btn input-group collapsed d-xl-flex pl-1 align-items-center t-y-block flex-nowrap"
+                                       data-toggle="collapse"
+                                       data-target="#otherWebsiteSubmenu"
+                                       aria-expanded="false"
+                                       aria-controls="otherWebsiteSubmenu" aria-label="More other websites">
+                                    <span class="value">
+											<span class="d-none d-xl-inline">Other websites</span>
+											<span class="d-xl-none">View other websites</span>
+                                    </span>
+                                   <span class="input-group-append">
+											<span class="input-group-icon">
+												<svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false">
+													<use xlink:href="#es_icon-arrow"></use>
+												</svg>
+
+												<svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-flip-y text-primary" data-show-expanded="true">
+													<use xlink:href="#es_icon-arrow"></use>
+												</svg>
+											</span>
+										</span>
+                                </button>
+                                <div>
+                                    <div id="otherWebsiteSubmenu" class="erpl_dropdown-content collapse">
+                                        <ul class="erpl_header-other-websites-submenu list-unstyled erpl_dropdown-menu">
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/news/en">
+                                                    <span class="t-item">News</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/topics/en">
+                                                    <span class="t-item">Topics</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/meps/en">
+                                                    <span class="t-item">MEPs</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/about-parliament/en">
+                                                    <span class="t-item">About Parliament</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/plenary/en">
+                                                    <span class="t-item">Plenary</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/committees/en">
+                                                    <span class="t-item">Committees</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/delegations/en">
+                                                    <span class="t-item">Delegations</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://elections.europa.eu/en/">
+                                                    <span class="t-item">Elections</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://multimedia.europarl.europa.eu/en/home">
+                                                    <span class="t-item">Multimedia Centre</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/the-president/en">
+                                                    <span class="t-item">President&#39;s website</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/the-secretary-general/en">
+                                                    <span class="t-item">Secretariat-general</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/thinktank/en">
+                                                    <span class="t-item">Thinktank</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.epnewshub.eu">
+                                                    <span class="t-item">EP Newshub</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/at-your-service/en">
+                                                    <span class="t-item">At your service</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/visiting/en">
+                                                    <span class="t-item">Visits</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/legislative-train">
+                                                    <span class="t-item">Legislative train</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/contracts-and-grants/en/">
+                                                    <span class="t-item">Contracts and Grants</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/RegistreWeb/home/welcome.htm?language=en">
+                                                    <span class="t-item">Register</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://data.europarl.europa.eu/en">
+                                                    <span class="t-item">Open Data Portal</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://liaison-offices.europarl.europa.eu/en">
+                                                    <span class="t-item">Liaison offices</span>
+                                                </a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </li>
+                        </ul>
+                    </nav>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="erpl_header-middle mb-3">
+        <div class="container">
+            <div class="row">
+                <div class="col-12 col-md">
+                    <div class="erpl_header-website-title a-i">
+                        <div class="erpl_header-website-title-main">
+                            <a href="/oeil/en" class="t-x">
+                                <span>Legislative Observatory</span>
+                            </a>
+                        </div>
+                        <div class="erpl_header-website-title-sub">
+                            <a class="t-x-block" href="https://www.europarl.europa.eu" target="_blank" >
+                                <span class="t-item">European Parliament</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+
+                
+                <div class="col-auto d-none d-xl-flex justify-content-end align-items-center erpl_header-search-container">
+                    <form class="erpl_header-search" method="GET" action="/oeil/en/search"> <label for="mainSearch" class="sr-only">Find a procedure</label>
+                        <div class="input-group" style="width: 300px">
+                            <input type="text" class="form-control"
+                                   id="mainSearch"
+                                   placeholder="Find a procedure..."
+                                   name="fullText.term"
+                                   aria-describedby="mainSearchHelper">
+                            <div class="input-group-append">
+                                <button class="btn btn-primary align-items-center d-flex" title="Start find a procedure" disabled="">
+                                    <svg aria-hidden="true" class="es_icon es_icon-search erpl_header-search-icon">
+                                        <use xlink:href="#es_icon-search"></use>
+                                    </svg>
+                                </button>
+                            </div>
+                        </div> <span id="mainSearchHelper" class="form-text text-muted sr-only">Please fill in this field to find a procedure</span>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="erpl_header-bottom">
+        <div class="erpl_header-menu-container">
+            <div class="container"><nav class="erpl_header-menu" aria-label="Main navigation">
+    <div class="erpl_header-menu-top row align-items-center">
+        <div class="col d-md-none d-flex align-items-center">
+            <svg aria-hidden="true" class="es_icon es_icon-ep-logo-w erpl_header-menu-top-logo">
+                <use xlink:href="#es_icon-ep-logo-w"></use>
+            </svg>
+        </div>
+
+        <span class="erpl_header-menu-top-title offset-3 col-6 text-center d-none d-md-block" aria-hidden="true">
+								<span>European Parliament</span></span>
+
+        <div class="erpl_header-menu-top-controls col-auto col-md-3 text-right">
+            <button type="button" class="btn btn-sm btn-dark-primary erpl_header-menu-top-controls-toggle-search" id="headerMenuToggleSearch" aria-haspopup="true" aria-expanded="false">
+                <span class="sr-only">Search</span>
+                <svg aria-hidden="true" class="es_icon es_icon-search">
+                    <use xlink:href="#es_icon-search"></use>
+                </svg>
+            </button>
+            <button type="button"
+                    class="btn btn-sm btn-dark-primary erpl_header-menu-top-controls-toggle-menu"
+                    id="headerMenuToggleMenu"
+                    aria-haspopup="true"
+                    aria-expanded="false">
+                <span class="mr-25">Menu</span> <span class="erpl_header-menu-icon" aria-hidden="true"></span>
+            </button>
+        </div>
+    </div>
+
+    <ul class="erpl_header-menu-list list-unstyled">
+        
+<li class="erpl_header-menu-item">
+    <a class="erpl_header-menu-item-title"
+       href="/oeil/en" data-selected="false">
+        <span class="t-y">Home</span>
+    </a>
+</li>
+<li class="erpl_header-menu-item">
+    <a class="erpl_header-menu-item-title"
+       href="/oeil/en/search" data-selected="false">
+        <span class="t-y">Search</span>
+    </a>
+</li>
+<li class="erpl_header-menu-item">
+    <a class="erpl_header-menu-item-title"
+       href="/oeil/en/legislative-priorities" data-selected="false">
+        <span class="t-y">Legislative priorities</span>
+    </a>
+</li>
+<li class="erpl_header-menu-item">
+    <a class="erpl_header-menu-item-title"
+       href="/oeil/en/find-out-more" data-selected="false">
+        <span class="t-y">Find out more</span>
+    </a>
+</li>
+<li class="erpl_header-menu-item">
+    <a class="erpl_header-menu-item-title"
+       href="/oeil/en/contact" data-selected="false">
+        <span class="t-y">Contact us</span>
+    </a>
+</li>
+
+    </ul>
+</nav></div>
+        </div>
+    </div>
+</header>
+
+    <div class="container">
+        <div class="breadcrumb"></div>
+    </div>
+
+    
+    <main id="website-body">
+<div class="container">
+    <div class="row">
+        <div class="col-12 col-xl-8">
+            <div class="row">
+                <div class="col-12 col-lg"><h2 class="erpl_title-h1 mb-3">2024/0258(COD)</h2>
+                </div>
+                <div class="col-12 col-lg-4">
+                    <div class="erpl_links-list text-lg-right my-1">
+                        <ul>
+                            <li>
+                                <a href="/oeil/en/procedure-file/pdf?reference=2024/0258(COD)">
+                                    <svg class="es_icon es_icon-pdf mr-1">
+                                        <title>pdf</title>
+                                        <use xlink:href="#es_icon-pdf"></use>
+                                    </svg>
+                                    <span class="t-x">Full procedure</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            
+            <h2 class="erpl_title-h2 mb-3">Establishing the Reform and Growth Facility for Moldova</h2>
+            <div class="separator border-dark my-3"></div>
+
+            
+            <div id="sectionsNavPositionRwd" class="mb-1"></div>
+
+
+            
+            <div class="erpl_product">
+                <div class="row">
+                    <div class="col">
+                        <div class="mb-3">
+                            <div class="erpl_product-body">
+                                
+                                <html lang="en">
+
+
+<div class="erpl_product-section">
+    <div id="section1" class="erpl-product-content oeil-spy-section mb-2">
+        <div class="row">
+            <div class="col-12 col-lg">
+                <h2 class="erpl_title-h2 mb-2">Basic information</h2></div>
+                <div class="col-12 col-lg-4">
+                    <div class="erpl_links-list text-lg-right my-1">
+                        <ul>
+                            <li>
+                                <a href="/oeil/en/procedure-file/pdf?reference=2024/0258(COD)&amp;section=BASIC_INFO">
+                                    <svg class="es_icon es_icon-pdf mr-1">
+                                        <title>pdf</title>
+                                        <use xlink:href="#es_icon-pdf"></use>
+                                    </svg>
+                                    <span class="t-x">Basic information</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+        </div>
+        <div class="row">
+            <div class="col-6">
+                <p class="font-weight-bold mb-1">2024/0258(COD)</p>
+
+                <p>COD - Ordinary legislative procedure (ex-codecision procedure)</p>
+                <p>Regulation</p>
+
+                
+                
+
+
+                
+                    <p class="font-weight-bold mb-1">Subject</p>
+                    <p>
+                        
+                            6.30.02 Financial and technical cooperation and assistance
+                            <br/>
+                        
+                            6.40.02 Relations with central and eastern Europe
+                            <br/>
+                        
+                            8.20.01 Candidate countries
+                            <br/>
+                        
+                            8.20.04 Pre-accession and partnership
+                            
+                        
+                    </p>
+                
+
+                
+                    <p class="font-weight-bold mb-1">Geographical area</p>
+                    <p>
+                        
+                            Moldova
+                            
+                        
+                    </p>
+                
+
+                
+            </div>
+
+            <div class="col-6">
+                
+                    <p class="font-weight-bold mb-1">Status</p>
+                    <p class="text-danger">Awaiting Council&#39;s 1st reading position</p>
+                
+
+                
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-12">
+                <div class="separator separator-dotted separator-2x mt-5 mb-3">
+                    <a class="erpl_smooth-scroll btn btn-default" href="#gateway">Please go to Documentation gateway for any follow-up documents.</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</html>
+
+
+                                
+                                <div class="erpl_product-section">
+    <div class="separator border-dark my-3"></div>
+    <div id="section2" class="erpl-product-content oeil-spy-section mb-2">
+        <div class="row">
+            <div class="col-12 col-lg"><h2 class="erpl_title-h2 mb-2">Key players</h2>
+            </div>
+            <div class="col-12 col-lg-4">
+                <div class="erpl_links-list text-lg-right my-1">
+                    <ul>
+                        <li>
+                            <a href="/oeil/en/procedure-file/pdf?reference=2024/0258(COD)&amp;section=KEY_PLAYERS">
+                                <svg class="es_icon es_icon-pdf mr-1">
+                                    <title>pdf</title>
+                                    <use xlink:href="#es_icon-pdf"></use>
+                                </svg>
+                                <span class="t-x">Key players</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="erpl_accordion mb-5" id="erplAccordionKeyPlayers">
+            <ul class="a-i">
+                
+    <li class="erpl_accordion-item" data-selected="false">
+        <button id="erpl_accordion-committee-title" type="button" class="erpl_accordion-item-title" data-toggle="collapse" data-target="#erpl_accordion-committee" aria-expanded="true" aria-controls="erpl_accordion-committee">
+            <span class="t-x">European Parliament</span>
+            <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
+                <use xlink:href="#es_icon-more"></use>
+            </svg>
+            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
+                <use xlink:href="#es_icon-less"></use>
+            </svg>
+        </span>
+        </button>
+        <div id="erpl_accordion-committee" class="erpl_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="erpl_accordion-committee-title">
+            <div>
+                <a href="http://www.europarl.europa.eu/" target="_blank">
+                    <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1">
+                        <use xlink:href="#es_icon-arrow"></use>
+                    </svg>
+                    <span class="t-x">European Parliament</span>
+                </a>
+
+                <div class="table-responsive mt-2">
+                    
+
+                        <table class="table table-bordered table-striped">
+                            <thead>
+                            <tr>
+                                <th class="w-50" scope="col">Joint committee responsible</th>
+                                <th class="w-25" scope="col">Rapporteur</th>
+                                <th class="w-25" scope="col">Appointed</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+
+                            
+
+                            
+                                
+
+                                
+                                    
+    <tr>
+        <th scope="row">
+            <div class="d-flex align-items-center">
+    <span class="erpl_badge erpl_badge-committee mr-1">AFET</span>
+    <div>
+        <a href="http://www.europarl.europa.eu/committees/EN/afet/home.html" target="_blank">
+                <span class="font-weight-normal">Foreign Affairs
+</span>
+        </a>
+        
+        <br/>
+        
+    </div>
+</div>
+        </th>
+        <td>
+            
+    
+    
+        
+
+        <a class="rapporteur mb-25"
+           data-toggle="tooltip-rapporteur"
+           data-placement="bottom"
+           href="https://www.europarl.europa.eu/meps/en/197497" target="_blank"
+           title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/197497.jpg&quot; alt=&quot;Photo MIKSER Sven &quot;&gt;">
+            <span>MIKSER Sven (S&amp;D)</span>
+        </a>
+        <br/>
+    
+
+        </td>
+        <td>
+
+            
+                <span>18/11/2024</span>
+                <br/>
+            
+        </td>
+    </tr>
+    <tr>
+        <th scope="row">
+            <div class="d-flex align-items-center">
+    <span class="erpl_badge erpl_badge-committee mr-1">BUDG</span>
+    <div>
+        <a href="http://www.europarl.europa.eu/committees/EN/budg/home.html" target="_blank">
+                <span class="font-weight-normal">Budgets
+
+</span>
+        </a>
+        
+        <br/>
+        
+    </div>
+</div>
+        </th>
+        <td>
+            
+    
+    
+        
+
+        <a class="rapporteur mb-25"
+           data-toggle="tooltip-rapporteur"
+           data-placement="bottom"
+           href="https://www.europarl.europa.eu/meps/en/124802" target="_blank"
+           title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/124802.jpg&quot; alt=&quot;Photo MUREŞAN Siegfried &quot;&gt;">
+            <span>MUREŞAN Siegfried (EPP)</span>
+        </a>
+        <br/>
+    
+
+        </td>
+        <td>
+
+            
+                <span>18/11/2024</span>
+                <br/>
+            
+        </td>
+    </tr>
+
+    <tr class="bg-none border">
+        <th scope="row" class="border-0"></th>
+        <td class="border-0">
+            
+    <button class="btn btn-primary my-1" type="button" data-toggle="collapse"
+            data-target="#collapseShadowRapporteur" aria-expanded="false"
+            aria-controls="collapseShadowRapporteur">Shadow rapporteur</button>
+
+    <div class="collapse" id="collapseShadowRapporteur">
+        <div class="card card-body border-0 p-0">
+            <a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/197514" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/197514.jpg&quot; alt=&quot;Photo HALICKI Andrzej &quot;&gt;">
+                <span>HALICKI Andrzej (EPP)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/88882" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/88882.jpg&quot; alt=&quot;Photo NEGRESCU Victor &quot;&gt;">
+                <span>NEGRESCU Victor (S&amp;D)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/256991" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/256991.jpg&quot; alt=&quot;Photo STÖTELER Sebastiaan &quot;&gt;">
+                <span>STÖTELER Sebastiaan (PfE)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/103246" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/103246.jpg&quot; alt=&quot;Photo ZIJLSTRA Auke &quot;&gt;">
+                <span>ZIJLSTRA Auke (PfE)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/197655" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/197655.jpg&quot; alt=&quot;Photo TERHEŞ Cristian &quot;&gt;">
+                <span>TERHEŞ Cristian (ECR)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/28615" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/28615.jpg&quot; alt=&quot;Photo ZĪLE Roberts &quot;&gt;">
+                <span>ZĪLE Roberts (ECR)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/257438" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/257438.jpg&quot; alt=&quot;Photo VAN BRUG Anouk &quot;&gt;">
+                <span>VAN BRUG Anouk (Renew)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/257110" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/257110.jpg&quot; alt=&quot;Photo BARNA Dan &quot;&gt;">
+                <span>BARNA Dan (Renew)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/256978" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/256978.jpg&quot; alt=&quot;Photo VAN LANSCHOT Reinier &quot;&gt;">
+                <span>VAN LANSCHOT Reinier (Greens/EFA)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/256965" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/256965.jpg&quot; alt=&quot;Photo TEGETHOFF Kai &quot;&gt;">
+                <span>TEGETHOFF Kai (Greens/EFA)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/257083" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/257083.jpg&quot; alt=&quot;Photo OLIVEIRA João &quot;&gt;">
+                <span>OLIVEIRA João (The Left)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/2268" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/2268.jpg&quot; alt=&quot;Photo SJÖSTEDT Jonas &quot;&gt;">
+                <span>SJÖSTEDT Jonas (The Left)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/256959" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/256959.jpg&quot; alt=&quot;Photo SELL Alexander &quot;&gt;">
+                <span>SELL Alexander (ESN)</span>
+            </a>
+        </div>
+    </div>
+
+        </td>
+        <td class="border-0"></td>
+    </tr>
+
+    
+
+                                
+                            
+
+                            </tbody>
+                        </table>
+
+                        
+                    
+
+                        <table class="table table-bordered table-striped">
+                            <thead>
+                            <tr>
+                                <th class="w-50" scope="col">Committee for opinion</th>
+                                <th class="w-25" scope="col">Rapporteur for opinion</th>
+                                <th class="w-25" scope="col">Appointed</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+
+                            
+
+                            
+                                
+                                    
+    <tr>
+        <th scope="row">
+            <div class="d-flex align-items-center">
+    <span class="erpl_badge erpl_badge-committee mr-1">INTA</span>
+    <div>
+        <a href="http://www.europarl.europa.eu/committees/EN/inta/home.html" target="_blank">
+                <span class="font-weight-normal">International Trade
+</span>
+        </a>
+        
+        <br/>
+        
+    </div>
+</div>
+        </th>
+        <td>
+            
+    
+    
+        
+
+        <a class="rapporteur mb-25"
+           data-toggle="tooltip-rapporteur"
+           data-placement="bottom"
+           href="https://www.europarl.europa.eu/meps/en/124893" target="_blank"
+           title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/124893.jpg&quot; alt=&quot;Photo ZDROJEWSKI Bogdan Andrzej &quot;&gt;">
+            <span>ZDROJEWSKI Bogdan Andrzej (EPP)</span>
+        </a>
+        <br/>
+    
+
+        </td>
+
+        <td>
+            
+                <span>18/11/2024</span>
+                <br/>
+            
+        </td>
+
+    </tr>
+    <tr>
+        <th scope="row">
+            <div class="d-flex align-items-center">
+    <span class="erpl_badge erpl_badge-committee mr-1">CONT</span>
+    <div>
+        <a href="http://www.europarl.europa.eu/committees/EN/cont/home.html" target="_blank">
+                <span class="font-weight-normal">Budgetary Control
+
+</span>
+        </a>
+        
+        <br/>
+        
+    </div>
+</div>
+        </th>
+        <td>
+            
+    
+    
+        
+
+        <a class="rapporteur mb-25"
+           data-toggle="tooltip-rapporteur"
+           data-placement="bottom"
+           href="https://www.europarl.europa.eu/meps/en/2268" target="_blank"
+           title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/2268.jpg&quot; alt=&quot;Photo SJÖSTEDT Jonas &quot;&gt;">
+            <span>SJÖSTEDT Jonas (The Left)</span>
+        </a>
+        <br/>
+    
+
+        </td>
+
+        <td>
+            
+                <span>28/11/2024</span>
+                <br/>
+            
+        </td>
+
+    </tr>
+    
+    
+
+                                
+
+                                
+                            
+
+                            </tbody>
+                        </table>
+
+                        
+                    
+                </div>
+            </div>
+        </div>
+    </li>
+
+
+                
+    <li class="erpl_accordion-item" data-selected="false">
+        <button id="erpl_accordion-item2-title" type="button" class="erpl_accordion-item-title collapsed" data-toggle="collapse" data-target="#erpl_accordion-item2" aria-expanded="false" aria-controls="erpl_accordion-item2">
+            <span class="t-x">Council of the European Union</span>
+            <span class="erpl_accordion-item-icon es_icon-container text-primary">
+                <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
+                    <use xlink:href="#es_icon-more"></use>
+                </svg>
+                <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
+                    <use xlink:href="#es_icon-less"></use>
+                </svg>
+            </span>
+        </button>
+
+        <div id="erpl_accordion-item2" class="collapse erpl_accordion-item-content a-i-none" aria-labelledby="erpl_accordion-item2-title">
+            <div>
+                <a href="http://www.consilium.europa.eu" target="_blank">
+                    <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1">
+                        <use xlink:href="#es_icon-arrow"></use>
+                    </svg>
+                    <span class="t-x">Council of the European Union</span>
+                </a>
+                
+            </div>
+        </div>
+    </li>
+
+
+                
+    <li class="erpl_accordion-item" data-selected="false">
+        <button id="erpl_accordion-item3-title" type="button" class="erpl_accordion-item-title collapsed" data-toggle="collapse" data-target="#erpl_accordion-item3" aria-expanded="false" aria-controls="erpl_accordion-item3">
+            <span class="t-x">European Commission</span>
+            <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
+                <use xlink:href="#es_icon-more"></use>
+            </svg>
+            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
+                <use xlink:href="#es_icon-less"></use>
+            </svg>
+        </span>
+        </button>
+        <div id="erpl_accordion-item3" class="collapse erpl_accordion-item-content a-i-none" aria-labelledby="erpl_accordion-item3-title">
+            <div>
+                <a href="http://ec.europa.eu/" target="_blank">
+                    <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1">
+                        <use xlink:href="#es_icon-arrow"></use>
+                    </svg>
+                    <span class="t-x">European Commission</span>
+                </a>
+                <div class="table-responsive mt-2">
+                    <table class="table table-striped table-bordered">
+                        <thead>
+                        <tr>
+                            <th class="align-middle" scope="col">Commission DG</th>
+                            <th class="align-middle" scope="col">Commissioner</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <th class="align-middle" scope="row">
+                                <a href="http://ec.europa.eu/info/departments/european-neighbourhood-policy-and-enlargement-negotiations_en" target="_blank"
+                                   class="font-weight-normal">
+                                    <span>Neighbourhood and Enlargement Negotiations</span>
+                                </a>
+                            </th>
+                            <td class="align-middle">
+                                <span>KOS Marta</span>
+                                
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+
+                </div>
+            </div>
+        </div>
+    </li>
+
+
+                
+    
+
+            </ul>
+        </div>
+    </div>
+
+</div>
+
+                                
+                                <html lang="en">
+
+
+
+
+<div class="erpl_product-section">
+    <div class="separator border-dark my-3"></div>
+    <div id="section3" class="erpl-product-content oeil-spy-section mb-2">
+        <div class="row">
+            <div class="col-12 col-lg">
+                <h2 class="erpl_title-h2 mb-2">Key events</h2>
+            </div>
+            <div class="col-12 col-lg-4">
+                <div class="erpl_links-list text-lg-right my-1">
+                    <ul>
+                        <li>
+                            <a href="/oeil/en/procedure-file/pdf?reference=2024/0258(COD)&amp;section=KEY_EVENTS" target="_blank">
+                                <svg class="es_icon es_icon-pdf mr-1">
+                                    <title>pdf</title>
+                                    <use xlink:href="#es_icon-pdf"></use>
+                                </svg>
+                                <span class="t-x">Key events</span>
+                            </a>
+                        </li>
+                    </ul>
+
+                </div>
+            </div>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-striped table-bordered">
+                <thead>
+                <tr>
+                    <th class="align-middle" scope="col">Date</th>
+                    <th class="align-middle" scope="col">Event</th>
+                    <th class="align-middle" scope="col">Reference</th>
+                    <th class="align-middle" scope="col">Summary</th>
+                </tr>
+                </thead>
+
+                <tbody>
+                <tr>
+                    
+                        <td class="align-middle" >09/10/2024</td>
+                        <td class="align-middle">Legislative proposal published</td>
+                        <td class="align-middle text-center">
+                            
+                                <a href="https://www.europarl.europa.eu/RegData/docs_autres_institutions/commission_europeenne/com/2024/0469/COM_COM(2024)0469_EN.docx" target="_blank">COM(2024)0469</a>
+                                
+                                <a href="https://eur-lex.europa.eu/smartapi/cgi/sga_doc?smartapi!celexplus!prod!DocNumber&amp;lg=EN&amp;type_doc=COMfinal&amp;an_doc=2024&amp;nu_doc=0469"
+                                   title="Go to the page Eur-Lex" target="_blank">
+                                    <i class="flag-icon flag-sm flag-icon-eu ml-25"></i>
+                                </a>
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            <a href="/oeil/en/document-summary?id=1791828" target="_blank">
+                                <button class="btn btn-success btn-sm" type="button">Summary</button>
+                            </a>
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >16/12/2024</td>
+                        <td class="align-middle">Committee referral announced in Parliament, 1st reading</td>
+                        <td class="align-middle text-center">
+                            
+                                
+                                <span></span>
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >30/01/2025</td>
+                        <td class="align-middle">Vote in committee, 1st reading</td>
+                        <td class="align-middle text-center">
+                            
+                                
+                                <span></span>
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >30/01/2025</td>
+                        <td class="align-middle">Committee decision to open interinstitutional negotiations with report adopted in committee</td>
+                        <td class="align-middle text-center">
+                            
+                                
+                                <span></span>
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >31/01/2025</td>
+                        <td class="align-middle">Committee report tabled for plenary, 1st reading</td>
+                        <td class="align-middle text-center">
+                            
+                                <a href="https://www.europarl.europa.eu/doceo/document/A-10-2025-0006_EN.html" target="_blank">A10-0006/2025</a>
+                                
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            <a href="/oeil/en/document-summary?id=1802918" target="_blank">
+                                <button class="btn btn-success btn-sm" type="button">Summary</button>
+                            </a>
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >10/02/2025</td>
+                        <td class="align-middle">Committee decision to enter into interinstitutional negotiations announced in plenary (Rule 71)</td>
+                        <td class="align-middle text-center">
+                            
+                                
+                                <span></span>
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >12/02/2025</td>
+                        <td class="align-middle">Committee decision to enter into interinstitutional negotiations confirmed by plenary (Rule 71)</td>
+                        <td class="align-middle text-center">
+                            
+                                
+                                <span></span>
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >06/03/2025</td>
+                        <td class="align-middle">Approval in committee of the text agreed at 1st reading interinstitutional negotiations</td>
+                        <td class="align-middle text-center">
+                            
+
+                            
+                                
+                                    
+                                    <span></span>
+                                    
+
+                                
+                                    <a class="d-block" href="https://www.europarl.europa.eu/RegData/commissions/budg/inag/2025/02-27/CJ15_AG(2025)770077_EN.pdf" target="_blank">PE770.077</a>
+                                    
+                                    
+
+                                
+                                    
+                                    <span>GEDA/A/(2025)001013</span>
+                                    
+
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >10/03/2025</td>
+                        <td class="align-middle">Debate in Parliament</td>
+                        <td class="align-middle text-center">
+                            
+                                
+                                <span></span>
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+                                <a href="https://www.europarl.europa.eu/doceo/document/CRE-10-2025-03-10-TOC_EN.html" title="Go to the page" target="_blank">
+                                    <svg aria-hidden="true" class="es_icon es_icon-comment-dots es_icon-24">
+                                        <use xlink:href="#es_icon-comment-dots"></use>
+                                    </svg>
+                                </a>
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+    </div>
+</div>
+
+
+                                
+                                
+
+
+
+
+
+                                
+                                <html lang="en">
+
+
+
+
+<div class="erpl_product-section">
+    <div class="separator border-dark my-3"></div>
+    <div id="section5" class="erpl-product-content oeil-spy-section mb-2">
+        <div class="row">
+            <div class="col-12 col-lg">
+                <h2 class="erpl_title-h2 mb-2">Technical information</h2>
+            </div>
+            <div class="col-12 col-lg-4">
+                <div class="erpl_links-list text-lg-right my-1">
+                    <ul>
+                        <li>
+                            <a href="/oeil/en/procedure-file/pdf?reference=2024/0258(COD)&amp;section=TECHNICAL_INFORMATION">
+                                <svg class="es_icon es_icon-pdf mr-1">
+                                    <title>pdf</title>
+                                    <use xlink:href="#es_icon-pdf"></use>
+                                </svg>
+                                <span class="t-x">Technical information</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <div class="table-responsive">
+            <table class="table table-striped table-bordered">
+                <thead>
+                </thead>
+                <tbody>
+                <tr>
+                    <th class="align-middle" scope="row">Procedure reference</th>
+                    <td class="align-middle">2024/0258(COD)</td>
+                </tr>
+                <tr>
+                    <th class="align-middle" scope="row">Procedure type</th>
+                    <td class="align-middle">COD - Ordinary legislative procedure (ex-codecision procedure)</td>
+                </tr>
+                <tr>
+                    <th class="align-middle" scope="row">Procedure subtype</th>
+                    <td class="align-middle">Legislation</td>
+                </tr>
+                <tr>
+                    <th class="align-middle" scope="row">Legislative instrument</th>
+                    <td class="align-middle">Regulation</td>
+                </tr>
+                
+                
+                
+                
+                <tr>
+                    <th class="align-middle" scope="row">Stage reached in procedure</th>
+                    <td class="align-middle">Awaiting Council&#39;s 1st reading position</td>
+                </tr>
+                <tr>
+                    <th class="align-middle" scope="row">Committee dossier</th>
+                    <td class="align-middle">
+                    
+                        <span>CJ15/10/01177</span>
+                        <br/>
+                    
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+                                
+                                <html lang="en">
+
+
+
+
+<div class="erpl_product-section">
+    <div class="separator border-dark my-3"></div>
+    <div id="section6" class="erpl-product-content oeil-spy-section mb-2">
+        <div class="row">
+            <div class="col-12 col-lg">
+                <h2 id="gateway" class="erpl_title-h2 mb-2">Documentation gateway</h2>
+            </div>
+            <div class="col-12 col-lg-4">
+                <div class="erpl_links-list text-lg-right my-1">
+                    <ul>
+                        <li>
+                            <a href="/oeil/en/procedure-file/pdf?reference=2024/0258(COD)&amp;section=DOCUMENTATION_GATEWAY" target="_blank">
+                                <svg class="es_icon es_icon-pdf mr-1">
+                                    <title>pdf</title>
+                                    <use xlink:href="#es_icon-pdf"></use>
+                                </svg>
+                                <span class="t-x">Documentation gateway</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="erpl_accordion mb-5" id="erplAccordionDocGateway">
+            <ul class="a-i">
+                
+                    <li class="erpl_accordion-item" data-selected="false">
+    <button
+            id="erpl_accordion-item-doc-gateway-EP-title"
+            type="button"
+            class="erpl_accordion-item-title collapsed"
+            data-toggle="collapse"
+            aria-expanded="true" data-target="#erpl_accordion-item-doc-gateway-EP" aria-controls="erpl_accordion-item-doc-gateway-EP"
+    >
+        <span class="t-x">European Parliament</span>
+        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
+                <use xlink:href="#es_icon-more"></use>
+            </svg>
+            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
+                <use xlink:href="#es_icon-less"></use>
+            </svg>
+        </span>
+    </button>
+    <div id="erpl_accordion-item-doc-gateway-EP" class="collapse erpl_accordion-item-content a-i-none collapse show" aria-labelledby="erpl_accordion-item-doc-gateway-EP-title">
+        <div>
+            <div class="table-responsive">
+                <table class="table table-striped table-bordered">
+                    <thead>
+                    <tr>
+                        
+
+                        <th class="align-middle" scope="col">Document type</th>
+                        <th class="align-middle" scope="col">Committee</th>
+                        <th class="align-middle w-25" scope="col">Reference</th>
+                        <th class="align-middle" scope="col">Date</th>
+                        <th class="align-middle" scope="col">Summary</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Committee draft report</span>
+                        </th>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/CJ15-PR-766648_EN.html" target="_blank">PE766.648</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >04/12/2024</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Amendments tabled in committee</span>
+                        </th>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/INTA-AM-766791_EN.html" target="_blank">PE766.791</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >06/12/2024</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Amendments tabled in committee</span>
+                        </th>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/CONT-AM-766858_EN.html" target="_blank">PE766.858</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >18/12/2024</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Amendments tabled in committee</span>
+                        </th>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/CJ15-AM-766941_EN.html" target="_blank">PE766.941</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >19/12/2024</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Committee opinion</span>
+                        </th>
+
+                        <td class="align-middle">
+                            <span class="erpl_badge erpl_badge-committee mr-25">INTA</span>
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/INTA-AD-766713_EN.html" target="_blank">PE766.713</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >16/01/2025</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Committee opinion</span>
+                        </th>
+
+                        <td class="align-middle">
+                            <span class="erpl_badge erpl_badge-committee mr-25">CONT</span>
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/CONT-AD-766703_EN.html" target="_blank">PE766.703</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >29/01/2025</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Committee report tabled for plenary, 1st reading/single reading</span>
+                        </th>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/A-10-2025-0006_EN.html" target="_blank">A10-0006/2025</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >31/01/2025</td>
+
+                        <td class="align-middle">
+                            <a href="/oeil/en/document-summary?id=1802918" target="_blank">
+                                <button class="btn btn-success btn-sm" type="button">Summary</button>
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Text agreed during interinstitutional negotiations</span>
+                        </th>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/RegData/commissions/budg/inag/2025/02-27/CJ15_AG(2025)770077_EN.pdf" target="_blank">PE770.077</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >27/02/2025</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Text adopted by Parliament, 1st reading/single reading</span>
+                        </th>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/TA-10-2025-0022_EN.html" target="_blank">T10-0022/2025</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >11/03/2025</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</li>
+                
+                    <li class="erpl_accordion-item" data-selected="false">
+    <button
+            id="erpl_accordion-item-doc-gateway-CSL-title"
+            type="button"
+            class="erpl_accordion-item-title collapsed"
+            data-toggle="collapse"
+            aria-expanded="true" data-target="#erpl_accordion-item-doc-gateway-CSL" aria-controls="erpl_accordion-item-doc-gateway-CSL"
+    >
+        <span class="t-x">Council of the EU</span>
+        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
+                <use xlink:href="#es_icon-more"></use>
+            </svg>
+            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
+                <use xlink:href="#es_icon-less"></use>
+            </svg>
+        </span>
+    </button>
+    <div id="erpl_accordion-item-doc-gateway-CSL" class="collapse erpl_accordion-item-content a-i-none collapse show" aria-labelledby="erpl_accordion-item-doc-gateway-CSL-title">
+        <div>
+            <div class="table-responsive">
+                <table class="table table-striped table-bordered">
+                    <thead>
+                    <tr>
+                        
+
+                        <th class="align-middle" scope="col">Document type</th>
+                        
+                        <th class="align-middle w-25" scope="col">Reference</th>
+                        <th class="align-middle" scope="col">Date</th>
+                        <th class="align-middle" scope="col">Summary</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Coreper letter confirming interinstitutional agreement </span>
+                        </th>
+
+                        
+                        <td class="align-middle w-25">
+                            
+                            <span>GEDA/A/(2025)001013</span>
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >26/02/2025</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</li>
+                
+                    <li class="erpl_accordion-item" data-selected="false">
+    <button
+            id="erpl_accordion-item-doc-gateway-EC-title"
+            type="button"
+            class="erpl_accordion-item-title collapsed"
+            data-toggle="collapse"
+            aria-expanded="true" data-target="#erpl_accordion-item-doc-gateway-EC" aria-controls="erpl_accordion-item-doc-gateway-EC"
+    >
+        <span class="t-x">European Commission</span>
+        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
+                <use xlink:href="#es_icon-more"></use>
+            </svg>
+            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
+                <use xlink:href="#es_icon-less"></use>
+            </svg>
+        </span>
+    </button>
+    <div id="erpl_accordion-item-doc-gateway-EC" class="collapse erpl_accordion-item-content a-i-none collapse show" aria-labelledby="erpl_accordion-item-doc-gateway-EC-title">
+        <div>
+            <div class="table-responsive">
+                <table class="table table-striped table-bordered">
+                    <thead>
+                    <tr>
+                        
+
+                        <th class="align-middle" scope="col">Document type</th>
+                        
+                        <th class="align-middle w-25" scope="col">Reference</th>
+                        <th class="align-middle" scope="col">Date</th>
+                        <th class="align-middle" scope="col">Summary</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Legislative proposal</span>
+                        </th>
+
+                        
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/RegData/docs_autres_institutions/commission_europeenne/com/2024/0469/COM_COM(2024)0469_EN.docx" target="_blank">COM(2024)0469</a>
+                            
+                            <a href="https://eur-lex.europa.eu/smartapi/cgi/sga_doc?smartapi!celexplus!prod!DocNumber&amp;lg=EN&amp;type_doc=COMfinal&amp;an_doc=2024&amp;nu_doc=0469" title="Go to the pageEur-Lex">
+                                <i class="flag-icon flag-sm flag-icon-eu ml-25"></i>
+                            </a>
+
+                            
+                        </td>
+                        <td class="align-middle" >09/10/2024</td>
+
+                        <td class="align-middle">
+                            <a href="/oeil/en/document-summary?id=1791828" target="_blank">
+                                <button class="btn btn-success btn-sm" type="button">Summary</button>
+                            </a>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</li>
+                
+            </ul>
+        </div>
+    </div>
+</div>
+
+                                
+                                <html lang="en">
+
+
+
+
+
+
+                                
+                                
+<div class="erpl_product-section">
+    <div id="section8" class="separator border-dark my-3"></div>
+    <div class="erpl-product-content mb-2">
+        <div class="row">
+            <div class="col-12 col-lg"><h2 class="erpl_title-h2 mb-2">Transparency</h2>
+            </div>
+            <div class="col-12 col-lg-4">
+                <div class="erpl_links-list text-lg-right my-1">
+                    <ul>
+                        <li>
+                            <a href="/oeil/en/procedure-file/pdf?reference=2024/0258(COD)&amp;section=TRANSPARENCY">
+                                <svg class="es_icon es_icon-pdf mr-1">
+                                    <title>pdf</title>
+                                    <use xlink:href="#es_icon-pdf"></use>
+                                </svg>
+                                <span class="t-x">Transparency</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <p>Meetings with interest representatives published in line with the Rules of Procedure</p>
+        <div class="erpl_accordion mb-5" id="erplAccordionTransparency">
+            <ul class="a-i">
+                <li class="erpl_accordion-item" data-selected="false">
+                    <button id="meetingGroup0-content-title"
+                            type="button"
+                            class="erpl_accordion-item-title collapsed"
+                            data-toggle="collapse"
+                            aria-expanded="false"
+                            data-target="#meetingGroup0-content"
+                            aria-controls="meetingGroup0-content">
+                        <span class="t-x">Rapporteurs, Shadow Rapporteurs and Committee Chairs</span>
+                        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+                            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
+                                <use xlink:href="#es_icon-more"></use>
+                            </svg>
+                            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
+                                <use xlink:href="#es_icon-less"></use>
+                            </svg>
+                        </span>
+                    </button>
+                    <div id="meetingGroup0-content"
+                         class="collapse erpl_accordion-item-content a-i-none"
+                         aria-labelledby="meetingGroup0-content-title">
+                        <div class="oeil-meetings-list-container">
+                            <div class="table-responsive">
+                                <table class="table table-striped table-bordered">
+                                    <thead>
+                                    <tr>
+                                        <th class="align-middle" scope="col">Name</th>
+                                        <th class="align-middle" scope="col">Role</th>
+                                        <th class="align-middle" scope="col">Committee</th>
+                                        <th class="align-middle" scope="col">Date</th>
+                                        <th class="align-middle" scope="col">Interest representatives</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/197655"
+                                               class="font-weight-normal">TERHEŞ Cristian</a>
+                                        </th>
+                                        <td class="align-middle">Shadow rapporteur</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/AFET"
+                                               title="Committee on Foreign Affairs">AFET</a>
+                                        </td>
+                                        <td class="align-middle">24/01/2025</td>
+                                        <td class="align-middle">
+                                            
+                                                Mission of the Republic of Moldova to the European Union
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/197497"
+                                               class="font-weight-normal">MIKSER Sven</a>
+                                        </th>
+                                        <td class="align-middle">Rapporteur</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/AFET"
+                                               title="Committee on Foreign Affairs">AFET</a>
+                                        </td>
+                                        <td class="align-middle">12/12/2024</td>
+                                        <td class="align-middle">
+                                            
+                                                Ms Daniela Morari, Ambassador of the Republic of Moldova to the European Union
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/197655"
+                                               class="font-weight-normal">TERHEŞ Cristian</a>
+                                        </th>
+                                        <td class="align-middle">Shadow rapporteur</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/AFET"
+                                               title="Committee on Foreign Affairs">AFET</a>
+                                        </td>
+                                        <td class="align-middle">05/12/2024</td>
+                                        <td class="align-middle">
+                                            
+                                                Mission of the Republic of Moldova to the European Union
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/2268"
+                                               class="font-weight-normal">SJÖSTEDT Jonas</a>
+                                        </th>
+                                        <td class="align-middle">Rapporteur for opinion</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/CONT"
+                                               title="Committee on Budgetary Control">CONT</a>
+                                        </td>
+                                        <td class="align-middle">03/12/2024</td>
+                                        <td class="align-middle">
+                                            
+                                                ECA
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/2268"
+                                               class="font-weight-normal">SJÖSTEDT Jonas</a>
+                                        </th>
+                                        <td class="align-middle">Rapporteur for opinion</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/CONT"
+                                               title="Committee on Budgetary Control">CONT</a>
+                                        </td>
+                                        <td class="align-middle">29/11/2024</td>
+                                        <td class="align-middle">
+                                            
+                                                Moldova Ministry for Economic Development and Digitalization
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/2268"
+                                               class="font-weight-normal">SJÖSTEDT Jonas</a>
+                                        </th>
+                                        <td class="align-middle">Rapporteur for opinion</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/CONT"
+                                               title="Committee on Budgetary Control">CONT</a>
+                                        </td>
+                                        <td class="align-middle">29/11/2024</td>
+                                        <td class="align-middle">
+                                            
+                                                Swedish Emabssy
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/2268"
+                                               class="font-weight-normal">SJÖSTEDT Jonas</a>
+                                        </th>
+                                        <td class="align-middle">Rapporteur for opinion</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/CONT"
+                                               title="Committee on Budgetary Control">CONT</a>
+                                        </td>
+                                        <td class="align-middle">29/11/2024</td>
+                                        <td class="align-middle">
+                                            
+                                                EUDEL Chisinau
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="align-middle" scope="row">
+                                            <a href="https://www.europarl.europa.eu/meps/en/197497"
+                                               class="font-weight-normal">MIKSER Sven</a>
+                                        </th>
+                                        <td class="align-middle">Rapporteur</td>
+                                        <td class="align-middle">
+                                            <a class="erpl_badge erpl_badge-committee mr-25"
+                                               href="https://www.europarl.europa.eu/committes/en/AFET"
+                                               title="Committee on Foreign Affairs">AFET</a>
+                                        </td>
+                                        <td class="align-middle">20/11/2024</td>
+                                        <td class="align-middle">
+                                            
+                                                Deputy Prime Minister, Minister of Economic Development and Digitalization, Mr. Dumitru Alaiba,
+                                                
+                                            
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            
+                        </div>
+                    </div>
+                </li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+                                
+                                <html lang="en">
+
+
+
+
+
+
+</html>
+
+                                
+                                <html lang="en">
+
+
+
+
+
+
+</html>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+
+        <div class="col-12 col-xl-3 offset-xl-1">
+            
+            <div class="position-sticky" id="sectionsNavPositionInitial">
+                
+                
+
+
+
+
+<div class="card erpl_move"
+     data-move-lg="#sectionsNavPositionRwd"
+     data-move-md="#sectionsNavPositionRwd"
+     data-move-sm="#sectionsNavPositionRwd"
+     data-move-xl="#sectionsNavPositionInitial"
+     data-move-xs="#sectionsNavPositionRwd"
+     data-move-xxl="#sectionsNavPositionInitial">
+    <div class="card-body py-0">
+        <nav class="erpl_side-navigation">
+            <h3 class="erpl_title-h3 mb-0 py-2">
+                <a class="text-primary" href="#">
+                    <span class="t-x">Procedure file</span>
+                </a>
+            </h3>
+            <div class="erpl_links-list erpl_links-list-nav">
+                <ul>
+                    <li data-selected="true">
+                        <a class="erpl_smooth-scroll" href="#section1">
+                            <span class="t-x">Basic information</span>
+                        </a>
+                    </li>
+                    <li data-selected="false">
+                        <a class="erpl_smooth-scroll" href="#section2">
+                            <span class="t-x">Key players</span>
+                        </a>
+                    </li>
+                    <li data-selected="false">
+                        <a class="erpl_smooth-scroll" href="#section3">
+                            <span class="t-x">Key events</span>
+                        </a>
+                    </li>
+                    
+                    <li data-selected="false">
+                        <a class="erpl_smooth-scroll" href="#section5">
+                            <span class="t-x">Technical information</span>
+                        </a>
+                    </li>
+                    <li data-selected="false">
+                        <a class="erpl_smooth-scroll" href="#section6">
+                            <span class="t-x">Documentation gateway</span>
+                        </a>
+                    </li>
+                    
+                    <li data-selected="false">
+                        <a class="erpl_smooth-scroll" href="#section8">
+                            <span class="t-x">Transparency</span>
+                        </a>
+                    </li>
+                    
+                    
+                </ul>
+            </div>
+        </nav>
+    </div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+</main>
+
+    
+    <button id="scrollToTopButton" type="button" class="btn btn-primary rounded-circle" data-duration="250" data-min-scroll-to-show="200" aria-label="Scroll to top">
+        <svg aria-hidden="true" class="es_icon es_icon-chevron es_icon-rotate-270">
+            <use xlink:href="#es_icon-chevron"></use>
+        </svg>
+    </button>
+
+    
+    <footer class="erpl_footer">
+    <div class="erpl_footer-top mt-8">
+        <div class="container">
+            <div class="erpl_footer-top-content border-top-lg border-secondary text-center d-md-flex justify-content-between pt-md-3 mb-5 a-i">
+                <nav id="share-links" class="erpl_share-links" aria-label="Share links">
+                    <div class="d-md-flex">
+                        <h2 class="erpl_title-h5 mb-2 mb-md-0"><span class="mr-md-1">Share this page</span></h2>
+                        <ul class="erpl_share-links-list d-flex justify-content-center mb-3 mb-md-0">
+                            <li class="mr-1">
+                                <a title="Share this page on Facebook" href="https://www.facebook.com/share.php?u=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2024/0258(COD)" target="_blank">
+                                    <span class="sr-only">Facebook</span>
+                                    <svg aria-hidden="true" class="es_icon es_icon-facebook">
+                                        <use xlink:href="#es_icon-facebook"></use>
+                                    </svg>
+                                </a>
+                            </li>
+                            <li class="mr-1">
+                                <a title="Share this page on Twitter" href="https://twitter.com/intent/tweet?url=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2024/0258(COD)&amp;text=Procedure%20File:%202024/0258(COD)&amp;via=Europarl_EN" target="_blank">
+                                    <span class="sr-only">Twitter</span>
+                                    <svg aria-hidden="true" class="es_icon es_icon-twitter">
+                                        <use xlink:href="#es_icon-twitter"></use>
+                                    </svg>
+                                </a>
+                            </li>
+                            <li class="mr-1">
+                                <a title="Share this page on LinkedIn" href="https://www.linkedin.com/sharing/share-offsite?url=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2024/0258(COD)" target="_blank">
+                                    <span class="sr-only">LinkedIn</span>
+                                    <svg aria-hidden="true" class="es_icon es_icon-linkedin">
+                                        <use xlink:href="#es_icon-linkedin"></use>
+                                    </svg>
+                                </a>
+                            </li>
+                            <li>
+                                <a title="Share this page on Whatsapp" href="https://api.whatsapp.com/send?text=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2024/0258(COD)" target="_blank">
+                                    <span class="sr-only">Whatsapp</span>
+                                    <svg aria-hidden="true" class="es_icon es_icon-whatsapp">
+                                        <use xlink:href="#es_icon-whatsapp"></use>
+                                    </svg>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </nav>
+                <nav class="erpl_horizontal-links" aria-label="data protection link">
+                    <div>
+                        <a href="https://oeil.secure.europarl.europa.eu/oeil/en/external-documents/download?id=2" target="_blank">
+                            <span class="t-y">Data Protection Notice</span>
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+    </div>
+    <div class="erpl_footer-bottom bg-black-footer pt-3 pb-3">
+        <div class="container">
+            <div class="row" id="footerLinks">
+                <nav class="col-12 col-xl-9 text-center text-md-left" id="website-links" aria-label="Website links">
+    <h3 class="erpl_title-h3 mb-2 text-white">Legislative Observatory</h3>
+    <div class="collapse show" id="website-links-items">
+        <div class="row">
+            <div class="col-12 col-md-6 col-xl-4">
+                <div>
+                    <div class="subtitle mb-1">Tools</div>
+                    <nav class="link-group t-x-mode" aria-label="Tools">
+                        <a href="https://www.europarl.europa.eu/news/en/press-room" class="link-group-item mb-1 d-block" aria-label="Tools - Press Service">
+                            <span>Press Service</span>
+                        </a><a href="https://www.europarl.europa.eu/olp/en/home" class="link-group-item mb-1 d-block" aria-label="Tools - Ordinary legislative procedure">
+                            <span>Ordinary legislative procedure</span>
+                        </a><a href="https://www.europarl.europa.eu/RegistreWeb/search/simple.htm?language=en" class="link-group-item mb-1 d-block" aria-label="Tools - Parliament register">
+                            <span>Parliament register</span>
+                        </a><a href="https://eur-lex.europa.eu/en/index.htm" class="link-group-item mb-1 d-block" aria-label="Tools - EUR-Lex">
+                            <span>EUR-Lex</span>
+                        </a><a href="https://www.consilium.europa.eu/en/documents-publications/public-register/" class="link-group-item mb-1 d-block" aria-label="Tools - Council register">
+                            <span>Council register</span>
+                        </a><a href="https://webgate.ec.europa.eu/regdel/#/home" class="link-group-item mb-1 d-block" aria-label="Tools - Delegated acts register">
+                            <span>Delegated acts register</span>
+                        </a>
+                    </nav>
+                </div>
+            </div>
+            <div class="col-12 col-md-6 col-xl-4">
+                <div>
+                    <div class="subtitle mb-1">Committees</div>
+                    <nav class="link-group t-x-mode" aria-label="Committees">
+                        <a href="https://www.europarl.europa.eu/committees/en/home" class="link-group-item mb-1 d-block" aria-label="Committees - Home">
+                            <span>Home</span>
+                        </a><a href="https://www.europarl.europa.eu/committees/en/meetings/meeting-documents" class="link-group-item mb-1 d-block" aria-label="Committees - Meetings">
+                            <span>Meetings</span>
+                        </a><a href="https://www.europarl.europa.eu/committees/en/documents/search" class="link-group-item mb-1 d-block" aria-label="Committees - Documents">
+                            <span>Documents</span>
+                        </a><a href="https://www.europarl.europa.eu/committees/en/events/events-hearings" class="link-group-item mb-1 d-block" aria-label="Committees - Events">
+                            <span>Events</span>
+                        </a><a href="https://www.europarl.europa.eu/committees/en/supporting-analyses/sa-highlights" class="link-group-item mb-1 d-block" aria-label="Committees - Supporting analyses">
+                            <span>Supporting analyses</span>
+                        </a>
+                    </nav>
+                </div>
+                <div>
+                    <div class="subtitle mb-1">Plenary</div>
+                    <nav class="link-group t-x-mode" aria-label="Plenary">
+                        <a href="https://www.europarl.europa.eu/plenary/en/" class="link-group-item mb-1 d-block" aria-label="Plenary - Plenary sitting">
+                            <span>Plenary sitting</span>
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/guide-plenary.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Around plenary">
+                            <span>Around plenary</span>
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliamentary-questions.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Questions and declarations">
+                            <span>Questions and declarations</span>
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliament-positions.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Legislative texts adopted">
+                            <span>Legislative texts adopted</span>
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/meetings-search.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Plenary calendar">
+                            <span>Plenary calendar</span>
+                        </a>
+                    </nav>
+                </div>
+            </div>
+            <div class="col-12 col-md-6 col-xl-4">
+                <div>
+                    <div class="subtitle mb-1">Delegations</div>
+                    <nav class="link-group t-x-mode" aria-label="Delegations">
+                        <a href="https://www.europarl.europa.eu/delegations/en/calendar" class="link-group-item mb-1 d-block" aria-label="Delegations - Delegations calendar">
+                            <span>Delegations calendar</span>
+                        </a><a href="https://www.europarl.europa.eu/delegations/en/home" class="link-group-item mb-1 d-block" aria-label="Delegations - Home">
+                            <span>Home</span>
+                        </a>
+                    </nav>
+                </div>
+                <div>
+                    <div class="subtitle mb-1">MEPs</div>
+                    <nav class="link-group t-x-mode" aria-label="MEPs">
+                        <a href="https://www.europarl.europa.eu/meps/en/search/advanced" class="link-group-item mb-1 d-block" aria-label="MEPs - Search">
+                            <span>Search</span>
+                        </a>
+                    </nav>
+                </div>
+                <div>
+                    <div class="subtitle mb-1">At your service</div>
+                    <nav class="link-group t-x-mode" aria-label="At your service">
+                        <a href="https://www.europarl.europa.eu/at-your-service/en" class="link-group-item mb-1 d-block" aria-label="At your service - Home">
+                            <span>Home</span>
+                        </a>
+                    </nav>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="d-block d-md-none">
+        <div class="footerLinkToggle separator separator-dotted separator-2x mb-5 mt-5 collapsed">
+            <a class="erpl_toggle-menu" href="#website-links"
+               title="Toggle linked links"
+               role="button"
+               data-toggle="collapse"
+               data-target="#website-links-items"
+               aria-expanded="false"
+               aria-controls="website-links" aria-label="Toggle linked links">
+                <svg aria-hidden="true" class="es_icon es_icon-plus" data-show-expanded="false">
+                    <use xlink:href="#es_icon-plus"></use>
+                </svg>
+
+                <svg aria-hidden="true" class="es_icon es_icon-minus" data-show-expanded="true">
+                    <use xlink:href="#es_icon-minus"></use>
+                </svg>
+            </a>
+            <a class="erpl_nojs-close-menu" href="#website-links-close"
+               title="Untoggle linked links"
+               role="button"
+               data-toggle="collapse"
+               data-target="#website-links-items"
+               aria-expanded="false"
+               aria-controls="website-links" aria-label="Untoggle linked links">
+                <svg aria-hidden="true" class="es_icon es_icon-minus">
+                    <use xlink:href="#es_icon-minus"></use>
+                </svg>
+            </a>
+        </div>
+    </div>
+</nav>
+                <nav class="col-12 col-xl-3 text-center text-md-left" id="europarl-links" aria-label="Europarl links">
+    <div class="separator separator-dotted separator-2x mt-3 mb-4 d-none d-md-flex d-xl-none"></div>
+    <h3 class="erpl_title-h3 mb-2 text-white">European Parliament</h3>
+    <div class="collapse show" id="europarl-links-items">
+        <nav class="link-group pt-25 t-x-mode" aria-label="European Parliament">
+            <a href="https://www.europarl.europa.eu/news/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - News">
+                <span>News</span></a><a href="https://www.europarl.europa.eu/topics/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Topics">
+                <span>Topics</span></a><a href="https://www.europarl.europa.eu/meps/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - MEPs">
+                <span>MEPs</span></a><a href="https://www.europarl.europa.eu/about-parliament/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - About Parliament">
+                <span>About Parliament</span></a><a href="https://www.europarl.europa.eu/plenary/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Plenary">
+                <span>Plenary</span></a><a href="https://www.europarl.europa.eu/committees/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Committees">
+                <span>Committees</span></a><a href="https://www.europarl.europa.eu/delegations/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Delegations">
+                <span>Delegations</span></a><a href="https://elections.europa.eu/en/" class="link-group-item mb-1 d-block" aria-label="European Parliament - Elections">
+                <span>Elections</span></a>
+        </nav>
+    </div>
+    <div class="d-block d-md-none">
+        <div class="footerLinkToggle separator separator-dotted separator-2x mb-5 mt-5 collapsed">
+            <a href="#europarl-links"
+               title="Toggle European Parliament websites"
+               role="button"
+               data-toggle="collapse"
+               data-target="#europarl-links-items"
+               aria-expanded="false"
+               aria-controls="europarl-links" aria-label="Toggle European Parliament websites">
+                <svg aria-hidden="true" class="es_icon es_icon-plus" data-show-expanded="false">
+                    <use xlink:href="#es_icon-plus"></use>
+                </svg>
+
+                <svg aria-hidden="true" class="es_icon es_icon-minus" data-show-expanded="true">
+                    <use xlink:href="#es_icon-minus"></use>
+                </svg>
+            </a>
+            <a class="erpl_nojs-close-menu" href="#europarl-links-close"
+               title="Untoggle European Parliament websites"
+               role="button" data-toggle="collapse"
+               data-target="#europarl-links-items"
+               aria-expanded="false"
+               aria-controls="europarl-links" aria-label="Untoggle European Parliament websites">
+                <svg aria-hidden="true" class="es_icon es_icon-minus">
+                    <use xlink:href="#es_icon-minus"></use>
+                </svg>
+            </a>
+        </div>
+    </div>
+</nav>
+            </div>
+
+
+            <div class="separator separator-dotted separator-2x mt-3 mb-3 d-none d-md-flex"></div>
+            <div class="row">
+                <nav class="col-12" id="social-links" aria-label="Social links">
+                    <div class="erpl_social-links mb-2">
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on Facebook" href="https://www.facebook.com/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-facebook-color">
+                                    <use href="#es_icon-facebook-color"></use>
+                                </svg>
+                                <span class="sr-only">Facebook</span>
+                            </a>
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on Twitter" href="https://twitter.com/Europarl_en" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-twitter-color">
+                                    <use href="#es_icon-twitter-color"></use>
+                                </svg>
+                                <span class="sr-only">Twitter</span>
+                            </a>
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on Flickr" href="https://www.flickr.com/photos/european_parliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-flickr-color">
+                                    <use href="#es_icon-flickr-color"></use>
+                                </svg>
+                                <span class="sr-only">Flickr</span>
+                            </a>
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on LinkedIn" href="https://www.linkedin.com/company/european-parliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-linkedin-color">
+                                    <use href="#es_icon-linkedin-color"></use>
+                                </svg>
+                                <span class="sr-only">LinkedIn</span>
+                            </a>
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on YouTube" href="https://www.youtube.com/user/EuropeanParliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-youtube-color">
+                                    <use href="#es_icon-youtube-color"></use>
+                                </svg>
+                                <span class="sr-only">YouTube</span>
+                            </a>
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on Instagram" href="https://www.instagram.com/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-instagram-color">
+                                    <use href="#es_icon-instagram-color"></use>
+                                </svg>
+                                <span class="sr-only">Instagram</span>
+                            </a>
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on Pinterest" href="https://www.pinterest.fr/epinfographics" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-pinterest-color">
+                                    <use href="#es_icon-pinterest-color"></use>
+                                </svg>
+                                <span class="sr-only">Pinterest</span>
+                            </a>
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on Snapchat" href="https://www.snapchat.com/add/europarl" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-snapchat-color">
+                                    <use href="#es_icon-snapchat-color"></use>
+                                </svg>
+                                <span class="sr-only">Snapchat</span>
+                            </a>
+                        
+                            <a data-toggle="tooltip" title="Check out Parliament on Reddit" href="https://www.reddit.com/r/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true" class="es_icon es_icon-reddit-color">
+                                    <use href="#es_icon-reddit-color"></use>
+                                </svg>
+                                <span class="sr-only">Reddit</span>
+                            </a>
+                        
+                    </div>
+                </nav>
+            </div>
+            <div class="row">
+                <nav id="information-links" class="col-12 small text-center text-white font-weight-bold t-y-mode" aria-label="Information links">
+                    
+                        <a href="https://www.europarl.europa.eu/portal/en/contact" class="mr-2 mb-1">
+                            <span>Contact</span>
+                        </a>
+                    
+                        <a href="https://www.europarl.europa.eu/portal/en/sitemap" class="mr-2 mb-1">
+                            <span>Sitemap</span>
+                        </a>
+                    
+                        <a href="https://www.europarl.europa.eu/legal-notice/en" class="mr-2 mb-1">
+                            <span>Legal notice</span>
+                        </a>
+                    
+                        <a href="https://www.europarl.europa.eu/privacy-policy/en" class="mr-2 mb-1">
+                            <span>Privacy policy</span>
+                        </a>
+                    
+                        <a href="https://www.europarl.europa.eu/portal/en/accessibility" class="mr-2 mb-1">
+                            <span>Accessibility</span>
+                        </a>
+                    
+                </nav>
+            </div>
+        </div>
+    </div>
+</footer>
+
+    
+    <script src="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/lib/jquery/jquery.min.js"></script>
+    
+    <script id="evostrap" src="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/dist/js/evostrap.js"></script>
+    <script src="https://www.europarl.europa.eu/commonFrontResources/evostrap-oeil/1.0.0//dist/js/oeil.js"></script>
+
+    
+    <script src="/oeil/oeil-addons/documents-loading.js"></script>
+    <script src="/oeil/oeil-addons/session-calendar.js"></script>
+    <script src="/oeil/oeil-addons/tools.js"></script>
+    <script src="/oeil/oeil-addons/meetings-list.js"></script>
+
+    
+    <script type="text/javascript" defer data-tracker-name="ATInternet"
+            data-value="https://www.europarl.europa.eu/website/webanalytics/ati-oeil.js"
+            src="https://www.europarl.europa.eu/website/privacy-policy/privacy-policy.js">
+    </script>
+
+    
+    
+    <script src="/oeil/oeil-addons/scroll-spy.js"></script>
+
+</body>
+</html>

--- a/backend/tests/scrapers/test_votes.py
+++ b/backend/tests/scrapers/test_votes.py
@@ -315,7 +315,7 @@ def test_procedure_scraper(responses):
         data={
             "procedure_title": "Implementation of the 2018 Geoblocking Regulation in the Digital Single Market",
             "geo_areas": [],
-            "responsible_committee": "IMCO",
+            "responsible_committees": {"IMCO"},
         },
     )
 
@@ -342,6 +342,17 @@ def test_procedure_scraper_geo_areas_fuzzy(responses):
     scraper = ProcedureScraper(vote_id=155056, procedure_reference="2022/2201(INI)")
     fragment = scraper.run()
     assert fragment.data["geo_areas"] == ["XKX"]
+
+
+def test_procedure_scraper_multiple_responsible_committees(responses):
+    responses.get(
+        "https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2024/0258(COD)",
+        body=load_fixture("scrapers/data/votes/oeil-procedure-file_2024-0258-cod.html"),
+    )
+
+    scraper = ProcedureScraper(vote_id=172102, procedure_reference="2024/0258(COD)")
+    fragment = scraper.run()
+    assert fragment.data["responsible_committees"] == {"AFET", "BUDG"}
 
 
 def test_eurlex_procedure_scraper_eurovoc_concepts(responses):


### PR DESCRIPTION
A procedure can have multiple responsible committees (see [Rules of Procedure](https://www.europarl.europa.eu/doceo/document/RULES-9-2022-07-11-RULE-058_EN.html) and an [example procedure](https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2024/0258(COD))).

* I’ve updated the procedure scraper to properly handle procedures with a joint committee responsible and added tests.
* I’ve updated the CSV export and removed the `responsible_committee_code` in the `votes.csv` table. Instead, there are now separate tables `committees.csv` and `responsible_committee_votes.csv`.

After deployment, we need to re-scrape the procedure files and then re-aggregate the votes.

Fixes #1121 