### PR TITLE
Remove phrase subquery

### DIFF
--- a/backend/stubs/xapian/__init__.pyi
+++ b/backend/stubs/xapian/__init__.pyi
@@ -102,7 +102,19 @@ class SimpleStopper(Stopper):
 
 class QueryParser:
     def __init__(self) -> None: ...
+    FLAG_BOOLEAN: int
+    FLAG_BOOLEAN_ANY_CASE: int
+    FLAG_CJK_NGRAM: int
     FLAG_DEFAULT: int
+    FLAG_LOVEHATE: int
+    FLAG_NGRAMS: int
+    FLAG_NO_POSITIONS: int
+    FLAG_PARTIAL: int
+    FLAG_PHRASE: int
+    FLAG_PURE_NOTE: int
+    FLAG_SPELLING_CORRECTION: int
+    FLAG_SYNONYM: int
+    FLAG_WILDCARD: int
     def parse_query(self, query_string: str, flags: int = ..., prefix: str = ...) -> Query: ...
     def set_stopper(self, stopper: Stopper) -> None: ...
     def set_database(self, db: Database) -> None: ...

--- a/backend/tests/api/test_votes_api.py
+++ b/backend/tests/api/test_votes_api.py
@@ -398,6 +398,29 @@ def test_votes_api_search_sort(db_session, search_index, api):
     assert res.json["results"][1]["id"] == 1
 
 
+def test_votes_api_search_special_chars(db_session, search_index, api):
+    vote = Vote(
+        id=1,
+        timestamp=datetime.datetime(2024, 1, 1, 0, 0, 0),
+        title="Union Secure Connectivity Programme 2023-2027",
+        is_main=True,
+    )
+    db_session.add(vote)
+    db_session.commit()
+    index_search(Vote, [vote])
+
+    res = api.get(
+        "/api/votes/search",
+        query_string={
+            "q": "Union Secure Connectivity Programme 2023-2027",
+        },
+    )
+
+    assert res.status_code == 200
+    assert len(res.json["results"]) == 1
+    assert res.json["results"][0]["id"] == 1
+
+
 def test_votes_api_show(records, db_session, api):
     fragment = Fragment(
         model="Vote",


### PR DESCRIPTION
The idea behind this was to boost results that contain the search query in the same order. However, this was causing errors for nested search queries (and queries that were parsed as such), because Xapian supports phrase queries only if all subqueries are leaf queries.

Not sure if there is a good alternative. For now, I’m simply removing this. I’ve also removed the option to use `+` and `-` operators, as these are also commonly used as normal characters in search queries (e.g. date ranges).

One example to reproduce this is the query from the test case: `Union Secure Connectivity Programme 2023-2027`