### PR TITLE
Add not voting as a fourth option to barcharts

### DIFF
--- a/frontend/src/components/CountryStatsList.tsx
+++ b/frontend/src/components/CountryStatsList.tsx
@@ -33,7 +33,7 @@ function Item({ country, stats }: ItemProps) {
         </>
       }
       subtitle={subtitle}
-      chart={<VoteResultChart stats={stats} style="slim" />}
+      chart={<VoteResultChart stats={stats} style="slim" includeNoShows={true} />}
     />
   );
 }

--- a/frontend/src/components/GroupStatsList.tsx
+++ b/frontend/src/components/GroupStatsList.tsx
@@ -28,7 +28,7 @@ function Item({ group, stats }: ItemProps) {
       title={`${group.label}`}
       subtitle={subtitle}
       avatar={<Avatar url={avatarUrl} style="square" />}
-      chart={<VoteResultChart stats={stats} style="slim" />}
+      chart={<VoteResultChart stats={stats} style="slim" includeNoShows={true} />}
     />
   );
 }

--- a/frontend/src/components/VoteResultChart.css
+++ b/frontend/src/components/VoteResultChart.css
@@ -58,6 +58,12 @@
   --vote-result-chart-bar-background-color: var(--blue);
 }
 
+.vote-result-chart__bar--did-not-vote {
+  --vote-result-chart-bar-background-color: var(--gray-medium);
+  --vote-result-chart-bar-background-image: var(--green-pattern);
+
+}
+
 @container vote-result-chart-bar (width < 50px) {
   .vote-result-chart__percentage {
     display: none;

--- a/frontend/src/components/VoteResultChart.tsx
+++ b/frontend/src/components/VoteResultChart.tsx
@@ -6,6 +6,7 @@ import "./VoteResultChart.css";
 
 type VoteResultChartProps = {
   stats: VotePositionCounts;
+  includeNoShows?: boolean;
   style?: "slim";
 };
 
@@ -66,14 +67,18 @@ function Summary({ stats }: SummaryProps) {
 export default function VoteResultChart({
   stats,
   style,
+  includeNoShows,
 }: VoteResultChartProps) {
-  const total = stats.FOR + stats.AGAINST + stats.ABSTENTION;
+  let total = stats.FOR + stats.AGAINST + stats.ABSTENTION;
+  if (includeNoShows) total += stats.DID_NOT_VOTE;
   return (
     <figure className={bem("vote-result-chart", style)}>
       <div class="vote-result-chart__bars" aria-hidden="true">
         <Bar position="FOR" value={stats.FOR} total={total} />
         <Bar position="AGAINST" value={stats.AGAINST} total={total} />
         <Bar position="ABSTENTION" value={stats.ABSTENTION} total={total} />
+        { includeNoShows &&         <Bar position="DID_NOT_VOTE" value={stats.DID_NOT_VOTE} total={total} />
+}
       </div>
       <figcaption class={style === "slim" ? "visually-hidden" : undefined}>
         <Summary stats={stats} />

--- a/frontend/src/css/variables.css
+++ b/frontend/src/css/variables.css
@@ -98,6 +98,7 @@
   --gray-s: 35%;
   --gray-l: 52.5%;
   --gray: hsl(var(--gray-h), var(--gray-s), var(--gray-l));
+  --gray-medium: hsl(var(--gray-h), var(--gray-s), calc(var(--gray-l) + 20%));
   --gray-light: hsl(var(--gray-h), var(--gray-s), calc(var(--gray-l) + 35%));
   --gray-lightest: hsl(var(--gray-h), var(--gray-s), calc(var(--gray-l) + 43%));
   --gray-dark: hsl(var(--gray-h), var(--gray-s), calc(var(--gray-l) - 20%));


### PR DESCRIPTION
<img width="1526" height="1796" alt="Screenshot from 2025-10-29 22-57-38" src="https://github.com/user-attachments/assets/35449215-677b-4ac5-9448-c5c71d7406ed" />

You recently wrote:

>I’m still a bit undecided, because not voting is different from the other options. I forgot which role exactly abstentions/missing votes play when it comes to majorities/thresholds, so I’d just make sure that adding MEPs that didn’t vote to the chart doesn’t make the chart more difficult to read in that regard.

@tillprochaska what are your thoughts on this solution? Regardless of whether this is great coding wise (it's not yet).

The possibility to only have that in the small bars only just came to me, but I think it makes absolute sense. In the small bars, people are mainly looking for the information on what the position of the group/country was. For that, it is always necessary to have a chart that actually presents 100% of the MEPs of that country/group. In the chart at the top, I think its less relevant to represent 100% of the MEPs and it would also clutter the chart quite a bit, just because you will always have people who are sick, in prison,...
This makes anything regarding thresholds at least not more complicated to visibly grasp than before.