### PR TITLE
Collapse specific delimiters directly following each other

### DIFF
--- a/backend/howtheyvote/scrapers/helpers.py
+++ b/backend/howtheyvote/scrapers/helpers.py
@@ -209,14 +209,18 @@ def parse_amendment_authors(raw_authors: str) -> list[AmendmentAuthor]:
     # If a newline or a comma is used as the delimiter, we can simply split the text
     if delimiter:
         for raw_author in raw_authors.split(delimiter):
-            authors.extend(parse_amendment_authors(raw_author))
+            # Ignore cases where additional, unnecessary white-space delimiters are present
+            raw_author = raw_author.strip()
+
+            if raw_author:
+                authors.extend(parse_amendment_authors(raw_author))
 
         return authors
 
     # If a space is used as the delimiter, we need to differentiate between spaces used as a
     # delimiter and spaces that a part of an author label. We start by splitting the text into
     # tokens. We then try to parse just the first token. If that fails, we try parsing the
-    # frist two tokens as an author, etc.
+    # first two tokens as an author, etc.
     #
     # For example, in case of the raw authors string "Renew The Left Members":
     #

--- a/backend/tests/scrapers/test_helpers.py
+++ b/backend/tests/scrapers/test_helpers.py
@@ -254,6 +254,14 @@ def test_parse_amendment_authors():
         AmendmentAuthorGroup(group=Group["GREEN_EFA"]),
     ]
 
+    # Multiple group authors, delimiter followed by additional whitespace
+    # A real-life example can be found here:
+    # https://www.europarl.europa.eu/doceo/document/PV-10-2025-10-22-VOT_EN.xml
+    assert parse_amendment_authors("S&D,\nRenew") == [
+        AmendmentAuthorGroup(group=Group["SD"]),
+        AmendmentAuthorGroup(group=Group["RENEW"]),
+    ]
+
     # Remove group suffix
     assert parse_amendment_authors("The Left Group S&D") == [
         AmendmentAuthorGroup(group=Group["GUE_NGL"]),


### PR DESCRIPTION
This is the reason the VOT Pipeline for 22.10. was not scraped correctly. An amendment author tag contains a comma, directly followed by a newline, which breaks the parser. I could not visibly see this issue in my browser, but needed to download the file (and its visible in a debugger session ofc, but I wanted to check in the original). [Source](https://www.europarl.europa.eu/doceo/document/PV-10-2025-10-22-VOT_EN.xml)

I thought a bit about introducing this combination as a new delimiter, but I expect this to be a typo rather than something that happens regularly and I think the current solution has no real downside?

---

Some thoughts as a consequence of this:

- [x] After we merged this, I will rescrape the VOT list for this day. That will complete #1241. (I will look into why an earlier day failed, but that was for an unrelated reason, that much I know)
- [x] This pipeline failed with a ScrapingError after data was available. Again, getting a pushover notification for this would have been nice. I think, with the change we did on Sunday, this should happen now. Just checking in if you'd agree @tillprochaska, otherwise we should keep tabs on this.