### PR TITLE
Generate share-picture for all votes

### DIFF
--- a/backend/howtheyvote/cli/temp.py
+++ b/backend/howtheyvote/cli/temp.py
@@ -43,8 +43,7 @@ def temp() -> None:
 @temp.command()
 def sharepics() -> None:
     """Generate share pictures for all votes."""
-    query = select(Vote).where(Vote.is_main == True)  # noqa: E712
-    votes = Session.execute(query, execution_options={"yield_per": 500}).scalars()
+    votes = Session.execute(select(Vote), execution_options={"yield_per": 500}).scalars()
 
     for vote in votes:
         try:

--- a/backend/howtheyvote/models/vote.py
+++ b/backend/howtheyvote/models/vote.py
@@ -345,8 +345,5 @@ class Vote(BaseWithId):
         return self.title or self.procedure_title
 
     @property
-    def sharepic_url(self) -> str | None:
-        if not self.is_main:
-            return None
-
+    def sharepic_url(self) -> str:
         return url_for("api.static_api.vote_sharepic", vote_id=self.id)

--- a/backend/howtheyvote/pipelines/common.py
+++ b/backend/howtheyvote/pipelines/common.py
@@ -85,10 +85,6 @@ def generate_vote_sharepics(votes: Iterable[Vote]) -> None:
     success_count = 0
 
     for vote in votes:
-        if not vote.is_main:
-            log.info("Skipping sharepic generation because vote is not main.", vote_id=vote.id)
-            continue
-
         log.info("Generating vote sharepic.", vote_id=vote.id)
 
         try:

--- a/backend/tests/worker/test_init.py
+++ b/backend/tests/worker/test_init.py
@@ -14,6 +14,10 @@ from howtheyvote.worker import get_worker
 
 
 def test_rcv_list_pipeline(db_session, mocker):
+    # Same as below, not patching these make the test extremely slow
+    mocker.patch("howtheyvote.pipelines.rcv_list.generate_vote_sharepics", return_value=None)
+    mocker.patch("howtheyvote.pipelines.vot_list.generate_vote_sharepics", return_value=None)
+
     plenary_session = PlenarySession(
         id="2025-07-07",
         start_date=datetime.date(2025, 7, 7),

--- a/backend/tests/worker/test_init.py
+++ b/backend/tests/worker/test_init.py
@@ -14,10 +14,6 @@ from howtheyvote.worker import get_worker
 
 
 def test_rcv_list_pipeline(db_session, mocker):
-    # Same as below, not patching these make the test extremely slow
-    mocker.patch("howtheyvote.pipelines.rcv_list.generate_vote_sharepics", return_value=None)
-    mocker.patch("howtheyvote.pipelines.vot_list.generate_vote_sharepics", return_value=None)
-
     plenary_session = PlenarySession(
         id="2025-07-07",
         start_date=datetime.date(2025, 7, 7),

--- a/frontend/src/pages/VotePage.tsx
+++ b/frontend/src/pages/VotePage.tsx
@@ -221,7 +221,7 @@ function MetaTags({ vote }: { vote: Vote }) {
   const stats = vote.stats.total;
   const total = stats.FOR + stats.AGAINST + stats.ABSTENTION;
 
-  const altText = `A barchart visualizing the result of a European Parliament vote. The vote took place on ${date}, and is titled “${vote.display_title}”. The chart has three bars representing the ${stats.FOR} MEPs who voted in favor, the ${stats.AGAINST} MEPs who voted against, and the ${stats.ABSTENTION} MEPs who abstained. A total of ${total} MEPs participated in the vote and ${stats.DID_NOT_VOTE} did not vote.`;
+  const altText = `A barchart visualizing the result of a European Parliament vote. The vote took place on ${date}, and is titled “${vote.display_title + (vote.description ? ` - ${vote.description}` : "")}”. The chart has three bars representing the ${stats.FOR} MEPs who voted in favor, the ${stats.AGAINST} MEPs who voted against, and the ${stats.ABSTENTION} MEPs who abstained. A total of ${total} MEPs participated in the vote and ${stats.DID_NOT_VOTE} did not vote.`;
   const title = `Vote results: ${vote.display_title}`;
   const description =
     "Find out how the Members of the European Parliament voted.";
@@ -229,18 +229,15 @@ function MetaTags({ vote }: { vote: Vote }) {
   return (
     <>
       {!vote.is_main && <meta name="robots" content="noindex" />}
-      {vote.sharepic_url && (
-        <>
-          <meta name="description" content={description} />
-          <meta property="og:site_name" content="HowTheyVote.eu" />
-          <meta property="og:type" content="article" />
-          <meta property="og:title" content={title} />
-          <meta property="og:description" content={description} />
-          <meta property="og:image" content={vote.sharepic_url} />
-          <meta property="og:image:alt" content={altText} />
-          <meta property="article:published_time" content={vote.timestamp} />
-        </>
-      )}
+
+      <meta name="description" content={description} />
+      <meta property="og:site_name" content="HowTheyVote.eu" />
+      <meta property="og:type" content="article" />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={vote.sharepic_url} />
+      <meta property="og:image:alt" content={altText} />
+      <meta property="article:published_time" content={vote.timestamp} />
     </>
   );
 }


### PR DESCRIPTION
Adds the description into the alt text as well and generates share-pictures for all votes. That also means that we generate slightly more pictures than necessary (think of amendments where we dont currently recognize that they are amendments or the agenda motions). However, I think the number is so small in comparison, that it does not matter.

I generated pictures for 22.10 on my local machine and that resulted in close to 200 pictures, totalling 12.5MB.
Rough math yields 1.5GB for pictures for all votes we currently have in the DB.

Closes #1229.