### PR TITLE
Add procedure type to API and export

### DIFF
--- a/backend/howtheyvote/api/serializers.py
+++ b/backend/howtheyvote/api/serializers.py
@@ -11,6 +11,7 @@ from ..models import (
     PlenarySessionLocation,
     PlenarySessionStatus,
     ProcedureStage,
+    ProcedureType,
     Vote,
     VotePosition,
     VoteResult,
@@ -21,10 +22,13 @@ class ProcedureDict(TypedDict):
     """European Union legislative procedure"""
 
     title: Annotated[str | None, "Nature restoration"]
-    """Title of the legislative proceudre as listed in the Legislative Observatory"""
+    """Title of the legislative proceudre as listed in the [Legislative Observatory](https://oeil.secure.europarl.europa.eu/oeil/en)"""
+
+    type: ProcedureType
+    """Procedure type as listed in the [Legislative Observatory](https://oeil.secure.europarl.europa.eu/oeil/en)"""
 
     reference: Annotated[str, "2022/0195(COD)"]
-    """Procedure reference as listed in the Legislative Observatory"""
+    """Procedure reference as listed in the [Legislative Observatory](https://oeil.secure.europarl.europa.eu/oeil/en)"""
 
     stage: ProcedureStage | None
     """Stage of the procedure in which the vote took place. This field is only available for

--- a/backend/howtheyvote/api/votes_api.py
+++ b/backend/howtheyvote/api/votes_api.py
@@ -8,7 +8,13 @@ from sqlalchemy import or_, select
 from structlog import get_logger
 
 from ..db import Session
-from ..helpers import PROCEDURE_REFERENCE_REGEX, REFERENCE_REGEX, flatten_dict, subset_dict
+from ..helpers import (
+    PROCEDURE_REFERENCE_REGEX,
+    REFERENCE_REGEX,
+    flatten_dict,
+    parse_procedure_reference,
+    subset_dict,
+)
 from ..models import Fragment, Member, PressRelease, Vote
 from ..query import fragments_for_records
 from ..vote_stats import count_vote_positions, count_vote_positions_by_group
@@ -242,8 +248,11 @@ def show(vote_id: int) -> Response:
     procedure: ProcedureDict | None = None
 
     if vote.procedure_reference:
+        procedure_reference = parse_procedure_reference(vote.procedure_reference)
+
         procedure = {
             "title": vote.procedure_title,
+            "type": procedure_reference["type"],
             "reference": vote.procedure_reference,
             "stage": vote.procedure_stage,
         }

--- a/backend/howtheyvote/helpers.py
+++ b/backend/howtheyvote/helpers.py
@@ -9,7 +9,7 @@ from typing import Any, TypedDict, TypeVar, cast
 from urllib.parse import urljoin
 
 from . import config
-from .models import ProcedureType
+from .models import DocumentType, ProcedureType
 
 REFERENCE_REGEX = re.compile(
     r"(?P<type>A|B|C|RC-B)"
@@ -27,7 +27,7 @@ PROCEDURE_REFERENCE_REGEX = re.compile(
 
 
 class Reference(TypedDict):
-    type: str
+    type: DocumentType
     term: int
     number: int
     year: int
@@ -45,11 +45,12 @@ def parse_reference(reference: str) -> Reference:
     if not match:
         raise ValueError(f"Invalid reference: {reference}")
 
-    type_ = cast(str, match.group("type"))
+    type_code = cast(str, match.group("type"))
 
-    if type_ == "RC-B":
-        type_ = "RC"
+    if type_code == "RC-B":
+        type_code = "RC"
 
+    type_ = DocumentType[type_code]
     term = int(match.group("term"))
     number = int(match.group("number"))
     year = int(match.group("year"))

--- a/backend/howtheyvote/helpers.py
+++ b/backend/howtheyvote/helpers.py
@@ -9,6 +9,7 @@ from typing import Any, TypedDict, TypeVar, cast
 from urllib.parse import urljoin
 
 from . import config
+from .models import ProcedureType
 
 REFERENCE_REGEX = re.compile(
     r"(?P<type>A|B|C|RC-B)"
@@ -33,7 +34,7 @@ class Reference(TypedDict):
 
 
 class ProcedureReference(TypedDict):
-    type: str
+    type: ProcedureType
     number: str
     year: int
 
@@ -62,7 +63,12 @@ def parse_procedure_reference(procedure_reference: str) -> ProcedureReference:
     if not match:
         raise ValueError(f"Invalid procedure reference: {procedure_reference}")
 
-    type_ = cast(str, match.group("type"))
+    try:
+        type_code = cast(str, match.group("type"))
+        type_ = ProcedureType[type_code]
+    except KeyError:
+        raise ValueError(f"Invalid procedure type {type_code}") from None
+
     number = cast(str, match.group("number"))
     year = int(match.group("year"))
 

--- a/backend/howtheyvote/models/__init__.py
+++ b/backend/howtheyvote/models/__init__.py
@@ -12,6 +12,7 @@ from .member import (
 from .press_release import PressRelease
 from .session import PlenarySession, PlenarySessionLocation, PlenarySessionStatus
 from .vote import (
+    DocumentType,
     MemberVote,
     ProcedureStage,
     ProcedureType,
@@ -47,6 +48,7 @@ __all__ = [
     "VotePositionCounts",
     "VoteResult",
     "MemberVote",
+    "DocumentType",
     "ProcedureStage",
     "ProcedureType",
     "Vote",

--- a/backend/howtheyvote/models/__init__.py
+++ b/backend/howtheyvote/models/__init__.py
@@ -14,6 +14,7 @@ from .session import PlenarySession, PlenarySessionLocation, PlenarySessionStatu
 from .vote import (
     MemberVote,
     ProcedureStage,
+    ProcedureType,
     Vote,
     VoteGroup,
     VotePosition,
@@ -47,6 +48,7 @@ __all__ = [
     "VoteResult",
     "MemberVote",
     "ProcedureStage",
+    "ProcedureType",
     "Vote",
     "VoteGroup",
     "PressRelease",

--- a/backend/howtheyvote/models/vote.py
+++ b/backend/howtheyvote/models/vote.py
@@ -30,6 +30,13 @@ class VotePosition(Enum):
     DID_NOT_VOTE = "DID_NOT_VOTE"
 
 
+class DocumentType(Enum):
+    A = "A"  # Report
+    B = "B"  # Resolution
+    C = "C"  # Commission proposal
+    RC = "RC"  # Joint resolution
+
+
 class ProcedureType(Enum):
     # Based on the codes used by the Parliament in the Legislative Observatory
     COD = "COD"  # Ordinary legislative procedure

--- a/backend/howtheyvote/models/vote.py
+++ b/backend/howtheyvote/models/vote.py
@@ -30,6 +30,33 @@ class VotePosition(Enum):
     DID_NOT_VOTE = "DID_NOT_VOTE"
 
 
+class ProcedureType(Enum):
+    # Based on the codes used by the Parliament in the Legislative Observatory
+    COD = "COD"  # Ordinary legislative procedure
+    CNS = "CNS"  # Consultation procedure
+    APP = "APP"  # Consent procedure
+    BUD = "BUD"  # Budgetary procedure
+    DEC = "DEC"  # Discharge procedure
+    BUI = "BUI"  # Budgetary initiative
+    NLE = "NLE"  # Non-legislative enactments
+    INL = "INL"  # Legislative initiative procedure
+    INI = "INI"  # Own-initiative procedure
+    RSP = "RSP"  # Resolutions on topical subjects
+    REG = "REG"  # Parliament's Rules of Procedure
+    IMM = "IMM"  # Member's immunity
+    RSO = "RSO"  # Internal organisation decisions
+    INS = "INS"  # Institutional procedure
+    ACI = "ACI"  # Interinstitutional agreement procedure
+    DEA = "DEA"  # Delegated acts procedure
+    RPS = "RPS"  # Implementing acts
+
+    # Historic procedures
+    AVC = "AVC"  # Assent procedure
+    SYN = "SYN"  # Cooperation procedure
+    DCE = "DCE"  # Written declaration
+    COS = "COS"  # Procedure on a strategy paper
+
+
 class ProcedureStage(Enum):
     OLP_FIRST_READING = "OLP_FIRST_READING"
     OLP_SECOND_READING = "OLP_SECOND_READING"

--- a/backend/howtheyvote/scrapers/votes.py
+++ b/backend/howtheyvote/scrapers/votes.py
@@ -445,7 +445,7 @@ class DocumentScraper(BeautifulSoupScraper):
     def _url(self) -> str:
         ref = parse_reference(self.reference)
         number = str(ref["number"]).rjust(4, "0")
-        formatted_ref = f"{ref['type']}-{ref['term']}-{ref['year']}-{number}"
+        formatted_ref = f"{ref['type'].value}-{ref['term']}-{ref['year']}-{number}"
         return f"{self.BASE_URL}/{formatted_ref}_EN.html"
 
     def _extract_data(self, doc: BeautifulSoup) -> Fragment:
@@ -693,7 +693,7 @@ class EurlexDocumentScraper(BeautifulSoupScraper):
 
         # EUR-Lex URLs have the format `https://eur-lex.europa.eu/legal-content/EN/ALL/?uri=EP:P9_A(2021)0270`
         # whereas the reference is usually formatted like this: `A9-0270/2021`.
-        return f"{self.BASE_URL}P{ref['term']}_{ref['type']}({ref['year']}){number}"
+        return f"{self.BASE_URL}P{ref['term']}_{ref['type'].value}({ref['year']}){number}"
 
     def _extract_data(self, doc: BeautifulSoup) -> Fragment | None:
         container = doc.select_one("#PPClass_Contents")

--- a/backend/tests/api/test_votes_api.py
+++ b/backend/tests/api/test_votes_api.py
@@ -62,6 +62,7 @@ def records(db_session):
         order=1,
         title="Should we have pizza for lunch?",
         description="Am 123",
+        procedure_reference="1234/2025(COD)",
         member_votes=[
             MemberVote(
                 web_id=1,
@@ -420,7 +421,12 @@ def test_votes_api_show(records, db_session, api):
         "timestamp": "2023-01-01T00:00:00",
         "reference": None,
         "description": "Am 123",
-        "procedure": None,
+        "procedure": {
+            "title": None,
+            "type": "COD",
+            "reference": "1234/2025(COD)",
+            "stage": None,
+        },
         "facts": None,
         "sharepic_url": None,
         "stats": {

--- a/backend/tests/export/test_init.py
+++ b/backend/tests/export/test_init.py
@@ -153,8 +153,8 @@ def test_export_votes(db_session, tmp_path):
     votes_meta = tmp_path.joinpath("votes.csv-metadata.json")
 
     expected = (
-        "id,timestamp,display_title,reference,description,is_main,procedure_reference,procedure_title,procedure_stage,responsible_committee_code,count_for,count_against,count_abstention,count_did_not_vote,result\n"
-        "123456,2024-01-01 00:00:00,Lorem Ipsum,,,False,2025/1234(COD),Lorem Ipsum,OLP_FIRST_READING,,1,0,0,0,ADOPTED\n"
+        "id,timestamp,display_title,reference,description,is_main,procedure_reference,procedure_title,procedure_type,procedure_stage,responsible_committee_code,count_for,count_against,count_abstention,count_did_not_vote,result\n"
+        "123456,2024-01-01 00:00:00,Lorem Ipsum,,,False,2025/1234(COD),Lorem Ipsum,COD,OLP_FIRST_READING,,1,0,0,0,ADOPTED\n"
     )
 
     assert votes_csv.read_text() == expected

--- a/backend/tests/test_helpers.py
+++ b/backend/tests/test_helpers.py
@@ -9,6 +9,7 @@ from howtheyvote.helpers import (
     parse_reference,
     subset_dict,
 )
+from howtheyvote.models import ProcedureType
 
 
 def test_parse_reference():
@@ -42,15 +43,15 @@ def test_parse_reference():
 
 def test_parse_procedure_reference():
     ref = parse_procedure_reference("2021/0106(COD)")
-    assert ref == ProcedureReference(type="COD", year=2021, number="0106")
+    assert ref == ProcedureReference(type=ProcedureType.COD, year=2021, number="0106")
 
     # In most cases the sequential number consists only of digits, but in some cases
     # it can also contain a letter at the end.
     ref = parse_procedure_reference("2023/0038M(NLE)")
-    assert ref == ProcedureReference(type="NLE", year=2023, number="0038M")
+    assert ref == ProcedureReference(type=ProcedureType.NLE, year=2023, number="0038M")
 
     ref = parse_procedure_reference("2023/0201R(APP)")
-    assert ref == ProcedureReference(type="APP", year=2023, number="0201R")
+    assert ref == ProcedureReference(type=ProcedureType.APP, year=2023, number="0201R")
 
     with pytest.raises(ValueError, match="Invalid procedure reference:"):
         parse_procedure_reference("2021/106(COD)")

--- a/backend/tests/test_helpers.py
+++ b/backend/tests/test_helpers.py
@@ -9,30 +9,30 @@ from howtheyvote.helpers import (
     parse_reference,
     subset_dict,
 )
-from howtheyvote.models import ProcedureType
+from howtheyvote.models import DocumentType, ProcedureType
 
 
 def test_parse_reference():
     ref = parse_reference("A9-1234/2024")
-    assert ref == Reference(type="A", term=9, number=1234, year=2024)
+    assert ref == Reference(type=DocumentType.A, term=9, number=1234, year=2024)
 
     ref = parse_reference("B9-1234/2024")
-    assert ref == Reference(type="B", term=9, number=1234, year=2024)
+    assert ref == Reference(type=DocumentType.B, term=9, number=1234, year=2024)
 
     ref = parse_reference("RC-B9-1234/2024")
-    assert ref == Reference(type="RC", term=9, number=1234, year=2024)
+    assert ref == Reference(type=DocumentType.RC, term=9, number=1234, year=2024)
 
     ref = parse_reference("C9-1234/2024")
-    assert ref == Reference(type="C", term=9, number=1234, year=2024)
+    assert ref == Reference(type=DocumentType.C, term=9, number=1234, year=2024)
 
     ref = parse_reference("A9-1234/2024/rev")
-    assert ref == Reference(type="A", term=9, number=1234, year=2024)
+    assert ref == Reference(type=DocumentType.A, term=9, number=1234, year=2024)
 
     ref = parse_reference("A9-1234/2024/rev1")
-    assert ref == Reference(type="A", term=9, number=1234, year=2024)
+    assert ref == Reference(type=DocumentType.A, term=9, number=1234, year=2024)
 
     ref = parse_reference("a9-1234/2024")
-    assert ref == Reference(type="A", term=9, number=1234, year=2024)
+    assert ref == Reference(type=DocumentType.A, term=9, number=1234, year=2024)
 
     with pytest.raises(ValueError, match="Invalid reference:"):
         parse_reference("D9-1234/2024")


### PR DESCRIPTION
This adds the procedure type as a separate field to the API and CSV export. As the procedure type is a part of the procedure reference (e.g. "COD" in "1234/2025(COD)"), technically, this is already part of API responses and CSV exports. However, in practice, it’s quite convenient to have this exposed as a separate field for filtering etc.