### PR TITLE
Add scheduling for VOT pipelines

### DIFF
--- a/backend/howtheyvote/alembic/versions/184528e5ba14_add_idempotency_key_to_pipeline_runs_.py
+++ b/backend/howtheyvote/alembic/versions/184528e5ba14_add_idempotency_key_to_pipeline_runs_.py
@@ -1,0 +1,24 @@
+"""Add idempotency key to pipeline_runs table
+
+Revision ID: 184528e5ba14
+Revises: 1deea9ed7c52
+Create Date: 2025-07-11 15:13:37.330203
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "184528e5ba14"
+down_revision = "1deea9ed7c52"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("pipeline_runs", sa.Column("idempotency_key", sa.Unicode))
+
+
+def downgrade() -> None:
+    op.drop_column("pipeline_runs", "idempotency_key")

--- a/backend/howtheyvote/models/common.py
+++ b/backend/howtheyvote/models/common.py
@@ -52,3 +52,4 @@ class PipelineRun(Base):
     pipeline: Mapped[str] = mapped_column(sa.Unicode)
     status: Mapped[PipelineStatus] = mapped_column(sa.Enum(PipelineStatus))
     checksum: Mapped[str] = mapped_column(sa.Unicode)
+    idempotency_key: Mapped[str] = mapped_column(sa.Unicode)

--- a/backend/howtheyvote/worker/__init__.py
+++ b/backend/howtheyvote/worker/__init__.py
@@ -75,10 +75,10 @@ def rcv_list_notification_handler() -> None:
         return None
 
     send_notification(
-        title="No RCV List found at end of day",
+        title="No RCV list found at end of day",
         message=(
             "The last scheduled run of the day did not find an RCV list."
-            "Either there were not roll-call votes today, or there was an issue."
+            "Either there were no roll-call votes today, or there was an issue."
         ),
     )
 

--- a/backend/howtheyvote/worker/__init__.py
+++ b/backend/howtheyvote/worker/__init__.py
@@ -174,7 +174,7 @@ def get_worker() -> Worker:
         hours=range(12, 15),
         minutes=range(0, 60, 10),
         tz=config.TIMEZONE,
-        idempotency_key=lambda: f"{datetime.date.today().isoformat()}-midday",
+        idempotency_key_func=lambda: f"{datetime.date.today().isoformat()}-midday",
     )
 
     # Mon-Thu between 17:00 and 20:00, every 10 mins until it succeeds
@@ -185,7 +185,7 @@ def get_worker() -> Worker:
         hours=range(17, 20),
         minutes=range(0, 60, 10),
         tz=config.TIMEZONE,
-        idempotency_key=lambda: f"{datetime.date.today().isoformat()}-evening",
+        idempotency_key_func=lambda: f"{datetime.date.today().isoformat()}-evening",
     )
 
     # Mon-Thu at 20:00
@@ -204,7 +204,7 @@ def get_worker() -> Worker:
             name=VOTListPipeline.__name__,
             hours={21},
             tz=config.TIMEZONE,
-            idempotency_key=(
+            idempotency_key_func=(
                 lambda i=i: (datetime.date.today() - datetime.timedelta(days=i)).isoformat()
             ),
         )

--- a/backend/howtheyvote/worker/__init__.py
+++ b/backend/howtheyvote/worker/__init__.py
@@ -130,69 +130,76 @@ def _is_session_day(date: datetime.date) -> bool:
     return session is not None
 
 
-worker = Worker()
+def get_worker() -> Worker:
+    worker = Worker()
 
-# Mon at 04:00
-worker.schedule_pipeline(
-    op_sessions,
-    name=SessionsPipeline.__name__,
-    weekdays={Weekday.MON},
-    hours={4},
-    tz=config.TIMEZONE,
-)
+    # Mon at 04:00
+    worker.schedule_pipeline(
+        op_sessions,
+        name=SessionsPipeline.__name__,
+        weekdays={Weekday.MON},
+        hours={4},
+        tz=config.TIMEZONE,
+    )
 
-# Mon at 05:00
-worker.schedule_pipeline(
-    op_members,
-    name=MembersPipeline.__name__,
-    weekdays={Weekday.MON},
-    hours={5},
-    tz=config.TIMEZONE,
-)
+    # Mon at 05:00
+    worker.schedule_pipeline(
+        op_members,
+        name=MembersPipeline.__name__,
+        weekdays={Weekday.MON},
+        hours={5},
+        tz=config.TIMEZONE,
+    )
 
-# Mon-Thu between 12:00 and 15:00, every 10 mins
-worker.schedule_pipeline(
-    op_rcv_midday,
-    name=RCVListPipeline.__name__,
-    weekdays={Weekday.MON, Weekday.TUE, Weekday.WED, Weekday.THU},
-    hours=range(12, 15),
-    minutes=range(0, 60, 10),
-    tz=config.TIMEZONE,
-)
+    # Mon-Thu between 12:00 and 15:00, every 10 mins
+    worker.schedule_pipeline(
+        op_rcv_midday,
+        name=RCVListPipeline.__name__,
+        weekdays={Weekday.MON, Weekday.TUE, Weekday.WED, Weekday.THU},
+        hours=range(12, 15),
+        minutes=range(0, 60, 10),
+        tz=config.TIMEZONE,
+    )
 
-# Mon-Thu between 17:00 and 20:00, every 10 mins
-worker.schedule_pipeline(
-    op_rcv_evening,
-    name=RCVListPipeline.__name__,
-    weekdays={Weekday.MON, Weekday.TUE, Weekday.WED, Weekday.THU},
-    hours=range(17, 20),
-    minutes=range(0, 60, 10),
-    tz=config.TIMEZONE,
-)
+    # Mon-Thu between 17:00 and 20:00, every 10 mins
+    worker.schedule_pipeline(
+        op_rcv_evening,
+        name=RCVListPipeline.__name__,
+        weekdays={Weekday.MON, Weekday.TUE, Weekday.WED, Weekday.THU},
+        hours=range(17, 20),
+        minutes=range(0, 60, 10),
+        tz=config.TIMEZONE,
+    )
 
-worker.schedule(
-    op_notify_last_run_unsuccessful,
-    weekdays={Weekday.MON, Weekday.TUE, Weekday.WED, Weekday.THU},
-    hours={20},
-    tz=config.TIMEZONE,
-)
+    worker.schedule(
+        op_notify_last_run_unsuccessful,
+        weekdays={Weekday.MON, Weekday.TUE, Weekday.WED, Weekday.THU},
+        hours={20},
+        tz=config.TIMEZONE,
+    )
 
-# Mon-Thu, between 13:00 and 20:00, every 30 mins
-worker.schedule_pipeline(
-    op_press,
-    name=PressPipeline.__name__,
-    weekdays={Weekday.MON, Weekday.TUE, Weekday.WED, Weekday.THU},
-    hours=range(13, 20),
-    minutes={0, 30},
-    tz=config.TIMEZONE,
-)
+    # Mon-Thu, between 13:00 and 20:00, every 30 mins
+    worker.schedule_pipeline(
+        op_press,
+        name=PressPipeline.__name__,
+        weekdays={Weekday.MON, Weekday.TUE, Weekday.WED, Weekday.THU},
+        hours=range(13, 20),
+        minutes={0, 30},
+        tz=config.TIMEZONE,
+    )
 
-# Sun at 04:00
-worker.schedule(
-    op_generate_export,
-    weekdays={Weekday.SUN},
-    hours={4},
-    # While the schedules for other pipelines follow real-life events in Brussels/Strasbourg
-    # time, this isn’t the case for the export so we can just use UTC for simplicity.
-    tz="UTC",
-)
+    # Sun at 04:00
+    worker.schedule(
+        op_generate_export,
+        weekdays={Weekday.SUN},
+        hours={4},
+        # While the schedules for other pipelines follow real-life events in Brussels/
+        # Strasbourg time, this isn’t the case for the export so we can just use UTC
+        # for simplicity.
+        tz="UTC",
+    )
+
+    return worker
+
+
+worker = get_worker()

--- a/backend/howtheyvote/worker/worker.py
+++ b/backend/howtheyvote/worker/worker.py
@@ -139,6 +139,7 @@ class Worker:
         hours: Iterable[int] = {0},
         minutes: Iterable[int] = {0},
         tz: str | None = None,
+        tag: str | None = None,
     ) -> None:
         """Schedule a job to be executed at the given weekdays, hours, minutes. Optionally
         passing a timezone string via the `tz` parameter indicates that the job should be
@@ -166,6 +167,9 @@ class Worker:
                     job = getattr(job, weekday.value)
                     job = job.at(formatted_time, tz)
                     job = job.do(handler)
+
+                    if tag:
+                        job = job.tag(tag)
 
     def schedule_pipeline(
         self,
@@ -256,6 +260,7 @@ class Worker:
             hours=hours,
             minutes=minutes,
             tz=tz,
+            tag=name,
         )
 
     def _update_next_run_metrics(self) -> None:

--- a/backend/howtheyvote/worker/worker.py
+++ b/backend/howtheyvote/worker/worker.py
@@ -66,24 +66,6 @@ class Weekday(enum.Enum):
 Handler = Callable[..., Any]
 
 
-def pipeline_ran_successfully(
-    pipeline: type[object],
-    date: datetime.date,
-    count: int = 1,
-) -> bool:
-    """Check if a given pipeline has been run successfully on a given day."""
-    query = (
-        select(func.count())
-        .select_from(PipelineRun)
-        .where(PipelineRun.pipeline == pipeline.__name__)
-        .where(func.date(PipelineRun.started_at) == func.date(date))
-        .where(PipelineRun.status == PipelineStatus.SUCCESS)
-    )
-    result = Session.execute(query).scalar() or 0
-
-    return result >= count
-
-
 def last_pipeline_run_checksum(pipeline: type[object], date: datetime.date) -> str | None:
     """Returns the checksum of the most recent pipeline run on a given day."""
     query = (

--- a/backend/tests/pipelines/data/document_a-9-2024-0163-en.html
+++ b/backend/tests/pipelines/data/document_a-9-2024-0163-en.html
@@ -1,0 +1,627 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /><meta name="title" content="REPORT on amendments to Parliament’s Rules of Procedure concerning the training on preventing conflict and harassment in the workplace and on good office management | A9-0163/2024 | European Parliament" /><meta http-equiv="Content-Language" content="en" /><meta name="language" content="en" /><meta name="robots" content="index, follow, noodp, noydir, notranslate" /><meta name="copyright" content="© European Union, 2024 - Source: European Parliament" /><meta name="available" content="04-04-2024" /><meta property="og:title" content="REPORT on amendments to Parliament’s Rules of Procedure concerning the training on preventing conflict and harassment in the workplace and on good office management | A9-0163/2024 | European Parliament" /><meta property="og:image" content="https://www.europarl.europa.eu/website/common/img/icon/sharelogo_facebook.jpg" /><meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" /><meta name="description" content="REPORT on amendments to Parliament’s Rules of Procedure concerning the training on preventing conflict and harassment in the workplace and on good office management (2024/2006(REG)) Committee on Constitutional Affairs Rapporteur: Gabriele Bischoff" /><meta name="author" content="Gabriele BISCHOFF" /><link rel="canonical" href="https://www.europarl.europa.eu/doceo/document/A-9-2024-0163_EN.html" /><link rel="icon" href="/commonFrontResources/evostrap/7.0.0/lib/dist/assets/img/favicon.ico" /><title>REPORT on amendments to Parliament’s Rules of Procedure concerning the training on preventing conflict and harassment in the workplace and on good office management | A9-0163/2024 | European Parliament</title><link href="/commonFrontResources/evostrap/7.0.0/lib/dist/css/evostrap.css" rel="stylesheet" /><link href="/commonFrontResources/evostrap-doceo/2.0.0/dist/css/doceo.css" rel="stylesheet" /><!--ATI analytics script--><script type="text/javascript" data-tracker-name="ATInternet" defer data-value="/website/webanalytics/ati-doceo.js" src="//www.europarl.europa.eu/website/privacy-policy/privacy-policy.js" ></script></head><body><header class="es_header"><nav class="es_wai-access" aria-label="Navigation accessible"><ul><li><a href="#website-body" class="es_smooth-scroll"><span class="btn btn-primary">Access to page content (press "Enter")</span></a></li><li><a href="#languageSelector" class="es_smooth-scroll"><span class="btn btn-primary">Direct access to language menu (press "Enter")</span></a></li></ul></nav><div class="es_header-top border-bottom mb-3 mb-xl-4 a-i"><div class="container-fluid"><div class="row no-gutters"><div class="col-auto"><div class="es_header-language-selector"><div class="es_dropdown"><button class="es_dropdown-btn" type="button" data-toggle="dropdown" id="languageSelector" aria-expanded="false" aria-controls="languageSelectorDropdownContent"><span class="es_dropdown-label">EN - English</span><span class="es_dropdown-icon"><svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false"><use href="#es_icon-arrow"></use></svg><svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-flip-y text-primary" data-show-expanded="true"><use href="#es_icon-arrow"></use></svg></span></button><div class="dropdown-menu" id="languageSelectorDropdownContent"><div class="border border-light"><div><ul class="es_topbar-list list-unstyled">
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_BG.html" lang="bg"><span class="t-item">BG - български</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_ES.html" lang="es"><span class="t-item">ES - español</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_CS.html" lang="cs"><span class="t-item">CS - čeština</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_DA.html" lang="da"><span class="t-item">DA - dansk</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_DE.html" lang="de"><span class="t-item">DE - Deutsch</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_ET.html" lang="et"><span class="t-item">ET - eesti keel</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_EL.html" lang="el"><span class="t-item">EL - ελληνικά</span></a></li>
+            <li class="t-x-block" data-selected="true"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_EN.html" lang="en"><span class="t-item">EN - English</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_FR.html" lang="fr"><span class="t-item">FR - français</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_GA.html" lang="ga"><span class="t-item">GA - Gaeilge</span></a></li>
+            <li aria-hidden="true"><span class="text-muted">HR - hrvatski</span></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_IT.html" lang="it"><span class="t-item">IT - italiano</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_LV.html" lang="lv"><span class="t-item">LV - latviešu valoda</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_LT.html" lang="lt"><span class="t-item">LT - lietuvių kalba</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_HU.html" lang="hu"><span class="t-item">HU - magyar</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_MT.html" lang="mt"><span class="t-item">MT - Malti</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_NL.html" lang="nl"><span class="t-item">NL - Nederlands</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_PL.html" lang="pl"><span class="t-item">PL - polski</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_PT.html" lang="pt"><span class="t-item">PT - português</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_RO.html" lang="ro"><span class="t-item">RO - română</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_SK.html" lang="sk"><span class="t-item">SK - slovenčina</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_SL.html" lang="sl"><span class="t-item">SL - slovenščina</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_FI.html" lang="fi"><span class="t-item">FI - suomi</span></a></li>
+            <li class="t-x-block"><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_SV.html" lang="sv"><span class="t-item">SV - svenska</span></a></li>
+        </ul></div></div></div></div></div></div><div class="col"><nav class="es_header-other-websites d-flex justify-content-end align-items-center" aria-label="Other websites"><ul class="d-flex list-unstyled"><li class="d-none d-xl-block"><a class="d-xl-flex px-1 align-items-center t-y-block" href="/news/en"><span class="t-item">News</span></a></li><li class="d-none d-xl-block"><a class="d-xl-flex px-1 align-items-center t-y-block" href="/topics/en"><span class="t-item">Topics</span></a></li><li class="d-none d-xl-block"><a class="d-xl-flex px-1 align-items-center t-y-block" href="/meps/en"><span class="t-item">MEPs</span></a></li><li class="d-none d-xl-block"><a class="d-xl-flex px-1 align-items-center t-y-block" href="/about-parliament/en"><span class="t-item">About Parliament</span></a></li><li class="d-none d-xl-block"><a class="d-xl-flex px-1 align-items-center t-y-block" href="/plenary/en"><span class="t-item">Plenary</span></a></li><li class="d-none d-xl-block"><a class="d-xl-flex px-1 align-items-center t-y-block" href="/committees/en"><span class="t-item">Committees</span></a></li><li class="d-none d-xl-block"><a class="d-xl-flex px-1 align-items-center t-y-block" href="/delegations/en"><span class="t-item">Delegations</span></a></li><li class="d-none d-xl-block"><a class="d-xl-flex px-1 align-items-center t-y-block" href="https://eubudget.europarl.europa.eu/en"><span class="t-item">EU budget</span></a></li><li class="es_dropdown"><button class="es_dropdown-btn d-xl-flex pl-1 align-items-center t-y-block flex-nowrap" type="button" data-toggle="dropdown" aria-expanded="false" aria-controls="otherWebsiteSubmenu" aria-label="More other websites"><span class="es_dropdown-label"><span class="d-none d-xl-inline">Other websites</span><span class="d-xl-none">View other websites</span></span><span class="es_dropdown-icon"><svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false"><use href="#es_icon-arrow"></use></svg><svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-flip-y text-primary" data-show-expanded="true"><use href="#es_icon-arrow"></use></svg></span></button><div id="otherWebsiteSubmenu" class="dropdown-menu"><ul class="es_header-other-websites-submenu list-unstyled es_dropdown-menu"><li class="d-xl-none t-x-block"><a class="es_dropdown-item" href="/news/en"><span class="t-item">News</span></a></li><li class="d-xl-none t-x-block"><a class="es_dropdown-item" href="/topics/en"><span class="t-item">Topics</span></a></li><li class="d-xl-none t-x-block"><a class="es_dropdown-item" href="/meps/en"><span class="t-item">MEPs</span></a></li><li class="d-xl-none t-x-block"><a class="es_dropdown-item" href="/about-parliament/en"><span class="t-item">About Parliament</span></a></li><li class="d-xl-none t-x-block"><a class="es_dropdown-item" href="/plenary/en"><span class="t-item">Plenary</span></a></li><li class="d-xl-none t-x-block"><a class="es_dropdown-item" href="/committees/en"><span class="t-item">Committees</span></a></li><li class="d-xl-none t-x-block"><a class="es_dropdown-item" href="/delegations/en"><span class="t-item">Delegations</span></a></li><li class="t-x-block"><a class="es_dropdown-item" href="https://multimedia.europarl.europa.eu/en"><span class="t-item">Multimedia Centre</span></a></li><li class="t-x-block"><a class="es_dropdown-item" href="/the-president/en/"><span class="t-item">Presidency</span></a></li><li class="t-x-block"><a class="es_dropdown-item" href="/the-secretary-general/en"><span class="t-item">Secretariat-general</span></a></li><li class="t-x-block"><a class="es_dropdown-item" href="https://elections.europa.eu/en"><span class="t-item">Elections</span></a></li><li class="t-x-block"><a class="es_dropdown-item" href="/thinktank/en"><span class="t-item">Think tank</span></a></li><li class="t-x-block"><a class="es_dropdown-item" href="https://www.epnewshub.eu/"><span class="t-item">EP Newshub</span></a></li><li class="t-x-block"><a class="es_dropdown-item" href="/atyourservice/en"><span class="t-item">At your service</span></a></li><li class="t-x-block"><a class="es_dropdown-item" href="/visiting/en"><span class="t-item">Visits</span></a></li><li class="t-x-block"><a class="es_dropdown-item" href="https://oeil.secure.europarl.europa.eu/oeil/en"><span class="t-item">Legislative Observatory</span></a></li><li class="t-x-block"><a class="es_dropdown-item" href="/legislative-train"><span class="t-item">Legislative train</span></a></li><li class="t-x-block"><a class="es_dropdown-item" href="/contracts-and-grants/en/"><span class="t-item">Contracts and Grants</span></a></li><li class="t-x-block"><a class="es_dropdown-item" href="/RegistreWeb/home/welcome.htm?language=EN"><span class="t-item">Register</span></a></li><li class="t-x-block"><a class="es_dropdown-item" href="https://data.europarl.europa.eu/en/home"><span class="t-item">Open Data Portal</span></a></li><li class="t-x-block"><a class="es_dropdown-item" href="https://liaison-offices.europarl.europa.eu/en"><span class="t-item">Liaison offices</span></a></li></ul></div></li></ul></nav></div></div></div></div><div class="es_header-middle mb-3"><div class="container-fluid"><div class="row"><div class="col-12 col-md"><div class="es_header-website-title a-i"><div class="es_header-website-title-main"><span class="d-none d-md-inline"><span class="text-break">Report</span><span class="es_title-h3 text-nowrap"> - A9-0163/2024</span></span><span class="d-md-none"><span class="text-break">Report</span><br /><span class="es_title-h3 text-nowrap">A9-0163/2024</span></span></div><div class="es_header-website-title-sub"><a class="t-x-block" href="/portal/en" title="Go back to the Europarl portal"><span class="t-item">European Parliament</span></a></div></div></div><div class="col-md-auto d-block d-sm-flex justify-content-md-end justify-content-center align-items-center doceo_header-download-container"><div class="es_dropdown mt-2 mt-md-0"><button class="es_dropdown-btn" type="button" data-toggle="dropdown" aria-expanded="false" id="documentDownloadDropdownButton" aria-controls="documentDownloadDropdownContent"><span class="es_dropdown-label">Download</span><span class="es_dropdown-icon"><svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false"><use href="#es_icon-arrow"></use></svg><svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-flip-y" data-show-expanded="true"><use href="#es_icon-arrow"></use></svg></span></button><div class="dropdown-menu" id="documentDownloadDropdownContent" aria-labelledby="documentDownloadDropdownButton"><div class="es_links-list"><ul style="max-height:250px; overflow:auto; min-width:auto; overflow-x: hidden; padding-top:4px; padding-bottom:4px; padding-left:4px;padding-right:20px"><li><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_EN.pdf"><svg aria-hidden="true" class="es_icon es_icon-pdf mr-1"><use href="#es_icon-pdf"></use></svg><span class="text-nowrap t-x">A-9-2024-0163_EN <span class="text-muted">(PDF - 177 KB)</span></span></a></li><li><a class="es_dropdown-item" href="/doceo/document/A-9-2024-0163_EN.docx"><svg aria-hidden="true" class="es_icon es_icon-doc mr-1"><use href="#es_icon-doc"></use></svg><span class="text-nowrap t-x">A-9-2024-0163_EN <span class="text-muted">(DOC - 77 KB)</span></span></a></li></ul></div></div></div></div></div></div></div>
+<div class="es_header-bottom">
+<div class="es_header-menu-container es_header-menu-container-small">
+<div class="container-fluid">
+<div class="es_header-menu">
+<div class="es_header-menu-top row align-items-center">
+<div class="col d-md-none d-flex align-items-center"><svg aria-hidden="true" class="es_icon es_icon-ep-logo-w es_header-menu-top-logo"><use href="#es_icon-ep-logo-w"></use></svg></div><span class="es_header-menu-top-title offset-3 col-6 text-center d-none d-md-block" aria-hidden="true"><span>European Parliament</span></span><div class="es_header-menu-top-controls col-auto col-md-3 text-right"></div></div></div></div></div></div></header><main id="website-body"><div class="container"><div class="breadcrumb"></div></div>
+<div class="container-fluid"><div class="mb-3"><h1 class="es_title-h1 text-break">REPORT on amendments to Parliament’s Rules of Procedure concerning the training on preventing conflict and harassment in the workplace and on good office management</h1><p class="text-muted m-lg-0">4.4.2024 - (<a href="https://oeil.secure.europarl.europa.eu/oeil/popups/ficheprocedure.do?lang=en&amp;reference=2024/2006(REG)">2024/2006(REG)</a>)</p></div><p> 
+     
+     
+     
+     
+     
+     
+     
+     
+     
+     
+    Committee on Constitutional Affairs 
+    <br />Rapporteur: Gabriele Bischoff 
+   </p><div class="row"><div class="col-12 col-xl-8 col-xxl-6"><div class="card"><div class="card-body"><div class="es_dropdown mb-0 mt-0 mt-md-0"><button class="es_dropdown-btn" type="button" data-toggle="dropdown" id="esDropdownAMDButton" aria-expanded="false" aria-controls="esDropdownAMDContent"><span class="es_dropdown-label">Amendments</span><span class="es_dropdown-icon"><svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false"><use href="#es_icon-arrow"></use></svg><svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-flip-y text-primary" data-show-expanded="true"><use href="#es_icon-arrow"></use></svg></span></button><div class="dropdown-menu w-100" id="esDropdownAMDContent" aria-labelledby="esDropdownAMDButton"><div class="es_links-list"><ul style="max-height:250px; overflow:auto; min-width:auto; overflow-x: hidden; padding-top:4px; padding-bottom:4px; padding-left:4px;padding-right:20px"><li><a href="/doceo/document/A-9-2024-0163-AM-001-005_EN.pdf" class="es_dropdown-item"><svg aria-hidden="true" class="es_icon es_icon-pdf mr-1"><use href="#es_icon-pdf"></use></svg><span class="t-x">001-005<span class="text-muted"> (PDF - 102 KB)</span></span></a></li><li><a href="/doceo/document/A-9-2024-0163-AM-001-005_EN.docx" class="es_dropdown-item"><svg aria-hidden="true" class="es_icon es_icon-doc mr-1"><use href="#es_icon-doc"></use></svg><span class="t-x">001-005<span class="text-muted"> (DOC - 27 KB)</span></span></a></li><li><a href="/doceo/document/A-9-2024-0163-AM-006-006_EN.pdf" class="es_dropdown-item"><svg aria-hidden="true" class="es_icon es_icon-pdf mr-1"><use href="#es_icon-pdf"></use></svg><span class="t-x">006-006<span class="text-muted"> (PDF - 106 KB)</span></span></a></li><li><a href="/doceo/document/A-9-2024-0163-AM-006-006_EN.docx" class="es_dropdown-item"><svg aria-hidden="true" class="es_icon es_icon-doc mr-1"><use href="#es_icon-doc"></use></svg><span class="t-x">006-006<span class="text-muted"> (DOC - 69 KB)</span></span></a></li><li><a href="/doceo/document/A-9-2024-0163-AM-007-011_EN.pdf" class="es_dropdown-item"><svg aria-hidden="true" class="es_icon es_icon-pdf mr-1"><use href="#es_icon-pdf"></use></svg><span class="t-x">007-011<span class="text-muted"> (PDF - 121 KB)</span></span></a></li><li><a href="/doceo/document/A-9-2024-0163-AM-007-011_EN.docx" class="es_dropdown-item"><svg aria-hidden="true" class="es_icon es_icon-doc mr-1"><use href="#es_icon-doc"></use></svg><span class="t-x">007-011<span class="text-muted"> (DOC - 76 KB)</span></span></a></li><li><a href="/doceo/document/A-9-2024-0163-AM-012-012_EN.pdf" class="es_dropdown-item"><svg aria-hidden="true" class="es_icon es_icon-pdf mr-1"><use href="#es_icon-pdf"></use></svg><span class="t-x">012-012<span class="text-muted"> (PDF - 99 KB)</span></span></a></li><li><a href="/doceo/document/A-9-2024-0163-AM-012-012_EN.docx" class="es_dropdown-item"><svg aria-hidden="true" class="es_icon es_icon-doc mr-1"><use href="#es_icon-doc"></use></svg><span class="t-x">012-012<span class="text-muted"> (DOC - 68 KB)</span></span></a></li></ul></div></div></div></div></div></div></div><br />
+                <div class="doceo-ring card mb-3" lang="en"><div class="card-header bg-white"><div class="d-flex justify-content-between flex-wrap"><div>Procedure : <a href="https://oeil.secure.europarl.europa.eu/oeil/popups/ficheprocedure.do?lang=en&amp;reference=2024/2006(REG)">2024/2006(REG)</a></div><div class="text-muted">Document stages in plenary</div></div></div><div class="card-body"><div class="d-block d-sm-flex mt-0 mb-2"><span class="mt-1">Document selected :  </span><div class="mt-1">A9-0163/2024</div></div><div><div class="doceo-ring-steps bg-white"><div class="doceo-ring-steps-step bg-white active"><div class="doceo-ring-steps-step-content"><span class="doceo-ring-steps-step-label">Texts tabled :
+			  </span><div class="doceo-ring-steps-step-details"><div>
+                        <span class="font-weight-bold text-break">A9-0163/2024</span>
+                    </div></div></div></div><div class="doceo-ring-steps-step bg-white"><div class="doceo-ring-steps-step-content"><span class="doceo-ring-steps-step-label">Debates :
+				</span><div class="doceo-ring-steps-step-details"><div></div></div></div></div><div class="doceo-ring-steps-step bg-white active"><div class="doceo-ring-steps-step-content"><span class="doceo-ring-steps-step-label">Votes :
+				</span><div class="doceo-ring-steps-step-details"><div>
+                        <a href="/doceo/document/PV-9-2024-04-24-ITM-007-01_EN.html" class="text-break">PV 24/04/2024 - 7.1</a><br />
+                        <a href="/doceo/document/CRE-9-2024-04-24-ITM-007-01_EN.html" class="text-break">CRE 24/04/2024 - 7.1</a>
+                    </div></div></div></div><div class="doceo-ring-steps-step bg-white active"><div class="doceo-ring-steps-step-content"><span class="doceo-ring-steps-step-label">Texts adopted :
+				</span><div class="doceo-ring-steps-step-details"><div>
+                        <a href="/doceo/document/TA-9-2024-0315_EN.html" class="text-break">P9_TA(2024)0315</a>
+                    </div></div></div></div></div></div></div></div>
+            
+<div class="es_links-list mb-3"><ul>
+<li><a class="es_smooth-scroll" href="#_section1"><svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1"><use href="#es_icon-arrow"></use></svg><span class="t-x"><span class="text-uppercase">PROPOSAL FOR A EUROPEAN PARLIAMENT DECISION</span></span></a></li>
+<li><a class="es_smooth-scroll" href="#_section2"><svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1"><use href="#es_icon-arrow"></use></svg><span class="t-x"><span class="text-uppercase">ANNEX: ENTITIES OR PERSONS</span> <span class="text-uppercase">FROM WHOM THE RAPPORTEUR HAS RECEIVED INPUT</span></span></a></li>
+<li><a class="es_smooth-scroll" href="#_section3"><svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1"><use href="#es_icon-arrow"></use></svg><span class="t-x"><span class="text-uppercase">INFORMATION ON ADOPTION IN COMMITTEE RESPONSIBLE</span></span></a></li>
+<li><a class="es_smooth-scroll" href="#_section4"><svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1"><use href="#es_icon-arrow"></use></svg><span class="t-x"><span class="text-uppercase">FINAL VOTE BY ROLL CALL IN COMMITTEE RESPONSIBLE</span></span></a></li></ul></div><div>
+  
+  
+  <div>
+   
+   <div class="red:section_MainContent">
+     
+     
+     
+     
+     
+     
+     
+     
+    <div class="separator separator-dotted separator-2x my-3"></div><h2 id="_section1"><span class="text-uppercase">PROPOSAL FOR A EUROPEAN PARLIAMENT DECISION</span></h2> 
+    <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">on amendments to Parliament’s Rules of Procedure concerning the training on preventing conflict and harassment in the workplace and on good office management</span></p>
+ 
+    <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+ 
+    <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">(<a href="https://oeil.secure.europarl.europa.eu/oeil/popups/ficheprocedure.do?lang=en&amp;reference=2024/2006(REG)">2024/2006(REG)</a>)</span></p>
+ 
+    <p style="margin-top:24pt; margin-bottom:12pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-style:italic" class="doceo-font-family-base doceo-font-size-base">The European Parliament</span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">,</span></p>
+ 
+    <p style="margin-top:0pt; margin-left:28.35pt; margin-bottom:12pt; text-indent:-28.35pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">–</span><span style="width:22.35pt; text-indent:0pt; display:inline-block" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">having regard to Rules 236 and 237 of its Rules of Procedure,</span></p>
+ 
+    <p style="margin-top:0pt; margin-left:28.35pt; margin-bottom:12pt; text-indent:-28.35pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">–</span><span style="width:22.35pt; text-indent:0pt; display:inline-block" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">having regard to the report of the Committee on Constitutional Affairs (A9-0163/2024),</span></p>
+ 
+    <p style="margin-top:0pt; margin-left:28.35pt; margin-bottom:12pt; text-indent:-28.35pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">1.</span><span style="width:19.35pt; text-indent:0pt; display:inline-block" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Decides to amend its Rules of Procedure as shown below;</span></p>
+ 
+    <p style="margin-top:0pt; margin-left:28.35pt; margin-bottom:12pt; text-indent:-28.35pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">2.</span><span style="width:19.35pt; text-indent:0pt; display:inline-block" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Decides that the amendments shall enter into force on 16 July 2024;</span></p>
+ 
+    <p style="margin-top:0pt; margin-left:28.35pt; margin-bottom:12pt; text-indent:-28.35pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">3.</span><span style="width:19.35pt; text-indent:0pt; display:inline-block" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Instructs its President to forward this decision to the Council and the Commission, for information.</span></p>
+ 
+    <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+ 
+    <p class="text-center" style="margin-top:12pt; margin-bottom:0pt; page-break-after:avoid; widows:0; orphans:0; font-size:12pt"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Amendment</span><span> </span><span> </span><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">1</span></p>
+ 
+    <p class="text-center" style="margin-top:12pt; margin-bottom:0pt; page-break-after:avoid; widows:0; orphans:0; font-size:12pt"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Parliament's Rules of Procedure</span></p>
+ 
+    <p class="text-center" style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Rule 10 – paragraph 6 – subparagraph 2</span></p>
+ 
+    
+<div class="table-responsive"><table class="table-borderless mw-100" style="width:487.6pt; margin-right:auto; margin-left:auto; border-collapse:collapse"> 
+      
+      
+<tr> 
+       
+<td colspan="2" style="width:453.6pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; page-break-after:avoid; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:12pt; text-align:center; page-break-after:avoid; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-style:italic" class="doceo-font-family-base doceo-font-size-base">Present text</span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:12pt; text-align:center; page-break-after:avoid; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-style:italic" class="doceo-font-family-base doceo-font-size-base">Amendment</span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Members may not be elected as office-holders of Parliament or one of its bodies, be appointed as rapporteur or participate in an official delegation or interinstitutional negotiations, if they have not signed the declaration </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">relating to</span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base"> that Code.</span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Members may not be elected as office-holders of Parliament or one of its bodies, be appointed as rapporteur or participate in an official delegation or interinstitutional negotiations:</span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">(a)</span><span style="width:22.01pt; display:inline-block" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">if they have not signed the declaration</span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base"> confirming their commitment to complying with </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">that Code</span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">, including completing the specialised training organised for them by the European Parliament on preventing conflict and harassment in the workplace and on good office management; or</span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">(b)</span><span style="width:22.01pt; display:inline-block" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">if they have not completed the specialised training referred to in point (a) in breach of the deadline and conditions laid down in that Code.</span></p>
+</td> 
+      </tr>
+ 
+      
+    </table></div> 
+    <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"><span style="-aw-bookmark-end:restart" class="doceo-font-family-base doceo-font-size-base"></span></p>
+ 
+    <p class="text-center" style="margin-top:12pt; margin-bottom:0pt; page-break-after:avoid; widows:0; orphans:0; font-size:12pt"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Amendment</span><span> </span><span> </span><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">2</span></p>
+ 
+    <p class="text-center" style="margin-top:12pt; margin-bottom:0pt; page-break-after:avoid; widows:0; orphans:0; font-size:12pt"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Parliament's Rules of Procedure</span></p>
+ 
+    <p class="text-center" style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Rule 21 – paragraph 1</span></p>
+ 
+    
+<div class="table-responsive"><table class="table-borderless mw-100" style="margin-right:auto; margin-left:auto; border-collapse:collapse"> 
+      
+      
+<tr> 
+       
+<td colspan="2" style="width:453.6pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; page-break-after:avoid; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:12pt; text-align:center; page-break-after:avoid; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-style:italic" class="doceo-font-family-base doceo-font-size-base">Present text</span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:12pt; text-align:center; page-break-after:avoid; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-style:italic" class="doceo-font-family-base doceo-font-size-base">Amendment</span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">The Conference of Presidents may, acting by a majority of three-fifths of the votes cast, representing at least three political groups, propose to Parliament that it bring to an end the term of office of the President, a Vice-President, a Quaestor, a Chair or Vice-Chair of a committee, a Chair or Vice-Chair of an interparliamentary delegation, or of any other office holder elected within the Parliament, where it considers that the Member in question has been guilty of serious misconduct. Parliament shall take a decision on that proposal by a majority of two-thirds of the votes cast, constituting a majority of its component Members.</span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">The Conference of Presidents may, acting by a majority of three-fifths of the votes cast, representing at least three political groups, propose to Parliament that it bring to an end the term of office of the President, a Vice-President, a Quaestor, a Chair or Vice-Chair of a committee, a Chair or Vice-Chair of an interparliamentary delegation, or of any other office holder elected within the Parliament, where it considers:</span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">(a)</span><span style="width:22.01pt; display:inline-block" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">that the Member in question has been guilty of serious misconduct, </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">or</span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">(b)</span><span style="width:22.01pt; display:inline-block" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">that the Member in question has not completed the specialised training organised for them by the European Parliament on preventing conflict and harassment in the workplace and on good office management in breach of the deadline and conditions laid down in the </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic; background-color:#ffffff" class="doceo-font-family-base doceo-font-size-base">Code of appropriate behaviour for Members of the European Parliament in exercising their duties </span><span style="font-family:'Times New Roman'; font-size:8pt; font-weight:bold; font-style:italic; vertical-align:super; background-color:#ffffff" class="doceo-font-family-base doceo-font-size-xs">12a</span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">.</span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Parliament shall take a decision on that proposal by a majority of two-thirds of the votes cast, constituting a majority of its component Members.</span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">___________________</span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-size:8pt; font-weight:bold; font-style:italic; vertical-align:super" class="doceo-font-family-base doceo-font-size-xs">12a</span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base"> See Annex II.</span></p>
+</td> 
+      </tr>
+ 
+      
+    </table></div> 
+    <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"></p>
+ 
+    <p class="text-center" style="margin-top:12pt; margin-bottom:0pt; page-break-after:avoid; widows:0; orphans:0; font-size:12pt"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Amendment</span><span> </span><span> </span><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">3</span></p>
+ 
+    <p class="text-center" style="margin-top:12pt; margin-bottom:0pt; page-break-after:avoid; widows:0; orphans:0; font-size:12pt"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Parliament's Rules of Procedure</span></p>
+ 
+    <p class="text-center" style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Rule 21 – paragraph 2</span></p>
+ 
+    
+<div class="table-responsive"><table class="table-borderless mw-100" style="margin-right:auto; margin-left:auto; border-collapse:collapse"> 
+      
+      
+<tr> 
+       
+<td colspan="2" style="width:453.6pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; page-break-after:avoid; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:12pt; text-align:center; page-break-after:avoid; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-style:italic" class="doceo-font-family-base doceo-font-size-base">Present text</span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:12pt; text-align:center; page-break-after:avoid; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-style:italic" class="doceo-font-family-base doceo-font-size-base">Amendment</span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Where a rapporteur </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">breaches the provisions of the Code of Conduct for Members of the European Parliament regarding integrity and transparency</span><span style="font-family:'Times New Roman Bold'; font-size:8pt; font-weight:bold; font-style:italic; vertical-align:super" class="doceo-font-family-base doceo-font-size-xs">13</span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">, the committee which appointed him or her may, at the initiative of the President and on a proposal by the Conference of Presidents, terminate the holding of that office. The majorities laid down in the first paragraph shall apply mutatis mutandis to each stage of this procedure.</span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Where a rapporteur </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">has been guilty of serious misconduct or has not completed the specialised training referred to in the first paragraph, point (b), in breach of the deadline and conditions laid down in the </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic; background-color:#ffffff" class="doceo-font-family-base doceo-font-size-base">Code of appropriate behaviour for Members of the European Parliament in exercising their duties</span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">, the committee which appointed him or her may, at the initiative of the President and on a proposal by the Conference of Presidents, terminate the holding of that office. The majorities laid down in the first </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">and second</span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">paragraphs</span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base"> shall apply mutatis mutandis to each stage of this procedure.</span></p>
+</td> 
+      </tr>
+ 
+      
+    </table></div> 
+    <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"></p>
+ 
+    <p class="text-center" style="margin-top:12pt; margin-bottom:0pt; page-break-after:avoid; widows:0; orphans:0; font-size:12pt"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Amendment</span><span> </span><span> </span><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">4</span></p>
+ 
+    <p class="text-center" style="margin-top:12pt; margin-bottom:0pt; page-break-after:avoid; widows:0; orphans:0; font-size:12pt"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Parliament's Rules of Procedure</span></p>
+ 
+    <p class="text-center" style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Rule 176 – paragraph 1 – subparagraph 3</span></p>
+ 
+    
+<div class="table-responsive"><table class="table-borderless mw-100" style="width:487.6pt; margin-right:auto; margin-left:auto; border-collapse:collapse"> 
+      
+      
+<tr> 
+       
+<td colspan="2" style="width:453.6pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; page-break-after:avoid; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:12pt; text-align:center; page-break-after:avoid; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-style:italic" class="doceo-font-family-base doceo-font-size-base">Present text</span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:12pt; text-align:center; page-break-after:avoid; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-style:italic" class="doceo-font-family-base doceo-font-size-base">Amendment</span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">In relation to</span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base"> Rule 10(6), the President may only adopt a reasoned decision under this Rule following the establishment of the occurrence of a harassment in accordance with the applicable internal administrative procedure on harassment and its prevention.</span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">As regards</span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">the prohibition of any type of psychological or sexual harassment laid down in </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Rule 10(6), </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">first subparagraph,</span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base"> the President may only adopt a reasoned decision under this Rule following the establishment of the occurrence of a harassment in accordance with the applicable internal administrative procedure on harassment and its prevention.</span></p>
+</td> 
+      </tr>
+ 
+      
+    </table></div> 
+    <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"></p>
+ 
+    <p class="text-center" style="margin-top:12pt; margin-bottom:0pt; page-break-after:avoid; widows:0; orphans:0; font-size:12pt"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Amendment</span><span> </span><span> </span><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">5</span></p>
+ 
+    <p class="text-center" style="margin-top:12pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Parliament's Rules of Procedure</span></p>
+ 
+    <p class="text-center" style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Annex II – point 5</span></p>
+ 
+    
+<div class="table-responsive"><table class="table-borderless mw-100" style="margin-right:auto; margin-left:auto; border-collapse:collapse"> 
+      
+      
+<tr> 
+       
+<td colspan="2" style="width:453.6pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; page-break-after:avoid; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:12pt; text-align:center; page-break-after:avoid; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-style:italic" class="doceo-font-family-base doceo-font-size-base">Present text</span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:12pt; text-align:center; page-break-after:avoid; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-style:italic" class="doceo-font-family-base doceo-font-size-base">Amendment</span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">5.</span><span style="width:27pt; display:inline-block" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Where necessary, Members will cooperate </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">promptly and</span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base"> fully with the procedures </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">in place</span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">for </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">managing situations of conflict or harassment (psychological or sexual), including responding promptly to any allegations of harassment. Members </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">should </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">take part in specialised training organised for them on preventing conflict and harassment in the workplace and on good office management.</span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">5.</span><span style="width:27pt; display:inline-block" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Where necessary, Members will cooperate fully</span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">, in accordance </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">with the procedures </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">laid down by the Bureau,</span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">with a view to</span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base"> managing situations of conflict or harassment (psychological or sexual), including </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">by</span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base"> responding promptly to any allegations of harassment.</span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Members</span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base"> who have not already done so</span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">shall</span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base"> take part in specialised training organised for them </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">by the European Parliament</span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base"> on preventing conflict and harassment in the workplace and on good office management. </span><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">That specialised training shall be completed within the first six months of the Member’s term of office save in duly substantiated exceptional cases. The Members’ certificates of completion of that specialised training will be published on Parliament’s website.</span></p>
+</td> 
+      </tr>
+ 
+      
+<tr> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+       
+<td style="width:209.8pt; padding-right:17pt; padding-left:17pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:6pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold; font-style:italic" class="doceo-font-family-base doceo-font-size-base">It is considered a serious breach of Rule 10(6) if a Member has not completed the specialised training in breach of the second subparagraph. That breach shall lead, pursuant to Rule 176, to the imposition of one or more penalties.</span></p>
+</td> 
+      </tr>
+ 
+      
+    </table></div> 
+    <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"></p>
+ 
+    <p style="margin-top:0pt; margin-bottom:0pt; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"></p>
+ 
+   </div>
+  </div> 
+  <br /> 
+  <div class="red:section_MainContent_Second"> 
+   <div style="-aw-headerfooter-type:linked; clear:both"> 
+    <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+ 
+   </div> 
+   <p style="margin-top:0pt; margin-bottom:0pt; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+ 
+   <div class="separator separator-dotted separator-2x my-3"></div><h2 id="_section2"><span class="text-uppercase">ANNEX: ENTITIES OR PERSONS</span> <span class="text-uppercase">FROM WHOM THE RAPPORTEUR HAS RECEIVED INPUT</span></h2> 
+   <p style="margin-top:0pt; margin-bottom:24pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">The rapporteur declares under her exclusive responsibility that she did not receive input from any entity or person to be mentioned in this Annex pursuant to Article 8 of Annex I to the Rules of Procedure.</span></p>
+ 
+   <p style="margin-top:0pt; margin-bottom:0pt; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="-aw-bookmark-end:FootprintPageRR" class="doceo-font-family-base doceo-font-size-base"></span><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+ 
+   <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><br /></p>
+ 
+   <div class="separator separator-dotted separator-2x my-3"></div><h2 id="_section3"><span class="text-uppercase">INFORMATION ON ADOPTION IN COMMITTEE RESPONSIBLE</span></h2> 
+   
+<div class="table-responsive"><table class="table-borderless mw-100" style="border:1pt solid #000000; border-collapse:collapse"> 
+     
+     
+<tr> 
+      
+<td style="width:176.35pt; border-right:1pt solid #000000; border-bottom:1pt solid #000000; padding:3.45pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Date adopted</span></p>
+</td> 
+      
+<td style="width:68.6pt; border-bottom:1pt solid #000000; padding:3.45pt 3.95pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">3.4.2024</span></p>
+</td> 
+      
+<td style="width:65.8pt; border-bottom:1pt solid #000000; padding:3.45pt 3.95pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:sans-serif; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+      
+<td style="width:65.8pt; border-bottom:1pt solid #000000; padding:3.45pt 3.95pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:sans-serif; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+      
+<td style="width:65.8pt; border-bottom:1pt solid #000000; padding:3.45pt 3.45pt 3.45pt 3.95pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:sans-serif; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+     </tr>
+ 
+     
+<tr> 
+      
+<td style="width:176.35pt; border-top:1pt solid #000000; border-right:1pt solid #000000; border-bottom:1pt solid #000000; padding:3.45pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Result of final vote</span></p>
+</td> 
+      
+<td style="width:68.6pt; border-top:1pt solid #000000; border-bottom:1pt solid #000000; padding:3.45pt 3.95pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">+:</span></p>
+<p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">–:</span></p>
+<p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">0:</span></p>
+</td> 
+      
+<td colspan="3" style="width:213.2pt; border-top:1pt solid #000000; border-bottom:1pt solid #000000; padding:3.45pt 3.45pt 3.45pt 3.95pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">14</span></p>
+<p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">9</span></p>
+<p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">0</span></p>
+</td> 
+     </tr>
+ 
+     
+<tr> 
+      
+<td style="width:176.35pt; border-top:1pt solid #000000; border-right:1pt solid #000000; border-bottom:1pt solid #000000; padding:3.45pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Members present for the final vote</span></p>
+</td> 
+      
+<td colspan="4" style="width:289.7pt; border-top:1pt solid #000000; border-bottom:1pt solid #000000; padding:3.45pt 3.45pt 3.45pt 3.95pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Gabriele Bischoff, Leila Chaibi, Włodzimierz Cimoszewicz, Ana Collado Jiménez, Daniel Freund, Charles Goerens, Sandro Gozi, Brice Hortefeux, Jaak Madison, Antonio Maria Rinaldi, Domènec Ruiz Devesa, Helmut Scholz, Pedro Silva Pereira, Sven Simon, Loránt Vincze, Rainer Wieland</span></p>
+</td> 
+     </tr>
+ 
+     
+<tr> 
+      
+<td style="width:176.35pt; border-right:1pt solid #000000; border-bottom:1pt solid #000000; padding:3.95pt 3.45pt 3.45pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Substitutes present for the final vote</span></p>
+</td> 
+      
+<td colspan="4" style="width:289.7pt; border-bottom:1pt solid #000000; padding:3.95pt 3.45pt 3.45pt 3.95pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Gilles Boyer, Mercedes Bresso, Christian Doleschal, Sophia in ‘t Veld, Miapetra Kumpula-Natri, Niklas Nienaß</span></p>
+</td> 
+     </tr>
+ 
+     
+<tr> 
+      
+<td style="width:176.35pt; border-right:1pt solid #000000; padding:3.95pt 3.45pt 3.45pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">Substitutes under Rule 209(7) present for the final vote</span></p>
+</td> 
+      
+<td colspan="4" style="width:289.7pt; padding:3.95pt 3.45pt 3.45pt 3.95pt; vertical-align:top"><p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:10pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">François Thiollet, Lucia Vuolo</span></p>
+</td> 
+     </tr>
+ 
+     
+   </table></div> 
+   <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+ 
+   <span style="-aw-bookmark-end:ProcPageRR" class="doceo-font-family-base doceo-font-size-base"></span> 
+  </div> 
+  <br /> 
+  <div class="red:section_MainContent_Second"> 
+   <div style="-aw-headerfooter-type:linked; clear:both"> 
+    <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+ 
+   </div> 
+   <div class="separator separator-dotted separator-2x my-3"></div><h2 id="_section4"><span class="text-uppercase">FINAL VOTE BY ROLL CALL IN COMMITTEE RESPONSIBLE</span></h2> 
+   
+<div class="table-responsive"><table class="table-borderless mw-100" style="margin-left:7.25pt; border:0.75pt double #000000; border-collapse:collapse"> 
+     
+     
+<tr> 
+      
+<td style="width:70.55pt; border-right:0.75pt solid #000000; border-bottom:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:middle; background-color:#e5e5e5"><p style="margin-top:6pt; margin-bottom:6pt; text-align:center; widows:0; orphans:0; font-size:8pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">14</span></p>
+</td> 
+      
+<td style="width:354.05pt; border-left:0.75pt solid #000000; border-bottom:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:top; background-color:#e5e5e5"><p style="margin-top:6pt; margin-bottom:6pt; text-align:center; widows:0; orphans:0; font-size:14pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:Arial; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">+</span></p>
+</td> 
+     </tr>
+ 
+     
+<tr> 
+      
+<td style="width:70.55pt; border-top:0.75pt solid #000000; border-right:0.75pt solid #000000; border-bottom:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:top; background-color:#ffffff"><p style="margin-top:6pt; margin-bottom:6pt; widows:0; orphans:0; font-size:8pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Renew</span></p>
+</td> 
+      
+<td style="width:354.05pt; border-top:0.75pt solid #000000; border-left:0.75pt solid #000000; border-bottom:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:top; background-color:#ffffff"><p style="margin-top:6pt; margin-bottom:6pt; widows:0; orphans:0; font-size:8pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Gilles Boyer, Charles Goerens, Sandro Gozi</span></p>
+</td> 
+     </tr>
+ 
+     
+<tr> 
+      
+<td style="width:70.55pt; border-top:0.75pt solid #000000; border-right:0.75pt solid #000000; border-bottom:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:top; background-color:#ffffff"><p style="margin-top:6pt; margin-bottom:6pt; widows:0; orphans:0; font-size:8pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">S&amp;D</span></p>
+</td> 
+      
+<td style="width:354.05pt; border-top:0.75pt solid #000000; border-left:0.75pt solid #000000; border-bottom:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:top; background-color:#ffffff"><p style="margin-top:6pt; margin-bottom:6pt; widows:0; orphans:0; font-size:8pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Gabriele Bischoff, Mercedes Bresso, Włodzimierz Cimoszewicz, Miapetra Kumpula-Natri, Domènec Ruiz Devesa, Pedro Silva Pereira</span></p>
+</td> 
+     </tr>
+ 
+     
+<tr> 
+      
+<td style="width:70.55pt; border-top:0.75pt solid #000000; border-right:0.75pt solid #000000; border-bottom:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:top; background-color:#ffffff"><p style="margin-top:6pt; margin-bottom:6pt; widows:0; orphans:0; font-size:8pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">The Left</span></p>
+</td> 
+      
+<td style="width:354.05pt; border-top:0.75pt solid #000000; border-left:0.75pt solid #000000; border-bottom:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:top; background-color:#ffffff"><p style="margin-top:6pt; margin-bottom:6pt; widows:0; orphans:0; font-size:8pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Leila Chaibi, Helmut Scholz</span></p>
+</td> 
+     </tr>
+ 
+     
+<tr> 
+      
+<td style="width:70.55pt; border-top:0.75pt solid #000000; border-right:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:top; background-color:#ffffff"><p style="margin-top:6pt; margin-bottom:6pt; widows:0; orphans:0; font-size:8pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Verts/ALE</span></p>
+</td> 
+      
+<td style="width:354.05pt; border-top:0.75pt solid #000000; border-left:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:top; background-color:#ffffff"><p style="margin-top:6pt; margin-bottom:6pt; widows:0; orphans:0; font-size:8pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Daniel Freund, Niklas Nienaß, François Thiollet</span></p>
+</td> 
+     </tr>
+ 
+     
+   </table></div> 
+   <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+ 
+   
+<div class="table-responsive"><table class="table-borderless mw-100" style="margin-left:7.25pt; border:0.75pt double #000000; border-collapse:collapse"> 
+     
+     
+<tr> 
+      
+<td style="width:70.55pt; border-right:0.75pt solid #000000; border-bottom:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:middle; background-color:#e5e5e5"><p style="margin-top:6pt; margin-bottom:6pt; text-align:center; widows:0; orphans:0; font-size:8pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">9</span></p>
+</td> 
+      
+<td style="width:354.05pt; border-left:0.75pt solid #000000; border-bottom:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:top; background-color:#e5e5e5"><p style="margin-top:6pt; margin-bottom:6pt; text-align:center; widows:0; orphans:0; font-size:14pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:Arial; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">-</span></p>
+</td> 
+     </tr>
+ 
+     
+<tr> 
+      
+<td style="width:70.55pt; border-top:0.75pt solid #000000; border-right:0.75pt solid #000000; border-bottom:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:top; background-color:#ffffff"><p style="margin-top:6pt; margin-bottom:6pt; widows:0; orphans:0; font-size:8pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">ID</span></p>
+</td> 
+      
+<td style="width:354.05pt; border-top:0.75pt solid #000000; border-left:0.75pt solid #000000; border-bottom:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:top; background-color:#ffffff"><p style="margin-top:6pt; margin-bottom:6pt; widows:0; orphans:0; font-size:8pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Jaak Madison, Antonio Maria Rinaldi</span></p>
+</td> 
+     </tr>
+ 
+     
+<tr> 
+      
+<td style="width:70.55pt; border-top:0.75pt solid #000000; border-right:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:top; background-color:#ffffff"><p style="margin-top:6pt; margin-bottom:6pt; widows:0; orphans:0; font-size:8pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">PPE</span></p>
+</td> 
+      
+<td style="width:354.05pt; border-top:0.75pt solid #000000; border-left:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:top; background-color:#ffffff"><p style="margin-top:6pt; margin-bottom:6pt; widows:0; orphans:0; font-size:8pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Ana Collado Jiménez, Christian Doleschal, Brice Hortefeux, Sven Simon, Loránt Vincze, Lucia Vuolo, Rainer Wieland</span></p>
+</td> 
+     </tr>
+ 
+     
+   </table></div> 
+   <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+ 
+   
+<div class="table-responsive"><table class="table-borderless mw-100" style="width:454.35pt; margin-left:7.25pt; border:0.75pt double #000000; border-collapse:collapse"> 
+     
+     
+<tr> 
+      
+<td style="width:70.55pt; border-right:0.75pt solid #000000; border-bottom:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:middle; background-color:#e5e5e5"><p style="margin-top:6pt; margin-bottom:6pt; text-align:center; widows:0; orphans:0; font-size:8pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">0</span></p>
+</td> 
+      
+<td style="width:354.05pt; border-left:0.75pt solid #000000; border-bottom:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:top; background-color:#e5e5e5"><p style="margin-top:6pt; margin-bottom:6pt; text-align:center; widows:0; orphans:0; font-size:14pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:Arial; font-weight:bold" class="doceo-font-family-base doceo-font-size-base">0</span></p>
+</td> 
+     </tr>
+ 
+     
+<tr> 
+      
+<td style="width:70.55pt; border-top:0.75pt solid #000000; border-right:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:top; background-color:#ffffff"><p style="margin-top:6pt; margin-bottom:6pt; widows:0; orphans:0; font-size:8pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+      
+<td style="width:354.05pt; border-top:0.75pt solid #000000; border-left:0.75pt solid #000000; padding-right:6.88pt; padding-left:6.88pt; vertical-align:top; background-color:#ffffff"><p style="margin-top:6pt; margin-bottom:6pt; widows:0; orphans:0; font-size:8pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+</td> 
+     </tr>
+ 
+     
+   </table></div> 
+   <p style="margin-top:0pt; margin-bottom:12pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+ 
+   <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">Key to symbols:</span></p>
+ 
+   <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">+</span><span style="width:5.77pt; display:inline-block; -aw-tabstop-align:center; -aw-tabstop-pos:14.2pt" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">:</span><span style="width:5.43pt; display:inline-block; -aw-tabstop-align:left; -aw-tabstop-pos:21.3pt" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">in favour</span></p>
+ 
+   <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">-</span><span style="width:8.54pt; display:inline-block; -aw-tabstop-align:center; -aw-tabstop-pos:14.2pt" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">:</span><span style="width:5.43pt; display:inline-block; -aw-tabstop-align:left; -aw-tabstop-pos:21.3pt" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">against</span></p>
+ 
+   <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">0</span><span style="width:6.53pt; display:inline-block; -aw-tabstop-align:center; -aw-tabstop-pos:14.2pt" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">:</span><span style="width:5.43pt; display:inline-block; -aw-tabstop-align:left; -aw-tabstop-pos:21.3pt" class="doceo-font-family-base doceo-font-size-base"> </span><span style="font-family:'Times New Roman'" class="doceo-font-family-base doceo-font-size-base">abstention</span></p>
+ 
+   <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+ 
+   <p style="margin-top:0pt; margin-bottom:0pt; widows:0; orphans:0; font-size:12pt" class="doceo-line-height-base doceo-font-size-base"><span style="-aw-bookmark-end:RollCallPageRR" class="doceo-font-family-base doceo-font-size-base"></span><span style="font-family:'Times New Roman'; -aw-import:ignore" class="doceo-font-family-base doceo-font-size-base"> </span></p>
+ 
+  </div>  
+ 
+</div></div><div class="container-fluid"><div class="separator separator-dotted my-2"></div><div class="d-block d-sm-flex justify-content-between small mb-3"><span class="text-muted">Last updated: 17 April 2024</span><div><span><a href="/legal-notice/en">Legal notice</a> - <a href="/privacy-policy/en">Privacy policy</a></span></div></div></div></main><script id="evostrap" type="module" src="/commonFrontResources/evostrap/7.0.0/lib/dist/js/evostrap.js"></script><script src="/commonFrontResources/evostrap-doceo/2.0.0/dist/js/doceo.js"></script></body></html>

--- a/backend/tests/pipelines/data/oeil_2024-2006-reg.html
+++ b/backend/tests/pipelines/data/oeil_2024-2006-reg.html
@@ -1,0 +1,1640 @@
+<!doctype html>
+<html lang="en">
+
+
+<head>
+
+    
+    <title>Procedure File: 2024/2006(REG) | Legislative Observatory | European Parliament</title>
+
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta content="@project.version@" name="project_version"/>
+    <meta content="@build.number@" name="build_number"/>
+    <meta content="@build.time@" name="build_time"/>
+
+    <!-- Commons meta tags -->
+    <meta content="https://www.europarl.europa.eu">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta content="IE=edge" http-equiv="X-UA-Compatible">
+    <meta content="no-cache" http-equiv="cache-control">
+    <meta content="-1" http-equiv="expires">
+    <meta content="no-cache" http-equiv="pragma">
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+    <meta content="en" name="language">
+    <meta content="en" http-equiv="Content-Language">
+    <meta content="European Parliament Legislative Observatory Procedure" name="description">
+    <meta content="index, follow, noodp, noydir, notranslate, noarchive" name="robots">
+    <meta content="European Union, 2025 - Source: European Parliament" name="copyright">
+    <meta content="Legislative Observatory" name="planet">
+    <meta content="26-07-2025" name="available">
+
+    <!-- Dynamics meta tags -->
+    
+        <meta content="OEIL, Legislative Observatory, Observatoire législatif, 2024/2006(REG), BISCHOFF Gabriele, S&amp;D, 8.40.01.08 Business of Parliament, procedure, sittings, rules of procedure, A9-0163/2024, T9-0315/2024" name="keywords">
+    
+
+    <!-- HTML <link> tags -->
+    <link rel="icon" href="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/assets/img/favicon.ico">
+
+    
+    <link href="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/dist/css/evostrap.css" rel="stylesheet">
+    <link href="https://www.europarl.europa.eu/commonFrontResources/evostrap-oeil/1.0.0//dist/css/oeil.css" rel="stylesheet">
+</head>
+
+<body id="main-content" data-app-context="/oeil/">
+
+    <header class="erpl_header">
+    <nav class="erpl_wai-access" aria-label="Shortcuts">
+        <ul>
+            <li> <a href="#website-body" class="erpl_smooth-scroll"> <span class="btn btn-primary">Access to page content (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#languageSelectorDropdownButton" class="erpl_smooth-scroll"> <span class="btn btn-primary">Direct access to language menu (press &quot;Enter&quot;)</span> </a> </li>
+
+            <li> <a href="#mainSearch" class="erpl_smooth-scroll"> <span class="btn btn-primary">Direct access to search menu (press &quot;Enter&quot;)</span> </a> </li>
+        </ul>
+    </nav>
+
+    
+    <div class="erpl_header-top border-bottom mb-3 mb-xl-4 a-i">
+        <div class="container">
+            <div class="row no-gutters">
+                <div class="col-auto"><div class="erpl_header-language-selector">
+    <div class="erpl_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute"
+         data-content-width="auto">
+        <button class="erpl_dropdown-btn input-group collapsed" type="button" data-toggle="collapse"
+                id="languageSelectorDropdownButton"
+                data-target="#languageSelectorDropdownContent"
+                aria-expanded="false"
+                aria-controls="languageSelectorDropdownContent">
+            <span class="value form-control">EN - English</span>
+            
+            <span class="input-group-append">
+                <span class="input-group-icon">
+                    <svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false">
+                        <use xlink:href="#es_icon-arrow"></use>
+                    </svg>
+                    <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-flip-y text-primary"
+                         data-show-expanded="true">
+                        <use xlink:href="#es_icon-arrow"></use>
+                    </svg>
+                </span>
+            </span>
+        </button>
+
+        <div>
+            <div class="erpl_dropdown-content collapse" id="languageSelectorDropdownContent">
+                <div class="border border-light">
+                    <div>
+                        <ul class="erpl_topbar-list list-unstyled erpl_dropdown-menu">
+                            <li class="t-x-block" data-selected="false">
+                                <!-- localized version URL is here -->
+                                <a class="erpl_dropdown-menu-item"
+                                   lang="fr"
+                                   href="https://oeil.secure.europarl.europa.eu/oeil/fr/procedure-file?reference=2024/2006(REG)">
+                                    
+                                    <span class="t-item">FR - français</span>
+                                </a>
+                            </li>
+                            <li class="t-x-block" data-selected="true">
+                                <!-- localized version URL is here -->
+                                <a class="erpl_dropdown-menu-item"
+                                   lang="en"
+                                   href="https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2024/2006(REG)">
+                                    <span class="t-item">EN - English</span>
+                                    
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div></div>
+                <div class="col">
+                    <nav class="erpl_header-other-websites d-flex justify-content-end align-items-center" aria-label="Other websites">
+                        <ul class="d-flex list-unstyled">
+
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/news/en">
+                                    <span class="t-item">News</span>
+                                </a>
+                            </li>
+
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/topics/en">
+                                    <span class="t-item">Topics</span>
+                                </a>
+                            </li>
+
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/meps/en">
+                                    <span class="t-item">MEPs</span>
+                                </a>
+                            </li>
+
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/about-parliament/en">
+                                    <span class="t-item">About Parliament</span>
+                                </a>
+                            </li>
+
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/plenary/en">
+                                    <span class="t-item">Plenary</span>
+                                </a>
+                            </li>
+
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/committees/en">
+                                    <span class="t-item">Committees</span>
+                                </a>
+                            </li>
+
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://www.europarl.europa.eu/delegations/en">
+                                    <span class="t-item">Delegations</span>
+                                </a>
+                            </li>
+
+                            
+                            <li class="d-none d-xl-block">
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://elections.europa.eu/en/">
+                                    <span class="t-item">Elections</span>
+                                </a>
+                            </li>
+
+
+                            <li class="erpl_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute">
+                               <button class="erpl_dropdown-btn input-group collapsed d-xl-flex pl-1 align-items-center t-y-block flex-nowrap"
+                                       data-toggle="collapse"
+                                       data-target="#otherWebsiteSubmenu"
+                                       aria-expanded="false"
+                                       aria-controls="otherWebsiteSubmenu" aria-label="More other websites">
+                                    <span class="value">
+											<span class="d-none d-xl-inline">Other websites</span>
+											<span class="d-xl-none">View other websites</span>
+                                    </span>
+                                   <span class="input-group-append">
+											<span class="input-group-icon">
+												<svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false">
+													<use xlink:href="#es_icon-arrow"></use>
+												</svg>
+
+												<svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-flip-y text-primary" data-show-expanded="true">
+													<use xlink:href="#es_icon-arrow"></use>
+												</svg>
+											</span>
+										</span>
+                                </button>
+                                <div>
+                                    <div id="otherWebsiteSubmenu" class="erpl_dropdown-content collapse">
+                                        <ul class="erpl_header-other-websites-submenu list-unstyled erpl_dropdown-menu">
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/news/en">
+                                                    <span class="t-item">News</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/topics/en">
+                                                    <span class="t-item">Topics</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/meps/en">
+                                                    <span class="t-item">MEPs</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/about-parliament/en">
+                                                    <span class="t-item">About Parliament</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/plenary/en">
+                                                    <span class="t-item">Plenary</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/committees/en">
+                                                    <span class="t-item">Committees</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/delegations/en">
+                                                    <span class="t-item">Delegations</span>
+                                                </a>
+                                            </li>
+                                            
+                                            <li class="d-xl-none t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://elections.europa.eu/en/">
+                                                    <span class="t-item">Elections</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://multimedia.europarl.europa.eu/en/home">
+                                                    <span class="t-item">Multimedia Centre</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/the-president/en">
+                                                    <span class="t-item">Presidency</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/the-secretary-general/en">
+                                                    <span class="t-item">Secretariat-general</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/thinktank/en">
+                                                    <span class="t-item">Thinktank</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.epnewshub.eu">
+                                                    <span class="t-item">EP Newshub</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/at-your-service/en">
+                                                    <span class="t-item">At your service</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/visiting/en">
+                                                    <span class="t-item">Visits</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/legislative-train">
+                                                    <span class="t-item">Legislative train</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/contracts-and-grants/en/">
+                                                    <span class="t-item">Contracts and Grants</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/RegistreWeb/home/welcome.htm?language=en">
+                                                    <span class="t-item">Register</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://data.europarl.europa.eu/en">
+                                                    <span class="t-item">Open Data Portal</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="erpl_dropdown-menu-item" href="https://liaison-offices.europarl.europa.eu/en">
+                                                    <span class="t-item">Liaison offices</span>
+                                                </a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </li>
+                        </ul>
+                    </nav>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="erpl_header-middle mb-3">
+        <div class="container">
+            <div class="row">
+                <div class="col-12 col-md">
+                    <div class="erpl_header-website-title a-i">
+                        <div class="erpl_header-website-title-main">
+                            <a href="/oeil/en" class="t-x">
+                                <span>Legislative Observatory</span>
+                            </a>
+                        </div>
+                        <div class="erpl_header-website-title-sub">
+                            <a class="t-x-block" href="https://www.europarl.europa.eu" target="_blank" >
+                                <span class="t-item">European Parliament</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+
+                
+                <div class="col-auto d-none d-xl-flex justify-content-end align-items-center erpl_header-search-container">
+                    <form class="erpl_header-search" method="GET" action="/oeil/en/search"> <label for="mainSearch" class="sr-only">Find a procedure</label>
+                        <div class="input-group" style="width: 300px">
+                            <input type="text" class="form-control"
+                                   id="mainSearch"
+                                   placeholder="Find a procedure..."
+                                   name="fullText.term"
+                                   aria-describedby="mainSearchHelper">
+                            <div class="input-group-append">
+                                <button class="btn btn-primary align-items-center d-flex" title="Start find a procedure" disabled="">
+                                    <svg aria-hidden="true" class="es_icon es_icon-search erpl_header-search-icon">
+                                        <use xlink:href="#es_icon-search"></use>
+                                    </svg>
+                                </button>
+                            </div>
+                        </div> <span id="mainSearchHelper" class="form-text text-muted sr-only">Please fill in this field to find a procedure</span>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="erpl_header-bottom">
+        <div class="erpl_header-menu-container">
+            <div class="container"><nav class="erpl_header-menu" aria-label="Main navigation">
+    <div class="erpl_header-menu-top row align-items-center">
+        <div class="col d-md-none d-flex align-items-center">
+            <svg aria-hidden="true" class="es_icon es_icon-ep-logo-w erpl_header-menu-top-logo">
+                <use xlink:href="#es_icon-ep-logo-w"></use>
+            </svg>
+        </div>
+
+        <span class="erpl_header-menu-top-title offset-3 col-6 text-center d-none d-md-block" aria-hidden="true">
+								<span>European Parliament</span></span>
+
+        <div class="erpl_header-menu-top-controls col-auto col-md-3 text-right">
+            <button type="button" class="btn btn-sm btn-dark-primary erpl_header-menu-top-controls-toggle-search" id="headerMenuToggleSearch" aria-haspopup="true" aria-expanded="false">
+                <span class="sr-only">Search</span>
+                <svg aria-hidden="true" class="es_icon es_icon-search">
+                    <use xlink:href="#es_icon-search"></use>
+                </svg>
+            </button>
+            <button type="button"
+                    class="btn btn-sm btn-dark-primary erpl_header-menu-top-controls-toggle-menu"
+                    id="headerMenuToggleMenu"
+                    aria-haspopup="true"
+                    aria-expanded="false">
+                <span class="mr-25">Menu</span> <span class="erpl_header-menu-icon" aria-hidden="true"></span>
+            </button>
+        </div>
+    </div>
+
+    <ul class="erpl_header-menu-list list-unstyled">
+        
+<li class="erpl_header-menu-item">
+    <a class="erpl_header-menu-item-title"
+       href="/oeil/en" data-selected="false">
+        <span class="t-y">Home</span>
+    </a>
+</li>
+<li class="erpl_header-menu-item">
+    <a class="erpl_header-menu-item-title"
+       href="/oeil/en/search" data-selected="false">
+        <span class="t-y">Search</span>
+    </a>
+</li>
+<li class="erpl_header-menu-item">
+    <a class="erpl_header-menu-item-title"
+       href="/oeil/en/legislative-priorities" data-selected="false">
+        <span class="t-y">Legislative priorities</span>
+    </a>
+</li>
+<li class="erpl_header-menu-item">
+    <a class="erpl_header-menu-item-title"
+       href="/oeil/en/find-out-more" data-selected="false">
+        <span class="t-y">Find out more</span>
+    </a>
+</li>
+<li class="erpl_header-menu-item">
+    <a class="erpl_header-menu-item-title"
+       href="/oeil/en/contact" data-selected="false">
+        <span class="t-y">Contact us</span>
+    </a>
+</li>
+
+    </ul>
+</nav></div>
+        </div>
+    </div>
+</header>
+
+    <div class="container">
+        <div class="breadcrumb"></div>
+    </div>
+
+    
+    <main id="website-body">
+<div class="container">
+    <div class="row">
+        <div class="col-12 col-xl-8">
+            <div class="row">
+                <div class="col-12 col-lg"><h2 class="erpl_title-h1 mb-3">2024/2006(REG)</h2>
+                </div>
+                <div class="col-12 col-lg-4">
+                    <div class="erpl_links-list text-lg-right my-1">
+                        <ul>
+                            <li>
+                                <a href="/oeil/en/procedure-file/pdf?reference=2024/2006(REG)">
+                                    <svg class="es_icon es_icon-pdf mr-1">
+                                        <title>pdf</title>
+                                        <use xlink:href="#es_icon-pdf"></use>
+                                    </svg>
+                                    <span class="t-x">Full procedure</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            
+            <h2 class="erpl_title-h2 mb-3">EP&nbsp;Rules of Procedure: training on preventing conflict and harassment in the workplace and on good office management</h2>
+            <div class="separator border-dark my-3"></div>
+
+            
+            <div id="sectionsNavPositionRwd" class="mb-1"></div>
+
+
+            
+            <div class="erpl_product">
+                <div class="row">
+                    <div class="col">
+                        <div class="mb-3">
+                            <div class="erpl_product-body">
+                                
+                                <html lang="en">
+
+
+<div class="erpl_product-section">
+    <div id="section1" class="erpl-product-content oeil-spy-section mb-2">
+        <div class="row">
+            <div class="col-12 col-lg">
+                <h2 class="erpl_title-h2 mb-2">Basic information</h2></div>
+                <div class="col-12 col-lg-4">
+                    <div class="erpl_links-list text-lg-right my-1">
+                        <ul>
+                            <li>
+                                <a href="/oeil/en/procedure-file/pdf?reference=2024/2006(REG)&amp;section=BASIC_INFO">
+                                    <svg class="es_icon es_icon-pdf mr-1">
+                                        <title>pdf</title>
+                                        <use xlink:href="#es_icon-pdf"></use>
+                                    </svg>
+                                    <span class="t-x">Basic information</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+        </div>
+        <div class="row">
+            <div class="col-6">
+                <p class="font-weight-bold mb-1">2024/2006(REG)</p>
+
+                <p>REG - Parliament&#39;s Rules of Procedure</p>
+                
+
+                
+                
+
+
+                
+                    <p class="font-weight-bold mb-1">Subject</p>
+                    <p>
+                        
+                            8.40.01.08 Business of Parliament, procedure, sittings, rules of procedure
+                            
+                        
+                    </p>
+                
+
+                
+
+                
+            </div>
+
+            <div class="col-6">
+                
+                    <p class="font-weight-bold mb-1">Status</p>
+                    <p class="text-danger">Procedure completed</p>
+                
+
+                
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-12">
+                <div class="separator separator-dotted separator-2x mt-5 mb-3">
+                    <a class="erpl_smooth-scroll btn btn-default" href="#gateway">Please go to Documentation gateway for any follow-up documents.</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</html>
+
+
+                                
+                                <div class="erpl_product-section">
+    <div class="separator border-dark my-3"></div>
+    <div id="section2" class="erpl-product-content oeil-spy-section mb-2">
+        <div class="row">
+            <div class="col-12 col-lg"><h2 class="erpl_title-h2 mb-2">Key players</h2>
+            </div>
+            <div class="col-12 col-lg-4">
+                <div class="erpl_links-list text-lg-right my-1">
+                    <ul>
+                        <li>
+                            <a href="/oeil/en/procedure-file/pdf?reference=2024/2006(REG)&amp;section=KEY_PLAYERS">
+                                <svg class="es_icon es_icon-pdf mr-1">
+                                    <title>pdf</title>
+                                    <use xlink:href="#es_icon-pdf"></use>
+                                </svg>
+                                <span class="t-x">Key players</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="erpl_accordion mb-5" id="erplAccordionKeyPlayers">
+            <ul class="a-i">
+                
+    <li class="erpl_accordion-item" data-selected="false">
+        <button id="erpl_accordion-committee-title" type="button" class="erpl_accordion-item-title" data-toggle="collapse" data-target="#erpl_accordion-committee" aria-expanded="true" aria-controls="erpl_accordion-committee">
+            <span class="t-x">European Parliament</span>
+            <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
+                <use xlink:href="#es_icon-more"></use>
+            </svg>
+            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
+                <use xlink:href="#es_icon-less"></use>
+            </svg>
+        </span>
+        </button>
+        <div id="erpl_accordion-committee" class="erpl_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="erpl_accordion-committee-title">
+            <div>
+                <a href="http://www.europarl.europa.eu/" target="_blank">
+                    <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1">
+                        <use xlink:href="#es_icon-arrow"></use>
+                    </svg>
+                    <span class="t-x">European Parliament</span>
+                </a>
+
+                <div class="table-responsive mt-2">
+                    
+
+                        <table class="table table-bordered table-striped">
+                            <thead>
+                            <tr>
+                                <th class="w-50" scope="col">Committee responsible</th>
+                                <th class="w-25" scope="col">Rapporteur</th>
+                                <th class="w-25" scope="col">Appointed</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+
+                            
+
+                            
+                                
+                                    
+    <tr>
+        <th scope="row">
+            <div class="d-flex align-items-center">
+    <span class="erpl_badge erpl_badge-committee mr-1">AFCO</span>
+    <div>
+        <a href="http://www.europarl.europa.eu/committees/EN/afco/home.html" target="_blank">
+                <span class="font-weight-normal">Constitutional Affairs</span>
+        </a>
+        
+        <br/>
+        
+    </div>
+</div>
+        </th>
+        <td>
+            
+    
+    
+        
+
+        <a class="rapporteur mb-25"
+           data-toggle="tooltip-rapporteur"
+           data-placement="bottom"
+           href="https://www.europarl.europa.eu/meps/en/197435" target="_blank"
+           title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/197435.jpg&quot; alt=&quot;Photo BISCHOFF Gabriele &quot;&gt;">
+            <span>BISCHOFF Gabriele (S&amp;D)</span>
+        </a>
+        <br/>
+    
+
+        </td>
+
+        <td>
+            
+                <span>29/02/2024</span>
+                <br/>
+            
+        </td>
+
+    </tr>
+    <tr class="bg-none border">
+        <th scope="row" class="border-0"></th>
+        <td class="border-0">
+            
+    <button class="btn btn-primary my-1" type="button" data-toggle="collapse"
+            data-target="#collapseShadowRapporteur" aria-expanded="false"
+            aria-controls="collapseShadowRapporteur">Shadow rapporteur</button>
+
+    <div class="collapse" id="collapseShadowRapporteur">
+        <div class="card card-body border-0 p-0">
+            <a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/2323" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/2323.jpg&quot; alt=&quot;Photo WIELAND Rainer &quot;&gt;">
+                <span>WIELAND Rainer (EPP)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/197577" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/197577.jpg&quot; alt=&quot;Photo BOYER Gilles &quot;&gt;">
+                <span>BOYER Gilles (Renew)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/197531" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/197531.jpg&quot; alt=&quot;Photo DELBOS-CORFIELD Gwendoline &quot;&gt;">
+                <span>DELBOS-CORFIELD Gwendoline (Greens/EFA)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/96646" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/96646.jpg&quot; alt=&quot;Photo SCHOLZ Helmut &quot;&gt;">
+                <span>SCHOLZ Helmut (The Left)</span>
+            </a>
+        </div>
+    </div>
+
+        </td>
+        <td class="border-0"></td>
+    </tr>
+
+                                
+
+                                
+                            
+
+                            </tbody>
+                        </table>
+
+                        
+                    
+                </div>
+            </div>
+        </div>
+    </li>
+
+
+                
+
+                
+
+                
+    
+
+            </ul>
+        </div>
+    </div>
+
+</div>
+
+                                
+                                <html lang="en">
+
+
+
+
+<div class="erpl_product-section">
+    <div class="separator border-dark my-3"></div>
+    <div id="section3" class="erpl-product-content oeil-spy-section mb-2">
+        <div class="row">
+            <div class="col-12 col-lg">
+                <h2 class="erpl_title-h2 mb-2">Key events</h2>
+            </div>
+            <div class="col-12 col-lg-4">
+                <div class="erpl_links-list text-lg-right my-1">
+                    <ul>
+                        <li>
+                            <a href="/oeil/en/procedure-file/pdf?reference=2024/2006(REG)&amp;section=KEY_EVENTS" target="_blank">
+                                <svg class="es_icon es_icon-pdf mr-1">
+                                    <title>pdf</title>
+                                    <use xlink:href="#es_icon-pdf"></use>
+                                </svg>
+                                <span class="t-x">Key events</span>
+                            </a>
+                        </li>
+                    </ul>
+
+                </div>
+            </div>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-striped table-bordered">
+                <thead>
+                <tr>
+                    <th class="align-middle" scope="col">Date</th>
+                    <th class="align-middle" scope="col">Event</th>
+                    <th class="align-middle" scope="col">Reference</th>
+                    <th class="align-middle" scope="col">Summary</th>
+                </tr>
+                </thead>
+
+                <tbody>
+                <tr>
+                    
+                        <td class="align-middle" >03/04/2024</td>
+                        <td class="align-middle">Vote in committee</td>
+                        <td class="align-middle text-center">
+                            
+                                
+                                <span></span>
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >04/04/2024</td>
+                        <td class="align-middle">Committee report tabled for plenary</td>
+                        <td class="align-middle text-center">
+                            
+                                <a href="https://www.europarl.europa.eu/doceo/document/A-9-2024-0163_EN.html" target="_blank">A9-0163/2024</a>
+                                
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >10/04/2024</td>
+                        <td class="align-middle">Committee referral announced in Parliament</td>
+                        <td class="align-middle text-center">
+                            
+                                
+                                <span></span>
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >24/04/2024</td>
+                        <td class="align-middle">Decision by Parliament</td>
+                        <td class="align-middle text-center">
+                            
+                                <a href="https://www.europarl.europa.eu/doceo/document/TA-9-2024-0315_EN.html" target="_blank">T9-0315/2024</a>
+                                
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            <a href="/oeil/en/document-summary?id=1784533" target="_blank">
+                                <button class="btn btn-success btn-sm" type="button">Summary</button>
+                            </a>
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >24/04/2024</td>
+                        <td class="align-middle">Results of vote in Parliament</td>
+                        <td class="align-middle text-center">
+                            
+
+                            
+
+                            
+                                <a href="https://www.europarl.europa.eu/doceo/document/PV-9-2024-04-24-VOT_EN.html?item=1"
+                                   title="Results of vote in Parliament" target="_blank">
+                                    <svg aria-hidden="true" class="es_icon es_icon-vote es_icon-24">
+                                        <use xlink:href="#es_icon-vote"></use>
+                                    </svg>
+                                </a>
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+    </div>
+</div>
+
+
+                                
+                                
+
+
+
+
+
+                                
+                                <html lang="en">
+
+
+
+
+<div class="erpl_product-section">
+    <div class="separator border-dark my-3"></div>
+    <div id="section5" class="erpl-product-content oeil-spy-section mb-2">
+        <div class="row">
+            <div class="col-12 col-lg">
+                <h2 class="erpl_title-h2 mb-2">Technical information</h2>
+            </div>
+            <div class="col-12 col-lg-4">
+                <div class="erpl_links-list text-lg-right my-1">
+                    <ul>
+                        <li>
+                            <a href="/oeil/en/procedure-file/pdf?reference=2024/2006(REG)&amp;section=TECHNICAL_INFORMATION">
+                                <svg class="es_icon es_icon-pdf mr-1">
+                                    <title>pdf</title>
+                                    <use xlink:href="#es_icon-pdf"></use>
+                                </svg>
+                                <span class="t-x">Technical information</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <div class="table-responsive">
+            <table class="table table-striped table-bordered">
+                <tbody>
+                <tr>
+                    <th class="align-middle" scope="row">Procedure reference</th>
+                    <td class="align-middle">2024/2006(REG)</td>
+                </tr>
+                <tr>
+                    <th class="align-middle" scope="row">Procedure type</th>
+                    <td class="align-middle">REG - Parliament&#39;s Rules of Procedure</td>
+                </tr>
+                <tr>
+                    <th class="align-middle" scope="row">Procedure subtype</th>
+                    <td class="align-middle">Rules</td>
+                </tr>
+                
+                
+                <tr>
+                    <th class="align-middle" scope="row">Legal basis</th>
+                    <td class="align-middle">
+                        
+                            <span class="d-block">Rules of Procedure EP 243-p1 </span>
+                        
+                    </td>
+                </tr>
+                
+                
+                <tr>
+                    <th class="align-middle" scope="row">Stage reached in procedure</th>
+                    <td class="align-middle">Procedure completed</td>
+                </tr>
+                <tr>
+                    <th class="align-middle" scope="row">Committee dossier</th>
+                    <td class="align-middle">
+                    
+                        <span>AFCO/9/14315</span>
+                        <br/>
+                    
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+                                
+                                <html lang="en">
+
+
+
+
+<div class="erpl_product-section">
+    <div class="separator border-dark my-3"></div>
+    <div id="section6" class="erpl-product-content oeil-spy-section mb-2">
+        <div class="row">
+            <div class="col-12 col-lg">
+                <h2 id="gateway" class="erpl_title-h2 mb-2">Documentation gateway</h2>
+            </div>
+            <div class="col-12 col-lg-4">
+                <div class="erpl_links-list text-lg-right my-1">
+                    <ul>
+                        <li>
+                            <a href="/oeil/en/procedure-file/pdf?reference=2024/2006(REG)&amp;section=DOCUMENTATION_GATEWAY" target="_blank">
+                                <svg class="es_icon es_icon-pdf mr-1">
+                                    <title>pdf</title>
+                                    <use xlink:href="#es_icon-pdf"></use>
+                                </svg>
+                                <span class="t-x">Documentation gateway</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="erpl_accordion mb-5" id="erplAccordionDocGateway">
+            <ul class="a-i">
+                
+                    <li class="erpl_accordion-item" data-selected="false">
+    <button
+            id="erpl_accordion-item-doc-gateway-EP-title"
+            type="button"
+            class="erpl_accordion-item-title collapsed"
+            data-toggle="collapse"
+            aria-expanded="true" data-target="#erpl_accordion-item-doc-gateway-EP" aria-controls="erpl_accordion-item-doc-gateway-EP"
+    >
+        <span class="t-x">European Parliament</span>
+        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
+                <use xlink:href="#es_icon-more"></use>
+            </svg>
+            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
+                <use xlink:href="#es_icon-less"></use>
+            </svg>
+        </span>
+    </button>
+    <div id="erpl_accordion-item-doc-gateway-EP" class="collapse erpl_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="erpl_accordion-item-doc-gateway-EP-title">
+            <div class="table-responsive">
+                <table class="table table-striped table-bordered">
+                    <thead>
+                    <tr>
+                        
+
+                        <th class="align-middle" scope="col">Document type</th>
+                        <th class="align-middle" scope="col">Committee</th>
+                        <th class="align-middle w-25" scope="col">Reference</th>
+                        <th class="align-middle" scope="col">Date</th>
+                        <th class="align-middle" scope="col">Summary</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Committee draft report</span>
+                        </th>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/AFCO-PR-759748_EN.html" target="_blank">PE759.748</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >29/02/2024</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Amendments tabled in committee</span>
+                        </th>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/AFCO-AM-759765_EN.html" target="_blank">PE759.765</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >04/03/2024</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Committee report tabled for plenary, single reading</span>
+                        </th>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/A-9-2024-0163_EN.html" target="_blank">A9-0163/2024</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >04/04/2024</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Text adopted by Parliament, single reading</span>
+                        </th>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://www.europarl.europa.eu/doceo/document/TA-9-2024-0315_EN.html" target="_blank">T9-0315/2024</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >24/04/2024</td>
+
+                        <td class="align-middle">
+                            <a href="/oeil/en/document-summary?id=1784533" target="_blank">
+                                <button class="btn btn-success btn-sm" type="button">Summary</button>
+                            </a>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+    </div>
+</li>
+                
+            </ul>
+        </div>
+    </div>
+</div>
+
+                                
+                                <html lang="en">
+
+
+
+
+
+
+                                
+                                
+
+
+                                
+                                <html lang="en">
+
+
+
+
+
+
+</html>
+
+                                
+                                <html lang="en">
+
+
+
+
+
+
+</html>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+
+        <div class="col-12 col-xl-3 offset-xl-1">
+            
+            <div class="position-sticky" id="sectionsNavPositionInitial">
+                
+                
+
+
+
+
+<div class="card erpl_move"
+     data-move-lg="#sectionsNavPositionRwd"
+     data-move-md="#sectionsNavPositionRwd"
+     data-move-sm="#sectionsNavPositionRwd"
+     data-move-xl="#sectionsNavPositionInitial"
+     data-move-xs="#sectionsNavPositionRwd"
+     data-move-xxl="#sectionsNavPositionInitial">
+    <div class="card-body py-0">
+        <nav class="erpl_side-navigation">
+            <h3 class="erpl_title-h3 mb-0 py-2">
+                <a class="text-primary" href="#">
+                    <span class="t-x">Procedure file</span>
+                </a>
+            </h3>
+            <div class="erpl_links-list erpl_links-list-nav">
+                <ul>
+                    <li data-selected="true">
+                        <a class="erpl_smooth-scroll" href="#section1">
+                            <span class="t-x">Basic information</span>
+                        </a>
+                    </li>
+                    <li data-selected="false">
+                        <a class="erpl_smooth-scroll" href="#section2">
+                            <span class="t-x">Key players</span>
+                        </a>
+                    </li>
+                    <li data-selected="false">
+                        <a class="erpl_smooth-scroll" href="#section3">
+                            <span class="t-x">Key events</span>
+                        </a>
+                    </li>
+                    
+                    <li data-selected="false">
+                        <a class="erpl_smooth-scroll" href="#section5">
+                            <span class="t-x">Technical information</span>
+                        </a>
+                    </li>
+                    <li data-selected="false">
+                        <a class="erpl_smooth-scroll" href="#section6">
+                            <span class="t-x">Documentation gateway</span>
+                        </a>
+                    </li>
+                    
+                    
+                    
+                    
+                </ul>
+            </div>
+        </nav>
+    </div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+</main>
+
+    
+    <button id="scrollToTopButton" type="button" class="btn btn-primary rounded-circle" data-duration="250" data-min-scroll-to-show="200" aria-label="Scroll to top">
+        <svg aria-hidden="true" class="es_icon es_icon-chevron es_icon-rotate-270">
+            <use xlink:href="#es_icon-chevron"></use>
+        </svg>
+    </button>
+
+    
+    <footer class="erpl_footer">
+    <div class="erpl_footer-top mt-8">
+        <div class="container">
+            <div class="erpl_footer-top-content border-top-lg border-secondary text-center d-md-flex justify-content-between pt-md-3 mb-5 a-i">
+                <nav id="share-links" class="erpl_share-links" aria-label="Share links">
+                    <div class="d-md-flex">
+                        <h2 class="erpl_title-h5 mb-2 mb-md-0"><span class="mr-md-1">Share this page</span></h2>
+                        <ul class="erpl_share-links-list d-flex justify-content-center mb-3 mb-md-0">
+                            <li class="mr-1">
+                                <a title="Share this page on Facebook" href="https://www.facebook.com/share.php?u=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2024/2006(REG)" target="_blank">
+                                    <span class="sr-only">Facebook</span>
+                                    <svg aria-hidden="true" class="es_icon es_icon-facebook">
+                                        <use xlink:href="#es_icon-facebook"></use>
+                                    </svg>
+                                </a>
+                            </li>
+                            <li class="mr-1">
+                                <a title="Share this page on X" href="https://x.com/intent/post?url=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2024/2006(REG)&amp;text=Procedure%20File:%202024/2006(REG)&amp;via=Europarl_EN" target="_blank">
+                                    <span class="sr-only">X</span>
+                                    <svg aria-hidden="true" class="es_icon es_icon-twitter-x">
+                                        <use xlink:href="#es_icon-twitter-x"></use>
+                                    </svg>
+                                </a>
+                            </li>
+                            <li class="mr-1">
+                                <a title="Share this page on LinkedIn" href="https://www.linkedin.com/sharing/share-offsite?url=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2024/2006(REG)" target="_blank">
+                                    <span class="sr-only">LinkedIn</span>
+                                    <svg aria-hidden="true" class="es_icon es_icon-linkedin">
+                                        <use xlink:href="#es_icon-linkedin"></use>
+                                    </svg>
+                                </a>
+                            </li>
+                            <li>
+                                <a title="Share this page on Whatsapp" href="https://api.whatsapp.com/send?text=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2024/2006(REG)" target="_blank">
+                                    <span class="sr-only">Whatsapp</span>
+                                    <svg aria-hidden="true" class="es_icon es_icon-whatsapp">
+                                        <use xlink:href="#es_icon-whatsapp"></use>
+                                    </svg>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </nav>
+                <nav class="erpl_horizontal-links" aria-label="data protection link">
+                    <div>
+                        <a href="https://oeil.secure.europarl.europa.eu/oeil/en/external-documents/download?id=2" target="_blank">
+                            <span class="t-y">Data Protection Notice</span>
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+    </div>
+    <div class="erpl_footer-bottom bg-black-footer pt-3 pb-3">
+        <div class="container">
+            <div class="row" id="footerLinks">
+                <nav class="col-12 col-xl-9 text-center text-md-left" id="website-links" aria-label="Website links">
+    <h3 class="erpl_title-h3 mb-2 text-white">Legislative Observatory</h3>
+    <div class="collapse show" id="website-links-items">
+        <div class="row">
+            <div class="col-12 col-md-6 col-xl-4">
+                <div>
+                    <div class="subtitle mb-1">Tools</div>
+                    <nav class="link-group t-x-mode" aria-label="Tools">
+                        <a href="https://www.europarl.europa.eu/news/en/press-room" class="link-group-item mb-1 d-block" aria-label="Tools - Press Service">
+                            <span>Press Service</span>
+                        </a><a href="https://www.europarl.europa.eu/olp/en/home" class="link-group-item mb-1 d-block" aria-label="Tools - Ordinary legislative procedure">
+                            <span>Ordinary legislative procedure</span>
+                        </a><a href="https://www.europarl.europa.eu/RegistreWeb/search/simple.htm?language=en" class="link-group-item mb-1 d-block" aria-label="Tools - Parliament register">
+                            <span>Parliament register</span>
+                        </a><a href="https://eur-lex.europa.eu/en/index.htm" class="link-group-item mb-1 d-block" aria-label="Tools - EUR-Lex">
+                            <span>EUR-Lex</span>
+                        </a><a href="https://www.consilium.europa.eu/en/documents-publications/public-register/" class="link-group-item mb-1 d-block" aria-label="Tools - Council register">
+                            <span>Council register</span>
+                        </a><a href="https://webgate.ec.europa.eu/regdel/#/home" class="link-group-item mb-1 d-block" aria-label="Tools - Delegated acts register">
+                            <span>Delegated acts register</span>
+                        </a>
+                    </nav>
+                </div>
+            </div>
+            <div class="col-12 col-md-6 col-xl-4">
+                <div>
+                    <div class="subtitle mb-1">Committees</div>
+                    <nav class="link-group t-x-mode" aria-label="Committees">
+                        <a href="https://www.europarl.europa.eu/committees/en/home" class="link-group-item mb-1 d-block" aria-label="Committees - Home">
+                            <span>Home</span>
+                        </a><a href="https://www.europarl.europa.eu/committees/en/meetings/meeting-documents" class="link-group-item mb-1 d-block" aria-label="Committees - Meetings">
+                            <span>Meetings</span>
+                        </a><a href="https://www.europarl.europa.eu/committees/en/documents/search" class="link-group-item mb-1 d-block" aria-label="Committees - Documents">
+                            <span>Documents</span>
+                        </a><a href="https://www.europarl.europa.eu/committees/en/events/events-hearings" class="link-group-item mb-1 d-block" aria-label="Committees - Events">
+                            <span>Events</span>
+                        </a><a href="https://www.europarl.europa.eu/committees/en/supporting-analyses/sa-highlights" class="link-group-item mb-1 d-block" aria-label="Committees - Supporting analyses">
+                            <span>Supporting analyses</span>
+                        </a>
+                    </nav>
+                </div>
+                <div>
+                    <div class="subtitle mb-1">Plenary</div>
+                    <nav class="link-group t-x-mode" aria-label="Plenary">
+                        <a href="https://www.europarl.europa.eu/plenary/en/" class="link-group-item mb-1 d-block" aria-label="Plenary - Plenary sitting">
+                            <span>Plenary sitting</span>
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/guide-plenary.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Around plenary">
+                            <span>Around plenary</span>
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliamentary-questions.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Questions and declarations">
+                            <span>Questions and declarations</span>
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliament-positions.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Legislative texts adopted">
+                            <span>Legislative texts adopted</span>
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/meetings-search.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Plenary calendar">
+                            <span>Plenary calendar</span>
+                        </a>
+                    </nav>
+                </div>
+            </div>
+            <div class="col-12 col-md-6 col-xl-4">
+                <div>
+                    <div class="subtitle mb-1">Delegations</div>
+                    <nav class="link-group t-x-mode" aria-label="Delegations">
+                        <a href="https://www.europarl.europa.eu/delegations/en/calendar" class="link-group-item mb-1 d-block" aria-label="Delegations - Delegations calendar">
+                            <span>Delegations calendar</span>
+                        </a><a href="https://www.europarl.europa.eu/delegations/en/home" class="link-group-item mb-1 d-block" aria-label="Delegations - Home">
+                            <span>Home</span>
+                        </a>
+                    </nav>
+                </div>
+                <div>
+                    <div class="subtitle mb-1">MEPs</div>
+                    <nav class="link-group t-x-mode" aria-label="MEPs">
+                        <a href="https://www.europarl.europa.eu/meps/en/search/advanced" class="link-group-item mb-1 d-block" aria-label="MEPs - Search">
+                            <span>Search</span>
+                        </a>
+                    </nav>
+                </div>
+                <div>
+                    <div class="subtitle mb-1">At your service</div>
+                    <nav class="link-group t-x-mode" aria-label="At your service">
+                        <a href="https://www.europarl.europa.eu/at-your-service/en" class="link-group-item mb-1 d-block" aria-label="At your service - Home">
+                            <span>Home</span>
+                        </a>
+                    </nav>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="d-block d-md-none">
+        <div class="footerLinkToggle separator separator-dotted separator-2x mb-5 mt-5 collapsed">
+            <a class="erpl_toggle-menu" href="#website-links"
+               title="Toggle linked links"
+               role="button"
+               data-toggle="collapse"
+               data-target="#website-links-items"
+               aria-expanded="false"
+               aria-controls="website-links" aria-label="Toggle linked links">
+                <svg aria-hidden="true" class="es_icon es_icon-plus" data-show-expanded="false">
+                    <use xlink:href="#es_icon-plus"></use>
+                </svg>
+
+                <svg aria-hidden="true" class="es_icon es_icon-minus" data-show-expanded="true">
+                    <use xlink:href="#es_icon-minus"></use>
+                </svg>
+            </a>
+            <a class="erpl_nojs-close-menu" href="#website-links-close"
+               title="Untoggle linked links"
+               role="button"
+               data-toggle="collapse"
+               data-target="#website-links-items"
+               aria-expanded="false"
+               aria-controls="website-links" aria-label="Untoggle linked links">
+                <svg aria-hidden="true" class="es_icon es_icon-minus">
+                    <use xlink:href="#es_icon-minus"></use>
+                </svg>
+            </a>
+        </div>
+    </div>
+</nav>
+                <nav class="col-12 col-xl-3 text-center text-md-left" id="europarl-links" aria-label="Europarl links">
+    <div class="separator separator-dotted separator-2x mt-3 mb-4 d-none d-md-flex d-xl-none"></div>
+    <h3 class="erpl_title-h3 mb-2 text-white">European Parliament</h3>
+    <div class="collapse show" id="europarl-links-items">
+        <nav class="link-group pt-25 t-x-mode" aria-label="European Parliament">
+            <a href="https://www.europarl.europa.eu/news/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - News">
+                <span>News</span></a><a href="https://www.europarl.europa.eu/topics/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Topics">
+                <span>Topics</span></a><a href="https://www.europarl.europa.eu/meps/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - MEPs">
+                <span>MEPs</span></a><a href="https://www.europarl.europa.eu/about-parliament/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - About Parliament">
+                <span>About Parliament</span></a><a href="https://www.europarl.europa.eu/plenary/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Plenary">
+                <span>Plenary</span></a><a href="https://www.europarl.europa.eu/committees/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Committees">
+                <span>Committees</span></a><a href="https://www.europarl.europa.eu/delegations/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Delegations">
+                <span>Delegations</span></a><a href="https://elections.europa.eu/en/" class="link-group-item mb-1 d-block" aria-label="European Parliament - Elections">
+                <span>Elections</span></a>
+        </nav>
+    </div>
+    <div class="d-block d-md-none">
+        <div class="footerLinkToggle separator separator-dotted separator-2x mb-5 mt-5 collapsed">
+            <a href="#europarl-links"
+               title="Toggle European Parliament websites"
+               role="button"
+               data-toggle="collapse"
+               data-target="#europarl-links-items"
+               aria-expanded="false"
+               aria-controls="europarl-links" aria-label="Toggle European Parliament websites">
+                <svg aria-hidden="true" class="es_icon es_icon-plus" data-show-expanded="false">
+                    <use xlink:href="#es_icon-plus"></use>
+                </svg>
+
+                <svg aria-hidden="true" class="es_icon es_icon-minus" data-show-expanded="true">
+                    <use xlink:href="#es_icon-minus"></use>
+                </svg>
+            </a>
+            <a class="erpl_nojs-close-menu" href="#europarl-links-close"
+               title="Untoggle European Parliament websites"
+               role="button" data-toggle="collapse"
+               data-target="#europarl-links-items"
+               aria-expanded="false"
+               aria-controls="europarl-links" aria-label="Untoggle European Parliament websites">
+                <svg aria-hidden="true" class="es_icon es_icon-minus">
+                    <use xlink:href="#es_icon-minus"></use>
+                </svg>
+            </a>
+        </div>
+    </div>
+</nav>
+            </div>
+
+
+            <div class="separator separator-dotted separator-2x mt-3 mb-3 d-none d-md-flex"></div>
+            <div class="row">
+                <nav class="col-12" id="social-links" aria-label="Social links">
+                    <div class="erpl_social-links mb-2">
+                        
+                            <a  data-toggle="tooltip" title="Check out Parliament on Facebook" href="https://www.facebook.com/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-facebook-color">
+                                    <use href="#es_icon-facebook-color"></use>
+                                </svg>
+                                <span class="sr-only">Facebook</span>
+                            </a>
+                        
+                            <a  data-toggle="tooltip" title="Check out Parliament on X" href="https://x.com/Europarl_en" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-twitter-x">
+                                    <use href="#es_icon-twitter-x"></use>
+                                </svg>
+                                <span class="sr-only">Twitter</span>
+                            </a>
+                        
+                            <a  data-toggle="tooltip" title="Check out Parliament on Flickr" href="https://www.flickr.com/photos/european_parliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-flickr-color">
+                                    <use href="#es_icon-flickr-color"></use>
+                                </svg>
+                                <span class="sr-only">Flickr</span>
+                            </a>
+                        
+                            <a  data-toggle="tooltip" title="Check out Parliament on LinkedIn" href="https://www.linkedin.com/company/european-parliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-linkedin-color">
+                                    <use href="#es_icon-linkedin-color"></use>
+                                </svg>
+                                <span class="sr-only">LinkedIn</span>
+                            </a>
+                        
+                            <a  data-toggle="tooltip" title="Check out Parliament on YouTube" href="https://www.youtube.com/user/EuropeanParliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-youtube-color">
+                                    <use href="#es_icon-youtube-color"></use>
+                                </svg>
+                                <span class="sr-only">YouTube</span>
+                            </a>
+                        
+                            <a  data-toggle="tooltip" title="Check out Parliament on Instagram" href="https://www.instagram.com/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-instagram-color">
+                                    <use href="#es_icon-instagram-color"></use>
+                                </svg>
+                                <span class="sr-only">Instagram</span>
+                            </a>
+                        
+                            <a  data-toggle="tooltip" title="Check out Parliament on Pinterest" href="https://www.pinterest.fr/epinfographics" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-pinterest-color">
+                                    <use href="#es_icon-pinterest-color"></use>
+                                </svg>
+                                <span class="sr-only">Pinterest</span>
+                            </a>
+                        
+                            <a  data-toggle="tooltip" title="Check out Parliament on Reddit" href="https://www.reddit.com/r/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-reddit-color">
+                                    <use href="#es_icon-reddit-color"></use>
+                                </svg>
+                                <span class="sr-only">Reddit</span>
+                            </a>
+                        
+                    </div>
+                </nav>
+            </div>
+            <div class="row">
+                <nav id="information-links" class="col-12 small text-center text-white font-weight-bold t-y-mode" aria-label="Information links">
+                    
+                        <a href="https://www.europarl.europa.eu/portal/en/contact" class="mr-2 mb-1">
+                            <span>Contact</span>
+                        </a>
+                    
+                        <a href="https://www.europarl.europa.eu/portal/en/sitemap" class="mr-2 mb-1">
+                            <span>Sitemap</span>
+                        </a>
+                    
+                        <a href="https://www.europarl.europa.eu/legal-notice/en" class="mr-2 mb-1">
+                            <span>Legal notice</span>
+                        </a>
+                    
+                        <a href="https://www.europarl.europa.eu/privacy-policy/en" class="mr-2 mb-1">
+                            <span>Privacy policy</span>
+                        </a>
+                    
+                        <a href="https://www.europarl.europa.eu/portal/en/accessibility" class="mr-2 mb-1">
+                            <span>Accessibility</span>
+                        </a>
+                    
+                </nav>
+            </div>
+        </div>
+    </div>
+</footer>
+
+    
+    <script src="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/lib/jquery/jquery.min.js"></script>
+    
+    <script id="evostrap" src="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/dist/js/evostrap.js"></script>
+    <script src="https://www.europarl.europa.eu/commonFrontResources/evostrap-oeil/1.0.0//dist/js/oeil.js"></script>
+
+    
+    <script src="/oeil/oeil-addons/documents-loading.js"></script>
+    <script src="/oeil/oeil-addons/session-calendar.js"></script>
+    <script src="/oeil/oeil-addons/tools.js"></script>
+    <script src="/oeil/oeil-addons/meetings-list.js"></script>
+
+    
+    <script type="text/javascript" defer data-tracker-name="ATInternet"
+            data-value="https://www.europarl.europa.eu/website/webanalytics/ati-oeil.js"
+            src="https://www.europarl.europa.eu/website/privacy-policy/privacy-policy.js">
+    </script>
+
+    
+    
+    <script src="/oeil/oeil-addons/scroll-spy.js"></script>
+
+</body>
+</html>

--- a/backend/tests/pipelines/test_rcv_list.py
+++ b/backend/tests/pipelines/test_rcv_list.py
@@ -3,26 +3,24 @@ import datetime
 import pytest
 from sqlalchemy import select
 
-from howtheyvote.models import Group, GroupMembership, Member, PipelineStatus, Vote
+from howtheyvote.models import (
+    Committee,
+    Group,
+    GroupMembership,
+    Member,
+    MemberVote,
+    OEILSubject,
+    PipelineStatus,
+    Vote,
+    VotePosition,
+)
 from howtheyvote.pipelines import RCVListPipeline
 
 from ..helpers import load_fixture
 
 
-@pytest.mark.always_mock_requests
-def test_run_source_not_available(responses, db_session):
-    pipe = RCVListPipeline(term=9, date=datetime.date(2024, 4, 10))
-    result = pipe.run()
-    assert result.status == PipelineStatus.DATA_UNAVAILABLE
-
-
-@pytest.mark.always_mock_requests
-def test_run_data_unchanged(responses, db_session):
-    responses.get(
-        "https://www.europarl.europa.eu/doceo/document/PV-9-2024-04-24-RCV_FR.xml",
-        body=load_fixture("pipelines/data/rcv-list_pv-9-2024-04-24-rcv-fr-noon.xml"),
-    )
-
+@pytest.fixture
+def member(db_session):
     member = Member(
         id=197490,
         first_name="Magdalena",
@@ -36,8 +34,68 @@ def test_run_data_unchanged(responses, db_session):
             ),
         ],
     )
+
     db_session.add(member)
     db_session.commit()
+
+    yield member
+
+
+@pytest.mark.always_mock_requests
+def test_run_source_not_available(responses, db_session):
+    pipe = RCVListPipeline(term=9, date=datetime.date(2024, 4, 10))
+    result = pipe.run()
+    assert result.status == PipelineStatus.DATA_UNAVAILABLE
+
+
+@pytest.mark.always_mock_requests
+def test_run(responses, db_session, member, mocker):
+    responses.get(
+        "https://www.europarl.europa.eu/doceo/document/PV-9-2024-04-24-RCV_FR.xml",
+        body=load_fixture("pipelines/data/rcv-list_pv-9-2024-04-24-rcv-fr-noon.xml"),
+    )
+    responses.get(
+        "https://www.europarl.europa.eu/doceo/document/A-9-2024-0163_EN.html",
+        body=load_fixture("pipelines/data/document_a-9-2024-0163-en.html"),
+    )
+    responses.get(
+        "https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2024/2006(REG)",
+        body=load_fixture("pipelines/data/oeil_2024-2006-reg.html"),
+    )
+
+    mock = mocker.patch("howtheyvote.pipelines.rcv_list.send_notification")
+
+    # Run the pipeline for the first time
+    RCVListPipeline(term=9, date=datetime.date(2024, 4, 24)).run()
+
+    votes = list(db_session.execute(select(Vote)).scalars())
+    assert len(votes) == 1
+
+    assert votes[0].id == 168834
+    assert votes[0].term == 9
+    assert votes[0].title is None
+    assert (
+        votes[0].procedure_title
+        == "EP\xa0Rules of Procedure: training on preventing conflict and harassment in the workplace and on good office management"
+    )
+    assert votes[0].reference == "A9-0163/2024"
+    assert votes[0].procedure_reference == "2024/2006(REG)"
+    assert votes[0].responsible_committees == [Committee["AFCO"]]
+    assert votes[0].oeil_subjects == [OEILSubject["8.40.01.08"]]
+    assert votes[0].member_votes == [MemberVote(web_id=197490, position=VotePosition.FOR)]
+
+    # Push notification is sent after pipeline has completed successfully
+    assert mock.call_count == 1
+    assert mock.call_args.kwargs["title"] == "Scraped RCV list for Wed, Apr 24"
+    assert mock.call_args.kwargs["message"] == "1 votes, 1 vote groups"
+
+
+@pytest.mark.always_mock_requests
+def test_run_data_unchanged(responses, db_session, member):
+    responses.get(
+        "https://www.europarl.europa.eu/doceo/document/PV-9-2024-04-24-RCV_FR.xml",
+        body=load_fixture("pipelines/data/rcv-list_pv-9-2024-04-24-rcv-fr-noon.xml"),
+    )
 
     # Run the pipeline for the first time
     pipe = RCVListPipeline(

--- a/backend/tests/worker/test_init.py
+++ b/backend/tests/worker/test_init.py
@@ -4,7 +4,12 @@ import time_machine
 from sqlalchemy import select
 
 from howtheyvote.models import PipelineRun, PipelineStatus, PlenarySession
-from howtheyvote.pipelines import PipelineResult, PressPipeline, RCVListPipeline
+from howtheyvote.pipelines import (
+    PipelineResult,
+    PressPipeline,
+    RCVListPipeline,
+    VOTListPipeline,
+)
 from howtheyvote.worker import get_worker
 
 
@@ -18,8 +23,12 @@ def test_rcv_list_pipeline(db_session, mocker):
     db_session.commit()
 
     rcv_mock = mocker.patch.object(RCVListPipeline, "run")
-    press_mock = mocker.patch.object(PressPipeline, "run")
 
+    # TODO: For some reason tests will take a very long time if we do not mock the
+    # press pipeline. Probably that's because it’s being executed many times due to
+    # time travel, and each time it’s retrying requests over and over again. But
+    # should double-check that.
+    press_mock = mocker.patch.object(PressPipeline, "run")
     press_mock.return_value = PipelineResult(
         status=PipelineStatus.SUCCESS,
         checksum=None,
@@ -200,3 +209,87 @@ def test_rcv_list_notification(db_session, mocker):
         # A notification has been sent because the pipeline hasn’t been executed successfully
         assert pushover_mock.call_count == 1
         assert pushover_mock.call_args.kwargs["title"] == "No RCV List found at end of day"
+
+
+def test_vot_list_pipeline(db_session, mocker):
+    plenary_session = PlenarySession(
+        id="2025-07-07",
+        start_date=datetime.date(2025, 7, 7),
+        end_date=datetime.date(2025, 7, 10),
+    )
+    db_session.add(plenary_session)
+    db_session.commit()
+
+    vot_mock = mocker.patch.object(
+        VOTListPipeline,
+        "run",
+        autospec=True,
+    )
+
+    rcv_mock = mocker.patch.object(RCVListPipeline, "run")
+    rcv_mock.return_value = PipelineResult(
+        status=PipelineStatus.SUCCESS,
+        checksum=None,
+    )
+
+    press_mock = mocker.patch.object(PressPipeline, "run")
+    press_mock.return_value = PipelineResult(
+        status=PipelineStatus.SUCCESS,
+        checksum=None,
+    )
+
+    query = (
+        select(PipelineRun)
+        .where(PipelineRun.pipeline == VOTListPipeline.__name__)
+        .order_by(PipelineRun.started_at)
+    )
+
+    # Tuesday, July 8th, at midnight
+    with time_machine.travel("2025-07-08T00:10:00+02:00"):
+        # Create worker and schedule pipelines
+        worker = get_worker()
+
+    # Tuesday, July 8th, at 21:00 am
+    with time_machine.travel("2025-07-08T21:00:00+02:00"):
+        vot_mock.return_value = PipelineResult(
+            status=PipelineStatus.DATA_UNAVAILABLE,
+            checksum=None,
+        )
+
+        worker.run_pending()
+
+        # The pipeline has been run once for Monday
+        runs = list(db_session.execute(query).scalars())
+        assert len(runs) == 1
+        assert runs[0].status == PipelineStatus.DATA_UNAVAILABLE
+        assert vot_mock.call_args_list[0].args[0].date == datetime.date(2025, 7, 7)
+
+    # Wednesday, July 9th, at 21:00 am
+    with time_machine.travel("2025-07-09T21:00:00+02:00"):
+        vot_mock.return_value = PipelineResult(
+            status=PipelineStatus.SUCCESS,
+            checksum=None,
+        )
+
+        worker.run_pending()
+
+        # The pipeline has been run one more time for Monday and once for Tuesday
+        runs = list(db_session.execute(query).scalars())
+        assert len(runs) == 3
+
+        assert runs[1].status == PipelineStatus.SUCCESS
+        assert vot_mock.call_args_list[1].args[0].date == datetime.date(2025, 7, 8)
+
+        assert runs[2].status == PipelineStatus.SUCCESS
+        assert vot_mock.call_args_list[2].args[0].date == datetime.date(2025, 7, 7)
+
+    # Thursday, July 10th, at 21:00 am
+    with time_machine.travel("2025-07-10T21:00:00+02:00"):
+        worker.run_pending()
+
+        # The pipeline has been run once for Wednesday
+        runs = list(db_session.execute(query).scalars())
+        assert len(runs) == 4
+
+        assert runs[3].status == PipelineStatus.SUCCESS
+        assert vot_mock.call_args_list[3].args[0].date == datetime.date(2025, 7, 9)

--- a/backend/tests/worker/test_init.py
+++ b/backend/tests/worker/test_init.py
@@ -1,0 +1,202 @@
+import datetime
+
+import time_machine
+from sqlalchemy import select
+
+from howtheyvote.models import PipelineRun, PipelineStatus, PlenarySession
+from howtheyvote.pipelines import PipelineResult, PressPipeline, RCVListPipeline
+from howtheyvote.worker import get_worker
+
+
+def test_rcv_list_pipeline(db_session, mocker):
+    plenary_session = PlenarySession(
+        id="2025-07-07",
+        start_date=datetime.date(2025, 7, 7),
+        end_date=datetime.date(2025, 7, 10),
+    )
+    db_session.add(plenary_session)
+    db_session.commit()
+
+    rcv_mock = mocker.patch.object(RCVListPipeline, "run")
+    press_mock = mocker.patch.object(PressPipeline, "run")
+
+    press_mock.return_value = PipelineResult(
+        status=PipelineStatus.SUCCESS,
+        checksum=None,
+    )
+
+    query = (
+        select(PipelineRun)
+        .where(PipelineRun.pipeline == RCVListPipeline.__name__)
+        .order_by(PipelineRun.started_at)
+    )
+
+    # Tuesday, July 8th, at midnight
+    with time_machine.travel("2025-07-08T00:00:00+02:00"):
+        # Create worker and schedule pipelines
+        worker = get_worker()
+
+    # Tuesday, July 8th, at 12:00 pm
+    with time_machine.travel("2025-07-08T12:00:00+02:00"):
+        rcv_mock.return_value = PipelineResult(
+            status=PipelineStatus.DATA_UNAVAILABLE,
+            checksum=None,
+        )
+
+        worker.run_pending()
+
+        # The pipeline has been run once, but the data wasn’t available yet
+        runs = list(db_session.execute(query).scalars())
+        assert len(runs) == 1
+        assert runs[0].status == PipelineStatus.DATA_UNAVAILABLE
+
+    # Tuesday, July 8th, at 12:10 pm
+    with time_machine.travel("2025-07-08T12:10:00+02:00"):
+        rcv_mock.return_value = PipelineResult(
+            status=PipelineStatus.SUCCESS,
+            checksum="123abc",
+        )
+
+        worker.run_pending()
+
+        # The pipeline has been run a second time and has successfully fetched the data
+        runs = list(db_session.execute(query).scalars())
+        assert len(runs) == 2
+        assert runs[1].status == PipelineStatus.SUCCESS
+        assert runs[1].checksum == "123abc"
+
+    # Tuesday, July 8th, at 12:20 pm
+    with time_machine.travel("2025-07-08T12:20:00+02:00"):
+        worker.run_pending()
+
+        # The pipeline hasn’t been run again as it was successfully run before
+        runs = list(db_session.execute(query).scalars())
+        assert len(runs) == 2
+
+    # Tuesday, July 8th, at 5:00 pm
+    with time_machine.travel("2025-07-08T17:00:00+02:00"):
+        rcv_mock.return_value = PipelineResult(
+            status=PipelineStatus.DATA_UNCHANGED,
+            checksum=None,
+        )
+
+        worker.run_pending()
+
+        # The pipeline has been run again to check for another voting session in
+        # the evening, but the data hasn’t changed
+        runs = list(db_session.execute(query).scalars())
+        assert len(runs) == 3
+        assert runs[2].status == PipelineStatus.DATA_UNCHANGED
+
+    # Tuesday, July 8th, at 5:10 pm
+    with time_machine.travel("2025-07-08T17:10:00+02:00"):
+        rcv_mock.return_value = PipelineResult(
+            status=PipelineStatus.SUCCESS,
+            checksum=None,
+        )
+
+        worker.run_pending()
+
+        # The pipeline has been run again and has successfully fetched the data
+        runs = list(db_session.execute(query).scalars())
+        assert len(runs) == 4
+        assert runs[3].status == PipelineStatus.SUCCESS
+
+    # Tuesday, July 8th, at 08:00 pm
+    with time_machine.travel("2025-07-08T20:00:00+02:00"):
+        worker.run_pending()
+
+        # The pipeline hasn’t been run again as it has already succeeded twice that day
+        runs = list(db_session.execute(query).scalars())
+        assert len(runs) == 4
+
+    # Wednesday, July 9th, at 12:00 pm
+    with time_machine.travel("2025-07-09T12:00:00+02:00"):
+        rcv_mock.return_value = PipelineResult(
+            status=PipelineStatus.SUCCESS,
+            checksum=None,
+        )
+
+        worker.run_pending()
+
+        # The pipeline has been executed again, as it’s the next day
+        runs = list(db_session.execute(query).scalars())
+        assert len(runs) == 5
+        assert runs[4].status == PipelineStatus.SUCCESS
+
+
+def test_rcv_list_notification(db_session, mocker):
+    plenary_session = PlenarySession(
+        id="2025-07-07",
+        start_date=datetime.date(2025, 7, 7),
+        end_date=datetime.date(2025, 7, 10),
+    )
+    db_session.add(plenary_session)
+    db_session.commit()
+
+    rcv_mock = mocker.patch.object(RCVListPipeline, "run")
+    press_mock = mocker.patch.object(PressPipeline, "run")
+
+    press_mock.return_value = PipelineResult(
+        status=PipelineStatus.SUCCESS,
+        checksum=None,
+    )
+
+    pushover_mock = mocker.patch("howtheyvote.worker.send_notification")
+
+    query = (
+        select(PipelineRun)
+        .where(PipelineRun.pipeline == RCVListPipeline.__name__)
+        .order_by(PipelineRun.started_at)
+    )
+
+    # Tuesday, July 8th, at 07:45 pm
+    with time_machine.travel("2025-07-08T19:45:00+02:00"):
+        # Create worker and schedule pipelines
+        worker = get_worker()
+
+    # Tuesday, July 8th, at 07:50 pm
+    with time_machine.travel("2025-07-08T19:50:00+02:00"):
+        rcv_mock.return_value = PipelineResult(
+            status=PipelineStatus.SUCCESS,
+            checksum=None,
+        )
+
+        worker.run_pending()
+
+        runs = list(db_session.execute(query).scalars())
+        assert len(runs) == 1
+        assert runs[0].status == PipelineStatus.SUCCESS
+
+    # Tuesday, July 8th, at 08:00 pm
+    with time_machine.travel("2025-07-08T20:00:00+02:00"):
+        worker.run_pending()
+
+        # No notification has been sent because the pipeline has been executed successfully
+        assert pushover_mock.call_count == 0
+
+    # Wednesday, July 9th, at 07:45 pm
+    with time_machine.travel("2025-07-09T19:45:00+02:00"):
+        # Create worker and schedule pipelines
+        worker = get_worker()
+
+    # Wednesday, July 9th, at 07:50 pm
+    with time_machine.travel("2025-07-09T19:50:00+02:00"):
+        rcv_mock.return_value = PipelineResult(
+            status=PipelineStatus.DATA_UNAVAILABLE,
+            checksum=None,
+        )
+
+        worker.run_pending()
+
+        runs = list(db_session.execute(query).scalars())
+        assert len(runs) == 2
+        assert runs[1].status == PipelineStatus.DATA_UNAVAILABLE
+
+    # Wednesday, July 9th, at 08:00 pm
+    with time_machine.travel("2025-07-09T20:00:00+02:00"):
+        worker.run_pending()
+
+        # A notification has been sent because the pipeline hasn’t been executed successfully
+        assert pushover_mock.call_count == 1
+        assert pushover_mock.call_args.kwargs["title"] == "No RCV List found at end of day"

--- a/backend/tests/worker/test_init.py
+++ b/backend/tests/worker/test_init.py
@@ -208,7 +208,7 @@ def test_rcv_list_notification_no_votes(db_session, mocker):
 
         # A notification has been sent because the pipeline hasn’t been executed successfully
         assert pushover_mock.call_count == 1
-        assert pushover_mock.call_args.kwargs["title"] == "No RCV List found at end of day"
+        assert pushover_mock.call_args.kwargs["title"] == "No RCV list found at end of day"
 
 
 def test_vot_list_pipeline(db_session, mocker):

--- a/backend/tests/worker/test_init.py
+++ b/backend/tests/worker/test_init.py
@@ -134,7 +134,7 @@ def test_rcv_list_pipeline(db_session, mocker):
         assert runs[4].status == PipelineStatus.SUCCESS
 
 
-def test_rcv_list_notification(db_session, mocker):
+def test_rcv_list_notification_no_votes(db_session, mocker):
     plenary_session = PlenarySession(
         id="2025-07-07",
         start_date=datetime.date(2025, 7, 7),

--- a/backend/tests/worker/test_worker.py
+++ b/backend/tests/worker/test_worker.py
@@ -239,7 +239,7 @@ def test_worker_schedule_pipeline_idempotency_key_success(db_session):
             handler=pipeline_handler,
             name="test",
             hours={9, 10},
-            idempotency_key=lambda: datetime.date.today().isoformat(),
+            idempotency_key_func=lambda: datetime.date.today().isoformat(),
         )
 
     # At 9 am, the pipeline is executed for the first time.
@@ -303,7 +303,7 @@ def test_worker_schedule_pipeline_idempotency_key_error(db_session):
             handler=pipeline_handler,
             name="test",
             hours={9, 10},
-            idempotency_key=lambda: datetime.date.today().isoformat(),
+            idempotency_key_func=lambda: datetime.date.today().isoformat(),
         )
 
     # At 9 am, the pipeline is executed for the first time and it fails

--- a/backend/tests/worker/test_worker.py
+++ b/backend/tests/worker/test_worker.py
@@ -9,7 +9,6 @@ from howtheyvote.worker.worker import (
     Weekday,
     Worker,
     last_pipeline_run_checksum,
-    pipeline_ran_successfully,
 )
 
 
@@ -332,48 +331,6 @@ def test_worker_schedule_pipeline_idempotency_key_error(db_session):
         assert runs[1].pipeline == "test"
         assert runs[1].status == PipelineStatus.SUCCESS
         assert runs[1].started_at.date() == datetime.date(2024, 1, 1)
-
-
-def test_pipeline_ran_successfully(db_session):
-    class TestPipeline:
-        pass
-
-    now = datetime.datetime.now()
-    today = now.date()
-
-    run = PipelineRun(
-        started_at=now,
-        finished_at=now,
-        pipeline=TestPipeline.__name__,
-        status=PipelineStatus.FAILURE,
-    )
-    db_session.add(run)
-    db_session.commit()
-
-    assert pipeline_ran_successfully(TestPipeline, today) is False
-
-    run = PipelineRun(
-        started_at=now,
-        finished_at=now,
-        pipeline=TestPipeline.__name__,
-        status=PipelineStatus.SUCCESS,
-    )
-    db_session.add(run)
-    db_session.commit()
-
-    assert pipeline_ran_successfully(TestPipeline, today) is True
-    assert pipeline_ran_successfully(TestPipeline, today, count=2) is False
-
-    run = PipelineRun(
-        started_at=now,
-        finished_at=now,
-        pipeline=TestPipeline.__name__,
-        status=PipelineStatus.SUCCESS,
-    )
-    db_session.add(run)
-    db_session.commit()
-
-    assert pipeline_ran_successfully(TestPipeline, today, count=2) is True
 
 
 def test_last_pipeline_run_checksum(db_session):


### PR DESCRIPTION
VOT lists currently have to be run manually. In contrast to RCV lists, VOT lists are usually published with at least one day of delay. That means we have to retry fetching VOT lists for multiple days until the data becomes available.

To solve this, I’ve added "idempotency keys" to scheduled pipelines. If such a key is given, a pipeline will only be executed until it has been executed successfully for the first time.

As the existing scheduling logic for RCV pipelines was mostly untested, I’ve added test coverage and then refactored it to also make use of idempotency keys.

Finally, I’ve added the actual scheduling of VOT lists.

Most of the diff is due to new tests, the number of lines added for the idempotency keys is fairly small. It works quite well for the RCV use case, but I think the scheduling of the VOT lists is a bit unintuitive. Not sure what a better/simpler solution would be though.

I’d recommend going through the changes commit by commit.