### PR TITLE
Add aliases for commonly used CLI commands

### DIFF
--- a/backend/howtheyvote/cli/__init__.py
+++ b/backend/howtheyvote/cli/__init__.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 
 import click
+from click_aliases import ClickAliasedGroup
 
 from ..db import Session
 from ..export import generate_export
@@ -17,7 +18,7 @@ from .system import system
 from .temp import temp
 
 
-@click.group()
+@click.group(cls=ClickAliasedGroup)
 def cli() -> None:
     pass
 
@@ -35,9 +36,9 @@ def export() -> None:
     generate_export(archive_path)
 
 
-cli.add_command(system)
-cli.add_command(aggregate)
-cli.add_command(pipeline)
+cli.add_command(system, aliases=["sys"])
+cli.add_command(aggregate, aliases=["agg"])
+cli.add_command(pipeline, aliases=["pipe"])
 cli.add_command(dev)
 cli.add_command(temp)
 cli.add_command(flush)

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -236,6 +236,21 @@ files = [
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
+name = "click-aliases"
+version = "1.0.5"
+description = "Add (mutiple) aliases to a click group or command"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "click_aliases-1.0.5-py3-none-any.whl", hash = "sha256:cbb83a348acc00809fe18b6da13a7f6307bc71b3c5f69cc730e012dfb4bbfdc3"},
+    {file = "click_aliases-1.0.5.tar.gz", hash = "sha256:e37d4cabbaad68e1c48ec0f063a59dfa15f0e7450ec901bd1ce4f4b954bc881d"},
+]
+
+[package.dependencies]
+click = ">=8.1.7,<9.0.0"
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -1687,4 +1702,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "0047317ba2e8bd6ed43c96b7ca097acd1d12b856d815dece9c1161b0b74f9b74"
+content-hash = "e03ca6bf4c00983b651642a918637c1d838f40f398b3edb0e1144eed773286fe"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pytz>=2025.1",
     "websocket-client>=1.8.0",
     "tabulate>=0.9.0",
+    "click-aliases (>=1.0.5,<2.0.0)",
 ]
 
 [tool.poetry]


### PR DESCRIPTION
This is purely for convenience, but I keep typing `htv pipeline rcv-list` or `htv aggregate votes` over and over again, and being able to type just `htv pipe rcv` or `htv agg votes` would be nice. Not a huge fan of including dependencies for such minor functionality, but given that we can easily remove this again at any time or even copy/paste a single class into our repo without breaking anything, I think it’s ok.