### PR TITLE
Index members before downloading MEP photos

### DIFF
--- a/backend/howtheyvote/pipelines/members.py
+++ b/backend/howtheyvote/pipelines/members.py
@@ -28,8 +28,8 @@ class MembersPipeline(BasePipeline):
         self._scrape_members()
         self._scrape_member_groups()
         self._scrape_member_infos()
-        self._download_member_photos()
         self._index_members()
+        self._download_member_photos()
 
     def _scrape_members(self) -> None:
         log.info("Scraping RCV lists", term=self.term)


### PR DESCRIPTION
I just waited for a long amount of time that the members get indexed so that I can run dependent RCV scrapers. This should make it possible to earlier stop the member scraper while still preserving the warranted result. 

Disclaimer: I have not tested this and while I am 90% certain this is okay smart, it is also quite late. Hence, this is a separate one-line PR.