### PR TITLE
Fix generation of share-pictures in worker (for scheduled runs)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,9 @@ services:
     command: "htv worker"
     depends_on:
       - chromium
+    networks:
+      - "default"
+      - "chromium"
     ports:
       # Make Prometheus metrics available on host machine
       - "3000:3000"
@@ -63,6 +66,7 @@ services:
     environment:
       HTV_BACKEND_PUBLIC_URL: "${HTV_BACKEND_PUBLIC_URL}"
       HTV_FRONTEND_PUBLIC_URL: "${HTV_FRONTEND_PUBLIC_URL}"
+      HTV_FRONTEND_PRIVATE_URL: "http://frontend:8000"
       PUSHOVER_API_TOKEN: "${PUSHOVER_API_TOKEN}"
       PUSHOVER_USER_KEY: "${PUSHOVER_USER_KEY}"
 


### PR DESCRIPTION
This was a ride :)

The share-picture generation itself works nicely, hence the pictures are generated when on executes `htv pipeline rcv-list` in production or locally **inside of the backend container**.
However, the scheduled runs are, to my understanding, not actually run inside of that container, but in the **worker**. 
The worker container however did not have access to the chromium container for making the screenshots and also was missing the local URL to display the page to be screenshot.

To confirm that I was not entirely on the wrong track, I first executed the pipeline locally in the worker container, confirmed it failed, made the changes, and afterwards re-executed the pipeline in the worker container locally again to confirm that the screenshots were in the expected location of the file-system.