### PR TITLE
Send Pushover notifications for important events

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,7 @@
 HTV_BACKEND_PUBLIC_URL=https://localhost/api
 HTV_FRONTEND_PUBLIC_URL=https://localhost
 CADDY_SITE_ADDRESS=localhost
+
+# Optional
+PUSHOVER_API_TOKEN=
+PUSHOVER_USER_KEY=

--- a/backend/howtheyvote/config.py
+++ b/backend/howtheyvote/config.py
@@ -26,3 +26,7 @@ SEARCH_INDEX_DIR = env.get("HTV_SEARCH_INDEX_DIR", "/howtheyvote/index")
 
 # The Alpine package `xapian-core` installs stop word lists in this location
 SEARCH_STOPWORDS_PATH = "/usr/share/xapian-core/stopwords/english.list"
+
+# Pushover
+PUSHOVER_API_TOKEN = env.get("PUSHOVER_API_TOKEN")
+PUSHOVER_USER_KEY = env.get("PUSHOVER_USER_KEY")

--- a/backend/howtheyvote/pushover.py
+++ b/backend/howtheyvote/pushover.py
@@ -1,0 +1,41 @@
+import requests
+from structlog import get_logger
+
+from . import config
+
+API_URL = "https://api.pushover.net/1/messages.json"
+log = get_logger(__name__)
+
+
+def send_notification(message: str, title: str | None = None, url: str | None = None) -> None:
+    if not config.PUSHOVER_API_TOKEN or not config.PUSHOVER_USER_KEY:
+        log.warn(
+            "Pushover API token or user key not configured. No push notification will be sent."
+        )
+        return
+
+    # Pushover limits the size of titles and messages, but apparently automatically truncates
+    # strings longer than that, so we don’t need to handle that on our side:
+    # https://jcs.org/2023/07/12/api
+
+    try:
+        response = requests.post(
+            API_URL,
+            data={
+                "token": config.PUSHOVER_API_TOKEN,
+                "user": config.PUSHOVER_USER_KEY,
+                "title": title,
+                "message": message,
+                "url": url,
+            },
+        )
+        response.raise_for_status()
+    except requests.RequestException:
+        # Sending push notifications isn't critical, so we don't want request exceptions
+        # to bubble up, logging them is enough.
+        log.exception(
+            "Failed to send push notification",
+            message=message,
+            title=title,
+            url=url,
+        )

--- a/backend/howtheyvote/worker/worker.py
+++ b/backend/howtheyvote/worker/worker.py
@@ -16,6 +16,7 @@ from .. import config
 from ..db import Session
 from ..models import PipelineRun, PipelineStatus
 from ..pipelines import PipelineResult
+from ..pushover import send_notification
 
 log = get_logger(__name__)
 
@@ -188,10 +189,14 @@ class Worker:
             except SkipPipeline:
                 # Do not log skipped pipeline runs
                 return
-            except Exception:
+            except Exception as exc:
                 status = PipelineStatus.FAILURE
                 checksum = None
                 log.exception("Unhandled exception during pipeline run", pipeline=name)
+                send_notification(
+                    title=f"Pipeline failure: {name}",
+                    message=f"Check logs for details. Error message: {exc}",
+                )
 
             duration = time.time() - start_time
             finished_at = datetime.datetime.now(datetime.UTC)

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1622,4 +1622,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "70d081b031d47239178443f1f440d572457207f29c871072ac5041876ed57f70"
+content-hash = "0ef5655cebc4cc33aa4625d7b243748e6542f855a4433dbcb176e66a82ed288d"

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1031,6 +1031,24 @@ pytest = ">=8.3.3"
 testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "pytest-mock (>=3.14)"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pytest_mock-3.14.1-py3-none-any.whl", hash = "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0"},
+    {file = "pytest_mock-3.14.1.tar.gz", hash = "sha256:159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -48,6 +48,7 @@ pytest-env = "^1.1.5"
 responses = "^0.25.7"
 time-machine = "^2.16.0"
 types-tabulate = "^0.9.0.20241207"
+pytest-mock = "^3.14.1"
 
 [tool.ruff]
 line-length = 95
@@ -68,6 +69,10 @@ env = [
     "D:HTV_BACKEND_DATABASE_URI=sqlite:////howtheyvote/database/database.test.sqlite3",
     "HTV_BACKEND_PUBLIC_URL=https://example.org/api",
     "HTV_SEARCH_INDEX_PREFIX=test",
+    # Disable pushover notifications in test env even when an API token and user key
+    # is configured in development environment
+    "PUSHOVER_API_TOKEN=",
+    "PUSHOVER_USER_KEY=",
 ]
 markers = [
     "always_mock_requests: Always mock HTTP requests, even when request mocks are disabled globally"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,6 +9,7 @@ import os
 
 import pytest
 from responses import FirstMatchRegistry, RequestsMock
+from structlog.testing import capture_logs
 
 from howtheyvote import config
 from howtheyvote.db import Session, engine, migrate, session_factory
@@ -90,3 +91,9 @@ def responses(request):
     with RequestsMock(registry=DummyRegistry) as r:
         r.add_passthru("http")
         yield r
+
+
+@pytest.fixture
+def logs():
+    with capture_logs() as captured_logs:
+        yield captured_logs

--- a/backend/tests/test_pushover.py
+++ b/backend/tests/test_pushover.py
@@ -1,0 +1,65 @@
+import requests
+from responses import matchers
+
+from howtheyvote.pushover import send_notification
+
+
+def test_send_notification(responses, mocker):
+    mocker.patch("howtheyvote.config.PUSHOVER_API_TOKEN", "api-token-123")
+    mocker.patch("howtheyvote.config.PUSHOVER_USER_KEY", "user-key-123")
+
+    res = responses.post(
+        url="https://api.pushover.net/1/messages.json",
+        match=[
+            matchers.urlencoded_params_matcher(
+                {
+                    "token": "api-token-123",
+                    "user": "user-key-123",
+                    "title": "Title",
+                    "message": "Message",
+                    "url": "https://howtheyvote.eu",
+                }
+            )
+        ],
+        body="1",
+    )
+
+    send_notification(
+        title="Title",
+        message="Message",
+        url="https://howtheyvote.eu",
+    )
+
+    assert res.call_count == 1
+
+
+def test_send_notification_connection_error(responses, mocker, logs):
+    mocker.patch("howtheyvote.config.PUSHOVER_API_TOKEN", "api-token-123")
+    mocker.patch("howtheyvote.config.PUSHOVER_USER_KEY", "user-key-123")
+
+    responses.post(
+        url="https://api.pushover.net/1/messages.json",
+        body=requests.ConnectionError("Could not connect to api.pushover.net"),
+    )
+
+    send_notification(
+        title="Title",
+        message="Message",
+        url="https://howtheyvote.eu",
+    )
+
+    assert len(logs) == 1
+    assert logs[0]["event"] == "Failed to send push notification"
+    assert logs[0]["log_level"] == "error"
+    assert logs[0]["title"] == "Title"
+    assert logs[0]["message"] == "Message"
+    assert logs[0]["url"] == "https://howtheyvote.eu"
+
+
+def test_send_notification_no_api_creds(logs):
+    send_notification(message="Lorem ipsum")
+    assert len(logs) == 1
+    assert (
+        logs[0]["event"]
+        == "Pushover API token or user key not configured. No push notification will be sent."
+    )

--- a/backend/tests/worker/test_worker.py
+++ b/backend/tests/worker/test_worker.py
@@ -205,6 +205,24 @@ def test_worker_schedule_pipeline_unhandled_exceptions(db_session):
         assert runs[0].status == PipelineStatus.FAILURE
 
 
+def test_worker_schedule_pipeline_unhandled_exception_notification(db_session, mocker):
+    send_notification = mocker.patch("howtheyvote.worker.worker.send_notification")
+    worker = Worker()
+
+    def woops():
+        raise Exception("Woops, that didn’t work!")
+
+    with time_machine.travel(datetime.datetime(2024, 1, 1, 0, 0)):
+        worker.schedule_pipeline(woops, name="woops", hours={10})
+
+    with time_machine.travel(datetime.datetime(2024, 1, 1, 10, 0)):
+        worker.run_pending()
+        send_notification.assert_called_with(
+            title="Pipeline failure: woops",
+            message="Check logs for details. Error message: Woops, that didn’t work!",
+        )
+
+
 def test_pipeline_ran_successfully(db_session):
     class TestPipeline:
         pass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       HTV_BACKEND_PUBLIC_URL: "${HTV_BACKEND_PUBLIC_URL}"
       HTV_FRONTEND_PUBLIC_URL: "${HTV_FRONTEND_PUBLIC_URL}"
       HTV_FRONTEND_PRIVATE_URL: "http://frontend:8000"
+      PUSHOVER_API_TOKEN: "${PUSHOVER_API_TOKEN}"
+      PUSHOVER_USER_KEY: "${PUSHOVER_USER_KEY}"
 
   worker:
     image: "ghcr.io/howtheyvote/howtheyvote-backend:main"
@@ -61,6 +63,8 @@ services:
     environment:
       HTV_BACKEND_PUBLIC_URL: "${HTV_BACKEND_PUBLIC_URL}"
       HTV_FRONTEND_PUBLIC_URL: "${HTV_FRONTEND_PUBLIC_URL}"
+      PUSHOVER_API_TOKEN: "${PUSHOVER_API_TOKEN}"
+      PUSHOVER_USER_KEY: "${PUSHOVER_USER_KEY}"
 
   caddy:
     image: "caddy:2.7.6-alpine"


### PR DESCRIPTION
This uses Pushover to send notifications for important events:

* New vote results are available.
* A pipeline fails. (If data isn't available yet, that isn't considered a pipeline failure and no notification is sent.)
* Generating sharepics fails. (This sends only one notification per pipeline run, even if multiple sharepics couldn’t be generated.)

In the future, I’d like to also implement notifications when we attempt to scrape a pipeline data source for the last time and data still isn’t available.

To test this:

1. Sign up for a [Pushover](https://pushover.net/) account
2. Create a new [API application](https://support.pushover.net/i175-how-to-get-a-pushover-api-or-pushover-application-token)
3. Add the API token and your user key (from the Pushover dashboard) to your `.env` file
4. Recreate the backend container: `docker compose up -d backend`
5. Run the RCV list pipeline from within the `backend` container: `htv pipeline rcv-list ...`