### PR TITLE
Fix two bugs in pushover notifications

### DIFF
--- a/backend/howtheyvote/pipelines/rcv_list.py
+++ b/backend/howtheyvote/pipelines/rcv_list.py
@@ -294,7 +294,7 @@ class RCVListPipeline(BasePipeline):
         if failure_count > 0:
             send_notification(
                 title="Failed generating sharepics",
-                message=f"{failure_count} failures (out of {success_count})",
+                message=f"{failure_count} failures (out of {success_count + failure_count})",
             )
 
     def _analyze_vote_data_issues(self) -> None:

--- a/backend/howtheyvote/worker/__init__.py
+++ b/backend/howtheyvote/worker/__init__.py
@@ -110,15 +110,16 @@ def op_generate_export() -> None:
 def op_notify_last_run_unsuccessful() -> None:
     today = datetime.date.today()
     # Do not check for last run on days without Plenary
-    if not _is_session_day(today) and not pipeline_ran_successfully(RCVListPipeline, today):
+    if not _is_session_day(today):
         return None
-    send_notification(
-        title="No RCV List found at end of day",
-        message=(
-            "The last scheduled run of the day did not find an RCV list."
-            "Either there were not roll-call votes today, or there was an issue."
-        ),
-    )
+    if not pipeline_ran_successfully(RCVListPipeline, today):
+        send_notification(
+            title="No RCV List found at end of day",
+            message=(
+                "The last scheduled run of the day did not find an RCV list."
+                "Either there were not roll-call votes today, or there was an issue."
+            ),
+        )
     return None
 
 


### PR DESCRIPTION
This fixes two small oversights that I noticed during the last plenary concerning the new pushover notifications:

1. The total of the share-picture notification was off, resulting in notifications like "6 failures (out of 0)". This should now be resolved.
2. The condition that should trigger a notification when the last run was unsuccessful on a plenary day was wrong. On plenary days, the condition would always be false, due to the first part checking whether plenary is on. Now, on non-plenary days, nothing should happen. On plenary days, we check whether the last run was successful and if not, send the notification, as intended.