### PR TITLE
Enforce response encoding for VOT lists

### DIFF
--- a/backend/howtheyvote/scrapers/votes.py
+++ b/backend/howtheyvote/scrapers/votes.py
@@ -341,6 +341,7 @@ class RCVListEnglishScraper(BeautifulSoupScraper):
 class VOTListScraper(BeautifulSoupScraper):
     BASE_URL = "https://www.europarl.europa.eu/doceo/document"
     BS_PARSER = "lxml-xml"
+    RESPONSE_ENCODING = "utf-8"
 
     def __init__(
         self,


### PR DESCRIPTION
Similar to the RCV data source, the web server doesn’t return the correct charset in the response headers, so we need to specify it explicitly.