### PR TITLE
Add CLI command to delete fragments

### DIFF
--- a/backend/howtheyvote/cli/__init__.py
+++ b/backend/howtheyvote/cli/__init__.py
@@ -11,6 +11,7 @@ from ..sharepics import generate_vote_sharepic
 from ..worker import worker as worker_
 from .aggregate import aggregate
 from .dev import dev
+from .flush import flush
 from .pipeline import pipeline
 from .system import system
 from .temp import temp
@@ -39,3 +40,4 @@ cli.add_command(aggregate)
 cli.add_command(pipeline)
 cli.add_command(dev)
 cli.add_command(temp)
+cli.add_command(flush)

--- a/backend/howtheyvote/cli/flush.py
+++ b/backend/howtheyvote/cli/flush.py
@@ -1,0 +1,54 @@
+import datetime
+
+import click
+from sqlalchemy import delete, func, select
+
+from ..db import Session
+from ..models import Fragment, Vote
+
+
+@click.group()
+def flush() -> None:
+    """Flush fragments."""
+    pass
+
+
+@flush.command()
+@click.option("--id", "vote_ids", type=int, multiple=True)
+@click.option("--date", "dates", type=click.DateTime(formats=["%Y-%m-%d"]), multiple=True)
+@click.option("--source-name", "source_names", multiple=True)
+def votes(
+    vote_ids: list[str],
+    dates: list[datetime.datetime] | None,
+    source_names: list[str],
+) -> None:
+    """Flush votes fragments."""
+    if not vote_ids and not dates and not source_names:
+        raise click.UsageError("Provide at least one option to filter fragments.")
+
+    votes_query = select(Vote.id)
+
+    if vote_ids:
+        votes_query = votes_query.where(Vote.id.in_(vote_ids))
+
+    if dates:
+        votes_query = votes_query.where(
+            func.date(Vote.timestamp).in_(date.date() for date in dates)
+        )
+
+    where = [
+        Fragment.model == Vote.__name__,
+        Fragment.group_key.in_(votes_query),
+    ]
+
+    if source_names:
+        where.append(Fragment.source_name.in_(source_names))
+
+    count = Session.execute(select(func.count()).select_from(Fragment).where(*where)).scalar()
+
+    click.confirm(f"This will delete {count} fragments. Continue?", abort=True)
+
+    result = Session.execute(delete(Fragment).where(*where))
+    Session.commit()
+
+    click.echo(f"Deleted {result.rowcount} fragments.")


### PR DESCRIPTION
Pipelines/scrapers only insert or update fragments, but they never delete them. That means if a fragment has been written erroneously (either because of an error in the source data or because of a bug in the software) it has to be deleted explicitly.

This adds a CLI command to manually delete fragments. Usage examples:

```
htv flush votes --id 12345
htv flush votes --id 12345 --id 67890
htv flush votes --date 2025-09-20
htv flush votes --source-name RCVListScraper
htv flush votes --source-name RCVListScraper --id 12345
```

Fixes #1171