### PR TITLE
Don’t run test against live data (to fix scheduled scraper tests)

### DIFF
--- a/backend/tests/scrapers/test_votes.py
+++ b/backend/tests/scrapers/test_votes.py
@@ -251,6 +251,7 @@ def test_vot_list_scraper(responses):
     }
 
 
+@pytest.mark.always_mock_requests
 def test_vot_list_scraper_french(responses):
     responses.get(
         "https://www.europarl.europa.eu/doceo/document/PV-10-2025-05-22-VOT_EN.xml",


### PR DESCRIPTION
This test ensures that the `VOTListScraper` doesn’t use a French version of the VOT list when the English translation isn’t yet available. There’s no way to test this against live data (except in the short time frame between a session and the time when the translations are published).