### PR TITLE
Fix CSS class name prefix in procedure scraper

### DIFF
--- a/backend/howtheyvote/scrapers/votes.py
+++ b/backend/howtheyvote/scrapers/votes.py
@@ -667,7 +667,7 @@ class ProcedureScraper(BeautifulSoupScraper):
         )
 
     def _procedure_reference(self, doc: BeautifulSoup) -> str | None:
-        heading = doc.select_one("#website-body h2.erpl_title-h1")
+        heading = doc.select_one("#website-body h2.es_title-h1")
 
         if not heading:
             return None
@@ -675,7 +675,7 @@ class ProcedureScraper(BeautifulSoupScraper):
         return heading.get_text(strip=True)
 
     def _title(self, doc: BeautifulSoup) -> str | None:
-        title = doc.select_one("#website-body h2.erpl_title-h2")
+        title = doc.select_one("#website-body h2.es_title-h2")
 
         if not title:
             return None
@@ -739,7 +739,7 @@ class ProcedureScraper(BeautifulSoupScraper):
         committees: set[str] = set()
 
         table = doc.select_one(
-            "#erpl_accordion-committee :where("
+            "#es_accordion-committee :where("
             + 'table:has(th:-soup-contains("Committee responsible")),'
             + 'table:has(th:-soup-contains("Joint committee responsible"))'
             + ")"
@@ -748,7 +748,7 @@ class ProcedureScraper(BeautifulSoupScraper):
         if not table:
             return committees
 
-        badges = table.select("tbody tr .erpl_badge-committee")
+        badges = table.select("tbody tr .es_badge-committee")
 
         for badge in badges:
             text = badge.text.strip()

--- a/backend/tests/pipelines/data/oeil_2024-2006-reg.html
+++ b/backend/tests/pipelines/data/oeil_2024-2006-reg.html
@@ -27,7 +27,7 @@
     <meta content="index, follow, noodp, noydir, notranslate, noarchive" name="robots">
     <meta content="European Union, 2025 - Source: European Parliament" name="copyright">
     <meta content="Legislative Observatory" name="planet">
-    <meta content="26-07-2025" name="available">
+    <meta content="13-11-2025" name="available">
 
     <!-- Dynamics meta tags -->
     
@@ -35,41 +35,40 @@
     
 
     <!-- HTML <link> tags -->
-    <link rel="icon" href="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/assets/img/favicon.ico">
+    <link rel="icon" href="https://evokits.europarl.europa.eu/evostrap/7.0.0/lib/dist/assets/img/favicon.ico">
 
     
-    <link href="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/dist/css/evostrap.css" rel="stylesheet">
-    <link href="https://www.europarl.europa.eu/commonFrontResources/evostrap-oeil/1.0.0//dist/css/oeil.css" rel="stylesheet">
+    <link href="https://evokits.europarl.europa.eu/evostrap/7.0.0/lib/dist/css/evostrap.css" rel="stylesheet">
+    <link href="https://evokits.europarl.europa.eu/evostrap-oeil/1.0.1/dist/css/oeil.css" rel="stylesheet">
 </head>
 
 <body id="main-content" data-app-context="/oeil/">
 
-    <header class="erpl_header">
-    <nav class="erpl_wai-access" aria-label="Shortcuts">
+    <header class="es_header">
+    <nav class="es_wai-access" aria-label="Shortcuts">
         <ul>
-            <li> <a href="#website-body" class="erpl_smooth-scroll"> <span class="btn btn-primary">Access to page content (press &quot;Enter&quot;)</span> </a> </li>
-            <li> <a href="#languageSelectorDropdownButton" class="erpl_smooth-scroll"> <span class="btn btn-primary">Direct access to language menu (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#website-body" class="es_smooth-scroll"> <span class="btn btn-primary">Access to page content (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#languageSelectorDropdownButton" class="es_smooth-scroll"> <span class="btn btn-primary">Direct access to language menu (press &quot;Enter&quot;)</span> </a> </li>
 
-            <li> <a href="#mainSearch" class="erpl_smooth-scroll"> <span class="btn btn-primary">Direct access to search menu (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#mainSearch" class="es_smooth-scroll"> <span class="btn btn-primary">Direct access to search menu (press &quot;Enter&quot;)</span> </a> </li>
         </ul>
     </nav>
 
     
-    <div class="erpl_header-top border-bottom mb-3 mb-xl-4 a-i">
+    <div class="es_header-top border-bottom mb-3 mb-xl-4 a-i">
         <div class="container">
             <div class="row no-gutters">
-                <div class="col-auto"><div class="erpl_header-language-selector">
-    <div class="erpl_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute"
+                <div class="col-auto"><div class="es_header-language-selector">
+    <div class="es_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute"
          data-content-width="auto">
-        <button class="erpl_dropdown-btn input-group collapsed" type="button" data-toggle="collapse"
+        <button class="es_dropdown-btn input-group collapsed" type="button" data-toggle="collapse"
                 id="languageSelectorDropdownButton"
                 data-target="#languageSelectorDropdownContent"
                 aria-expanded="false"
                 aria-controls="languageSelectorDropdownContent">
-            <span class="value form-control">EN - English</span>
+            <span class="es_dropdown-label">EN - English</span>
             
-            <span class="input-group-append">
-                <span class="input-group-icon">
+            <span class="es_dropdown-icon">
                     <svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false">
                         <use xlink:href="#es_icon-arrow"></use>
                     </svg>
@@ -77,18 +76,15 @@
                          data-show-expanded="true">
                         <use xlink:href="#es_icon-arrow"></use>
                     </svg>
-                </span>
             </span>
         </button>
 
         <div>
-            <div class="erpl_dropdown-content collapse" id="languageSelectorDropdownContent">
-                <div class="border border-light">
-                    <div>
-                        <ul class="erpl_topbar-list list-unstyled erpl_dropdown-menu">
+            <div class="dropdown-menu border border-light" id="languageSelectorDropdownContent">
+                        <ul class="erpl_topbar-list list-unstyled es_dropdown-menu">
                             <li class="t-x-block" data-selected="false">
                                 <!-- localized version URL is here -->
-                                <a class="erpl_dropdown-menu-item"
+                                <a class="es_dropdown-menu-item"
                                    lang="fr"
                                    href="https://oeil.secure.europarl.europa.eu/oeil/fr/procedure-file?reference=2024/2006(REG)">
                                     
@@ -97,7 +93,7 @@
                             </li>
                             <li class="t-x-block" data-selected="true">
                                 <!-- localized version URL is here -->
-                                <a class="erpl_dropdown-menu-item"
+                                <a class="es_dropdown-menu-item"
                                    lang="en"
                                    href="https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2024/2006(REG)">
                                     <span class="t-item">EN - English</span>
@@ -105,14 +101,12 @@
                                 </a>
                             </li>
                         </ul>
-                    </div>
-                </div>
             </div>
         </div>
     </div>
 </div></div>
                 <div class="col">
-                    <nav class="erpl_header-other-websites d-flex justify-content-end align-items-center" aria-label="Other websites">
+                    <nav class="es_header-other-websites d-flex justify-content-end align-items-center" aria-label="Other websites">
                         <ul class="d-flex list-unstyled">
 
                             
@@ -166,24 +160,23 @@
 
                             
                             <li class="d-none d-xl-block">
-                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://elections.europa.eu/en/">
-                                    <span class="t-item">Elections</span>
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://eubudget.europarl.europa.eu/en">
+                                    <span class="t-item">EU budget</span>
                                 </a>
                             </li>
 
 
-                            <li class="erpl_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute">
-                               <button class="erpl_dropdown-btn input-group collapsed d-xl-flex pl-1 align-items-center t-y-block flex-nowrap"
+                            <li class="es_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute">
+                               <button class="es_dropdown-btn input-group collapsed d-xl-flex pl-1 align-items-center t-y-block flex-nowrap"
                                        data-toggle="collapse"
                                        data-target="#otherWebsiteSubmenu"
                                        aria-expanded="false"
                                        aria-controls="otherWebsiteSubmenu" aria-label="More other websites">
-                                    <span class="value">
+                                    <span class="es_dropdown-label">
 											<span class="d-none d-xl-inline">Other websites</span>
 											<span class="d-xl-none">View other websites</span>
                                     </span>
-                                   <span class="input-group-append">
-											<span class="input-group-icon">
+                                   <span class="es_dropdown-icon">
 												<svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false">
 													<use xlink:href="#es_icon-arrow"></use>
 												</svg>
@@ -192,140 +185,153 @@
 													<use xlink:href="#es_icon-arrow"></use>
 												</svg>
 											</span>
-										</span>
                                 </button>
                                 <div>
-                                    <div id="otherWebsiteSubmenu" class="erpl_dropdown-content collapse">
-                                        <ul class="erpl_header-other-websites-submenu list-unstyled erpl_dropdown-menu">
+                                    <div id="otherWebsiteSubmenu" class="dropdown-menu border border-light">
+                                        <ul class="es_header-other-websites-submenu erpl_topbar-list list-unstyled es_dropdown-men">
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/news/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/news/en">
                                                     <span class="t-item">News</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/topics/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/topics/en">
                                                     <span class="t-item">Topics</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/meps/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/meps/en">
                                                     <span class="t-item">MEPs</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/about-parliament/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/about-parliament/en">
                                                     <span class="t-item">About Parliament</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/plenary/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/plenary/en">
                                                     <span class="t-item">Plenary</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/committees/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/committees/en">
                                                     <span class="t-item">Committees</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/delegations/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/delegations/en">
                                                     <span class="t-item">Delegations</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://elections.europa.eu/en/">
-                                                    <span class="t-item">Elections</span>
+                                                <a class="es_dropdown-menu-item" href="https://eubudget.europarl.europa.eu/en">
+                                                    <span class="t-item">EU budget</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://multimedia.europarl.europa.eu/en/home">
+                                                <a class="es_dropdown-menu-item" href="https://multimedia.europarl.europa.eu/en/home">
                                                     <span class="t-item">Multimedia Centre</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/the-president/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/the-president/en">
                                                     <span class="t-item">Presidency</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/the-secretary-general/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/the-secretary-general/en">
                                                     <span class="t-item">Secretariat-general</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/thinktank/en">
+                                                <a class="es_dropdown-menu-item" href="https://elections.europa.eu/en/">
+                                                    <span class="t-item">Elections</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/thinktank/en">
                                                     <span class="t-item">Thinktank</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.epnewshub.eu">
+                                                <a class="es_dropdown-menu-item" href="https://www.epnewshub.eu">
                                                     <span class="t-item">EP Newshub</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/at-your-service/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/at-your-service/en">
                                                     <span class="t-item">At your service</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/visiting/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/visiting/en">
                                                     <span class="t-item">Visits</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/legislative-train">
+                                                <a class="es_dropdown-menu-item" href="https://oeil.secure.europarl.europa.eu/oeil/en">
+                                                    <span class="t-item">Legislative Observatory</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/legislative-train">
                                                     <span class="t-item">Legislative train</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/contracts-and-grants/en/">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/contracts-and-grants/en/">
                                                     <span class="t-item">Contracts and Grants</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/RegistreWeb/home/welcome.htm?language=en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/RegistreWeb/home/welcome.htm?language=en">
                                                     <span class="t-item">Register</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://data.europarl.europa.eu/en">
+                                                <a class="es_dropdown-menu-item" href="https://data.europarl.europa.eu/en">
                                                     <span class="t-item">Open Data Portal</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://liaison-offices.europarl.europa.eu/en">
+                                                <a class="es_dropdown-menu-item" href="https://liaison-offices.europarl.europa.eu/en">
                                                     <span class="t-item">Liaison offices</span>
                                                 </a>
                                             </li>
@@ -339,17 +345,17 @@
             </div>
         </div>
     </div>
-    <div class="erpl_header-middle mb-3">
+    <div class="es_header-middle mb-3">
         <div class="container">
             <div class="row">
                 <div class="col-12 col-md">
-                    <div class="erpl_header-website-title a-i">
-                        <div class="erpl_header-website-title-main">
+                    <div class="es_header-website-title a-i">
+                        <div class="es_header-website-title-main">
                             <a href="/oeil/en" class="t-x">
                                 <span>Legislative Observatory</span>
                             </a>
                         </div>
-                        <div class="erpl_header-website-title-sub">
+                        <div class="es_header-website-title-sub">
                             <a class="t-x-block" href="https://www.europarl.europa.eu" target="_blank" >
                                 <span class="t-item">European Parliament</span>
                             </a>
@@ -358,17 +364,18 @@
                 </div>
 
                 
-                <div class="col-auto d-none d-xl-flex justify-content-end align-items-center erpl_header-search-container">
-                    <form class="erpl_header-search" method="GET" action="/oeil/en/search"> <label for="mainSearch" class="sr-only">Find a procedure</label>
+                <div class="col-auto d-none d-xl-flex justify-content-end align-items-center es_header-search-container">
+                    <form class="es_header-search" method="GET" action="/oeil/en/search"> <label for="mainSearch" class="sr-only">Find a procedure</label>
                         <div class="input-group" style="width: 300px">
                             <input type="text" class="form-control"
                                    id="mainSearch"
+                                   maxlength="100"
                                    placeholder="Find a procedure..."
                                    name="fullText.term"
                                    aria-describedby="mainSearchHelper">
                             <div class="input-group-append">
                                 <button class="btn btn-primary align-items-center d-flex" title="Start find a procedure" disabled="">
-                                    <svg aria-hidden="true" class="es_icon es_icon-search erpl_header-search-icon">
+                                    <svg aria-hidden="true" class="es_icon es_icon-search es_header-search-icon">
                                         <use xlink:href="#es_icon-search"></use>
                                     </svg>
                                 </button>
@@ -379,64 +386,64 @@
             </div>
         </div>
     </div>
-    <div class="erpl_header-bottom">
-        <div class="erpl_header-menu-container">
-            <div class="container"><nav class="erpl_header-menu" aria-label="Main navigation">
-    <div class="erpl_header-menu-top row align-items-center">
+    <div class="es_header-bottom">
+        <div class="es_header-menu-container">
+            <div class="container"><nav class="es_header-menu" aria-label="Main navigation">
+    <div class="es_header-menu-top row align-items-center">
         <div class="col d-md-none d-flex align-items-center">
-            <svg aria-hidden="true" class="es_icon es_icon-ep-logo-w erpl_header-menu-top-logo">
+            <svg aria-hidden="true" class="es_icon es_icon-ep-logo-w es_header-menu-top-logo">
                 <use xlink:href="#es_icon-ep-logo-w"></use>
             </svg>
         </div>
 
-        <span class="erpl_header-menu-top-title offset-3 col-6 text-center d-none d-md-block" aria-hidden="true">
+        <span class="es_header-menu-top-title offset-3 col-6 text-center d-none d-md-block" aria-hidden="true">
 								<span>European Parliament</span></span>
 
-        <div class="erpl_header-menu-top-controls col-auto col-md-3 text-right">
-            <button type="button" class="btn btn-sm btn-dark-primary erpl_header-menu-top-controls-toggle-search" id="headerMenuToggleSearch" aria-haspopup="true" aria-expanded="false">
+        <div class="es_header-menu-top-controls col-auto col-md-3 text-right">
+            <button type="button" class="btn btn-sm btn-dark-primary es_header-menu-top-controls-toggle-search" id="headerMenuToggleSearch" aria-haspopup="true" aria-expanded="false">
                 <span class="sr-only">Search</span>
                 <svg aria-hidden="true" class="es_icon es_icon-search">
                     <use xlink:href="#es_icon-search"></use>
                 </svg>
             </button>
             <button type="button"
-                    class="btn btn-sm btn-dark-primary erpl_header-menu-top-controls-toggle-menu"
+                    class="btn btn-sm btn-dark-primary es_header-menu-top-controls-toggle-menu"
                     id="headerMenuToggleMenu"
                     aria-haspopup="true"
                     aria-expanded="false">
-                <span class="mr-25">Menu</span> <span class="erpl_header-menu-icon" aria-hidden="true"></span>
+                <span class="mr-25">Menu</span> <span class="es_header-menu-icon" aria-hidden="true"></span>
             </button>
         </div>
     </div>
 
-    <ul class="erpl_header-menu-list list-unstyled">
+    <ul class="es_header-menu-list list-unstyled">
         
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en" data-selected="false">
         <span class="t-y">Home</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/search" data-selected="false">
         <span class="t-y">Search</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/legislative-priorities" data-selected="false">
         <span class="t-y">Legislative priorities</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/find-out-more" data-selected="false">
         <span class="t-y">Find out more</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/contact" data-selected="false">
         <span class="t-y">Contact us</span>
     </a>
@@ -458,10 +465,10 @@
     <div class="row">
         <div class="col-12 col-xl-8">
             <div class="row">
-                <div class="col-12 col-lg"><h2 class="erpl_title-h1 mb-3">2024/2006(REG)</h2>
+                <div class="col-12 col-lg"><h2 class="es_title-h1 mb-3">2024/2006(REG)</h2>
                 </div>
                 <div class="col-12 col-lg-4">
-                    <div class="erpl_links-list text-lg-right my-1">
+                    <div class="es_links-list text-lg-right my-1">
                         <ul>
                             <li>
                                 <a href="/oeil/en/procedure-file/pdf?reference=2024/2006(REG)">
@@ -477,7 +484,7 @@
                 </div>
             </div>
             
-            <h2 class="erpl_title-h2 mb-3">EP&nbsp;Rules of Procedure: training on preventing conflict and harassment in the workplace and on good office management</h2>
+            <h2 class="es_title-h2 mb-3">EP&nbsp;Rules of Procedure: training on preventing conflict and harassment in the workplace and on good office management</h2>
             <div class="separator border-dark my-3"></div>
 
             
@@ -485,22 +492,22 @@
 
 
             
-            <div class="erpl_product">
+            <div class="es_product">
                 <div class="row">
                     <div class="col">
                         <div class="mb-3">
-                            <div class="erpl_product-body">
+                            <div class="es_product-body">
                                 
                                 <html lang="en">
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div id="section1" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 class="erpl_title-h2 mb-2">Basic information</h2></div>
+                <h2 class="es_title-h2 mb-2">Basic information</h2></div>
                 <div class="col-12 col-lg-4">
-                    <div class="erpl_links-list text-lg-right my-1">
+                    <div class="es_links-list text-lg-right my-1">
                         <ul>
                             <li>
                                 <a href="/oeil/en/procedure-file/pdf?reference=2024/2006(REG)&amp;section=BASIC_INFO">
@@ -554,7 +561,7 @@
         <div class="row">
             <div class="col-12">
                 <div class="separator separator-dotted separator-2x mt-5 mb-3">
-                    <a class="erpl_smooth-scroll btn btn-default" href="#gateway">Please go to Documentation gateway for any follow-up documents.</a>
+                    <a class="es_smooth-scroll btn btn-default" href="#gateway">Please go to Documentation gateway for any follow-up documents.</a>
                 </div>
             </div>
         </div>
@@ -564,14 +571,14 @@
 
 
                                 
-                                <div class="erpl_product-section">
+                                <div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section2" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
-            <div class="col-12 col-lg"><h2 class="erpl_title-h2 mb-2">Key players</h2>
+            <div class="col-12 col-lg"><h2 class="es_title-h2 mb-2">Key players</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2024/2006(REG)&amp;section=KEY_PLAYERS">
@@ -586,13 +593,13 @@
                 </div>
             </div>
         </div>
-        <div class="erpl_accordion mb-5" id="erplAccordionKeyPlayers">
+        <div class="es_accordion mb-5" id="erplAccordionKeyPlayers">
             <ul class="a-i">
                 
-    <li class="erpl_accordion-item" data-selected="false">
-        <button id="erpl_accordion-committee-title" type="button" class="erpl_accordion-item-title" data-toggle="collapse" data-target="#erpl_accordion-committee" aria-expanded="true" aria-controls="erpl_accordion-committee">
+    <li class="es_accordion-item" data-selected="false">
+        <button id="es_accordion-committee-title" type="button" class="es_accordion-item-title" data-toggle="collapse" data-target="#es_accordion-committee" aria-expanded="true" aria-controls="es_accordion-committee">
             <span class="t-x">European Parliament</span>
-            <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <span class="es_accordion-item-icon es_icon-container text-primary">
             <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
                 <use xlink:href="#es_icon-more"></use>
             </svg>
@@ -601,7 +608,7 @@
             </svg>
         </span>
         </button>
-        <div id="erpl_accordion-committee" class="erpl_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="erpl_accordion-committee-title">
+        <div id="es_accordion-committee" class="es_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="es_accordion-committee-title">
             <div>
                 <a href="http://www.europarl.europa.eu/" target="_blank">
                     <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1">
@@ -631,7 +638,7 @@
     <tr>
         <th scope="row">
             <div class="d-flex align-items-center">
-    <span class="erpl_badge erpl_badge-committee mr-1">AFCO</span>
+    <span class="es_badge es_badge-committee mr-1">AFCO</span>
     <div>
         <a href="http://www.europarl.europa.eu/committees/EN/afco/home.html" target="_blank">
                 <span class="font-weight-normal">Constitutional Affairs</span>
@@ -745,15 +752,15 @@
 
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section3" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 class="erpl_title-h2 mb-2">Key events</h2>
+                <h2 class="es_title-h2 mb-2">Key events</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2024/2006(REG)&amp;section=KEY_EVENTS" target="_blank">
@@ -930,15 +937,15 @@
 
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section5" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 class="erpl_title-h2 mb-2">Technical information</h2>
+                <h2 class="es_title-h2 mb-2">Technical information</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2024/2006(REG)&amp;section=TECHNICAL_INFORMATION">
@@ -1006,15 +1013,15 @@
 
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section6" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 id="gateway" class="erpl_title-h2 mb-2">Documentation gateway</h2>
+                <h2 id="gateway" class="es_title-h2 mb-2">Documentation gateway</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2024/2006(REG)&amp;section=DOCUMENTATION_GATEWAY" target="_blank">
@@ -1029,19 +1036,19 @@
                 </div>
             </div>
         </div>
-        <div class="erpl_accordion mb-5" id="erplAccordionDocGateway">
+        <div class="es_accordion mb-5" id="erplAccordionDocGateway">
             <ul class="a-i">
                 
-                    <li class="erpl_accordion-item" data-selected="false">
+                    <li class="es_accordion-item" data-selected="false">
     <button
-            id="erpl_accordion-item-doc-gateway-EP-title"
+            id="es_accordion-item-doc-gateway-EP-title"
             type="button"
-            class="erpl_accordion-item-title collapsed"
+            class="es_accordion-item-title collapsed"
             data-toggle="collapse"
-            aria-expanded="true" data-target="#erpl_accordion-item-doc-gateway-EP" aria-controls="erpl_accordion-item-doc-gateway-EP"
+            aria-expanded="true" data-target="#es_accordion-item-doc-gateway-EP" aria-controls="es_accordion-item-doc-gateway-EP"
     >
         <span class="t-x">European Parliament</span>
-        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+        <span class="es_accordion-item-icon es_icon-container text-primary">
             <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
                 <use xlink:href="#es_icon-more"></use>
             </svg>
@@ -1050,7 +1057,7 @@
             </svg>
         </span>
     </button>
-    <div id="erpl_accordion-item-doc-gateway-EP" class="collapse erpl_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="erpl_accordion-item-doc-gateway-EP-title">
+    <div id="es_accordion-item-doc-gateway-EP" class="collapse es_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="es_accordion-item-doc-gateway-EP-title">
             <div class="table-responsive">
                 <table class="table table-striped table-bordered">
                     <thead>
@@ -1222,7 +1229,7 @@
 
 
 
-<div class="card erpl_move"
+<div class="card es_move"
      data-move-lg="#sectionsNavPositionRwd"
      data-move-md="#sectionsNavPositionRwd"
      data-move-sm="#sectionsNavPositionRwd"
@@ -1230,37 +1237,37 @@
      data-move-xs="#sectionsNavPositionRwd"
      data-move-xxl="#sectionsNavPositionInitial">
     <div class="card-body py-0">
-        <nav class="erpl_side-navigation">
-            <h3 class="erpl_title-h3 mb-0 py-2">
+        <nav class="es_side-navigation">
+            <h3 class="es_title-h3 mb-0 py-2">
                 <a class="text-primary" href="#">
                     <span class="t-x">Procedure file</span>
                 </a>
             </h3>
-            <div class="erpl_links-list erpl_links-list-nav">
+            <div class="es_links-list es_links-list-nav">
                 <ul>
                     <li data-selected="true">
-                        <a class="erpl_smooth-scroll" href="#section1">
+                        <a class="es_smooth-scroll" href="#section1">
                             <span class="t-x">Basic information</span>
                         </a>
                     </li>
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section2">
+                        <a class="es_smooth-scroll" href="#section2">
                             <span class="t-x">Key players</span>
                         </a>
                     </li>
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section3">
+                        <a class="es_smooth-scroll" href="#section3">
                             <span class="t-x">Key events</span>
                         </a>
                     </li>
                     
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section5">
+                        <a class="es_smooth-scroll" href="#section5">
                             <span class="t-x">Technical information</span>
                         </a>
                     </li>
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section6">
+                        <a class="es_smooth-scroll" href="#section6">
                             <span class="t-x">Documentation gateway</span>
                         </a>
                     </li>
@@ -1288,14 +1295,14 @@
     </button>
 
     
-    <footer class="erpl_footer">
-    <div class="erpl_footer-top mt-8">
+    <footer class="es_footer">
+    <div class="es_footer-top mt-8">
         <div class="container">
-            <div class="erpl_footer-top-content border-top-lg border-secondary text-center d-md-flex justify-content-between pt-md-3 mb-5 a-i">
-                <nav id="share-links" class="erpl_share-links" aria-label="Share links">
-                    <div class="d-md-flex">
-                        <h2 class="erpl_title-h5 mb-2 mb-md-0"><span class="mr-md-1">Share this page</span></h2>
-                        <ul class="erpl_share-links-list d-flex justify-content-center mb-3 mb-md-0">
+            <div class="es_footer-top-content border-top-lg border-secondary text-center d-md-flex justify-content-between pt-md-3 mb-5 a-i">
+                <nav id="share-links" class="es_footer-share-links" aria-label="Share links">
+                    <div class="d-md-flex align-items-center">
+                        <h2 class="es_title-h5 mb-2 mb-md-0"><span class="mr-md-1">Share this page</span></h2>
+                        <ul class="es_social-share-horizontal d-flex justify-content-center align-items-center mb-3 mb-md-0 pl-0">
                             <li class="mr-1">
                                 <a title="Share this page on Facebook" href="https://www.facebook.com/share.php?u=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2024/2006(REG)" target="_blank">
                                     <span class="sr-only">Facebook</span>
@@ -1331,7 +1338,7 @@
                         </ul>
                     </div>
                 </nav>
-                <nav class="erpl_horizontal-links" aria-label="data protection link">
+                <nav class="es_horizontal-links" aria-label="data protection link">
                     <div>
                         <a href="https://oeil.secure.europarl.europa.eu/oeil/en/external-documents/download?id=2" target="_blank">
                             <span class="t-y">Data Protection Notice</span>
@@ -1341,11 +1348,11 @@
             </div>
         </div>
     </div>
-    <div class="erpl_footer-bottom bg-black-footer pt-3 pb-3">
+    <div class="es_footer-bottom bg-black-footer pt-3 pb-3">
         <div class="container">
             <div class="row" id="footerLinks">
                 <nav class="col-12 col-xl-9 text-center text-md-left" id="website-links" aria-label="Website links">
-    <h3 class="erpl_title-h3 mb-2 text-white">Legislative Observatory</h3>
+    <h3 class="es_title-h3 mb-2 text-white">Legislative Observatory</h3>
     <div class="collapse show" id="website-links-items">
         <div class="row">
             <div class="col-12 col-md-6 col-xl-4">
@@ -1435,7 +1442,7 @@
 
     <div class="d-block d-md-none">
         <div class="footerLinkToggle separator separator-dotted separator-2x mb-5 mt-5 collapsed">
-            <a class="erpl_toggle-menu" href="#website-links"
+            <a class="es_toggle-menu" href="#website-links"
                title="Toggle linked links"
                role="button"
                data-toggle="collapse"
@@ -1450,7 +1457,7 @@
                     <use xlink:href="#es_icon-minus"></use>
                 </svg>
             </a>
-            <a class="erpl_nojs-close-menu" href="#website-links-close"
+            <a class="es_nojs-close-menu" href="#website-links-close"
                title="Untoggle linked links"
                role="button"
                data-toggle="collapse"
@@ -1466,7 +1473,7 @@
 </nav>
                 <nav class="col-12 col-xl-3 text-center text-md-left" id="europarl-links" aria-label="Europarl links">
     <div class="separator separator-dotted separator-2x mt-3 mb-4 d-none d-md-flex d-xl-none"></div>
-    <h3 class="erpl_title-h3 mb-2 text-white">European Parliament</h3>
+    <h3 class="es_title-h3 mb-2 text-white">European Parliament</h3>
     <div class="collapse show" id="europarl-links-items">
         <nav class="link-group pt-25 t-x-mode" aria-label="European Parliament">
             <a href="https://www.europarl.europa.eu/news/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - News">
@@ -1476,8 +1483,8 @@
                 <span>About Parliament</span></a><a href="https://www.europarl.europa.eu/plenary/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Plenary">
                 <span>Plenary</span></a><a href="https://www.europarl.europa.eu/committees/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Committees">
                 <span>Committees</span></a><a href="https://www.europarl.europa.eu/delegations/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Delegations">
-                <span>Delegations</span></a><a href="https://elections.europa.eu/en/" class="link-group-item mb-1 d-block" aria-label="European Parliament - Elections">
-                <span>Elections</span></a>
+                <span>Delegations</span></a><a href="https://eubudget.europarl.europa.eu/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - EU budget">
+                <span>EU budget</span></a>
         </nav>
     </div>
     <div class="d-block d-md-none">
@@ -1497,7 +1504,7 @@
                     <use xlink:href="#es_icon-minus"></use>
                 </svg>
             </a>
-            <a class="erpl_nojs-close-menu" href="#europarl-links-close"
+            <a class="es_nojs-close-menu" href="#europarl-links-close"
                title="Untoggle European Parliament websites"
                role="button" data-toggle="collapse"
                data-target="#europarl-links-items"
@@ -1515,10 +1522,10 @@
 
             <div class="separator separator-dotted separator-2x mt-3 mb-3 d-none d-md-flex"></div>
             <div class="row">
-                <nav class="col-12" id="social-links" aria-label="Social links">
-                    <div class="erpl_social-links mb-2">
+                <nav class="col-12 d-flex justify-content-center" id="social-links" aria-label="Social links">
+                    <div class="es_footer-social-links mb-2">
                         
-                            <a  data-toggle="tooltip" title="Check out Parliament on Facebook" href="https://www.facebook.com/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Facebook" href="https://www.facebook.com/europeanparliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
                                 <svg aria-hidden="true"
                                      class="es_icon es_icon-facebook-color">
                                     <use href="#es_icon-facebook-color"></use>
@@ -1526,7 +1533,7 @@
                                 <span class="sr-only">Facebook</span>
                             </a>
                         
-                            <a  data-toggle="tooltip" title="Check out Parliament on X" href="https://x.com/Europarl_en" target="_blank" class="mr-1 ml-1 mb-2">
+                            <a  data-toggle="tooltip" title="Check out Parliament on X" href="https://x.com/Europarl_en" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
                                 <svg aria-hidden="true"
                                      class="es_icon es_icon-twitter-x">
                                     <use href="#es_icon-twitter-x"></use>
@@ -1534,7 +1541,7 @@
                                 <span class="sr-only">Twitter</span>
                             </a>
                         
-                            <a  data-toggle="tooltip" title="Check out Parliament on Flickr" href="https://www.flickr.com/photos/european_parliament" target="_blank" class="mr-1 ml-1 mb-2">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Flickr" href="https://www.flickr.com/photos/european_parliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
                                 <svg aria-hidden="true"
                                      class="es_icon es_icon-flickr-color">
                                     <use href="#es_icon-flickr-color"></use>
@@ -1542,7 +1549,7 @@
                                 <span class="sr-only">Flickr</span>
                             </a>
                         
-                            <a  data-toggle="tooltip" title="Check out Parliament on LinkedIn" href="https://www.linkedin.com/company/european-parliament" target="_blank" class="mr-1 ml-1 mb-2">
+                            <a  data-toggle="tooltip" title="Check out Parliament on LinkedIn" href="https://www.linkedin.com/company/european-parliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
                                 <svg aria-hidden="true"
                                      class="es_icon es_icon-linkedin-color">
                                     <use href="#es_icon-linkedin-color"></use>
@@ -1550,7 +1557,7 @@
                                 <span class="sr-only">LinkedIn</span>
                             </a>
                         
-                            <a  data-toggle="tooltip" title="Check out Parliament on YouTube" href="https://www.youtube.com/user/EuropeanParliament" target="_blank" class="mr-1 ml-1 mb-2">
+                            <a  data-toggle="tooltip" title="Check out Parliament on YouTube" href="https://www.youtube.com/user/EuropeanParliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
                                 <svg aria-hidden="true"
                                      class="es_icon es_icon-youtube-color">
                                     <use href="#es_icon-youtube-color"></use>
@@ -1558,7 +1565,7 @@
                                 <span class="sr-only">YouTube</span>
                             </a>
                         
-                            <a  data-toggle="tooltip" title="Check out Parliament on Instagram" href="https://www.instagram.com/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Instagram" href="https://www.instagram.com/europeanparliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
                                 <svg aria-hidden="true"
                                      class="es_icon es_icon-instagram-color">
                                     <use href="#es_icon-instagram-color"></use>
@@ -1566,7 +1573,7 @@
                                 <span class="sr-only">Instagram</span>
                             </a>
                         
-                            <a  data-toggle="tooltip" title="Check out Parliament on Pinterest" href="https://www.pinterest.fr/epinfographics" target="_blank" class="mr-1 ml-1 mb-2">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Pinterest" href="https://www.pinterest.fr/epinfographics" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
                                 <svg aria-hidden="true"
                                      class="es_icon es_icon-pinterest-color">
                                     <use href="#es_icon-pinterest-color"></use>
@@ -1574,7 +1581,7 @@
                                 <span class="sr-only">Pinterest</span>
                             </a>
                         
-                            <a  data-toggle="tooltip" title="Check out Parliament on Reddit" href="https://www.reddit.com/r/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Reddit" href="https://www.reddit.com/r/europeanparliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
                                 <svg aria-hidden="true"
                                      class="es_icon es_icon-reddit-color">
                                     <use href="#es_icon-reddit-color"></use>
@@ -1613,12 +1620,9 @@
         </div>
     </div>
 </footer>
-
     
-    <script src="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/lib/jquery/jquery.min.js"></script>
-    
-    <script id="evostrap" src="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/dist/js/evostrap.js"></script>
-    <script src="https://www.europarl.europa.eu/commonFrontResources/evostrap-oeil/1.0.0//dist/js/oeil.js"></script>
+    <script id="evostrap" type="module" src="https://evokits.europarl.europa.eu/evostrap/7.0.0/lib/dist/js/evostrap.js"></script>
+    <script src="https://evokits.europarl.europa.eu/evostrap-oeil/1.0.1/dist/js/oeil.js"></script>
 
     
     <script src="/oeil/oeil-addons/documents-loading.js"></script>

--- a/backend/tests/scrapers/data/votes/oeil-procedure-file_2022-2201-ini.html
+++ b/backend/tests/scrapers/data/votes/oeil-procedure-file_2022-2201-ini.html
@@ -25,9 +25,9 @@
     <meta content="en" http-equiv="Content-Language">
     <meta content="European Parliament Legislative Observatory Procedure" name="description">
     <meta content="index, follow, noodp, noydir, notranslate, noarchive" name="robots">
-    <meta content="European Union, 2024 - Source: European Parliament" name="copyright">
+    <meta content="European Union, 2025 - Source: European Parliament" name="copyright">
     <meta content="Legislative Observatory" name="planet">
-    <meta content="17-11-2024" name="available">
+    <meta content="13-11-2025" name="available">
 
     <!-- Dynamics meta tags -->
     
@@ -35,41 +35,40 @@
     
 
     <!-- HTML <link> tags -->
-    <link rel="icon" href="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/assets/img/favicon.ico">
+    <link rel="icon" href="https://evokits.europarl.europa.eu/evostrap/7.0.0/lib/dist/assets/img/favicon.ico">
 
     
-    <link href="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/dist/css/evostrap.css" rel="stylesheet">
-    <link href="https://www.europarl.europa.eu/commonFrontResources/evostrap-oeil/1.0.0//dist/css/oeil.css" rel="stylesheet">
+    <link href="https://evokits.europarl.europa.eu/evostrap/7.0.0/lib/dist/css/evostrap.css" rel="stylesheet">
+    <link href="https://evokits.europarl.europa.eu/evostrap-oeil/1.0.1/dist/css/oeil.css" rel="stylesheet">
 </head>
 
 <body id="main-content" data-app-context="/oeil/">
 
-    <header class="erpl_header">
-    <nav class="erpl_wai-access" aria-label="Shortcuts">
+    <header class="es_header">
+    <nav class="es_wai-access" aria-label="Shortcuts">
         <ul>
-            <li> <a href="#website-body" class="erpl_smooth-scroll"> <span class="btn btn-primary">Access to page content (press &quot;Enter&quot;)</span> </a> </li>
-            <li> <a href="#languageSelectorDropdownButton" class="erpl_smooth-scroll"> <span class="btn btn-primary">Direct access to language menu (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#website-body" class="es_smooth-scroll"> <span class="btn btn-primary">Access to page content (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#languageSelectorDropdownButton" class="es_smooth-scroll"> <span class="btn btn-primary">Direct access to language menu (press &quot;Enter&quot;)</span> </a> </li>
 
-            <li> <a href="#mainSearch" class="erpl_smooth-scroll"> <span class="btn btn-primary">Direct access to search menu (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#mainSearch" class="es_smooth-scroll"> <span class="btn btn-primary">Direct access to search menu (press &quot;Enter&quot;)</span> </a> </li>
         </ul>
     </nav>
 
     
-    <div class="erpl_header-top border-bottom mb-3 mb-xl-4 a-i">
+    <div class="es_header-top border-bottom mb-3 mb-xl-4 a-i">
         <div class="container">
             <div class="row no-gutters">
-                <div class="col-auto"><div class="erpl_header-language-selector">
-    <div class="erpl_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute"
+                <div class="col-auto"><div class="es_header-language-selector">
+    <div class="es_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute"
          data-content-width="auto">
-        <button class="erpl_dropdown-btn input-group collapsed" type="button" data-toggle="collapse"
+        <button class="es_dropdown-btn input-group collapsed" type="button" data-toggle="collapse"
                 id="languageSelectorDropdownButton"
                 data-target="#languageSelectorDropdownContent"
                 aria-expanded="false"
                 aria-controls="languageSelectorDropdownContent">
-            <span class="value form-control">EN - English</span>
+            <span class="es_dropdown-label">EN - English</span>
             
-            <span class="input-group-append">
-                <span class="input-group-icon">
+            <span class="es_dropdown-icon">
                     <svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false">
                         <use xlink:href="#es_icon-arrow"></use>
                     </svg>
@@ -77,18 +76,15 @@
                          data-show-expanded="true">
                         <use xlink:href="#es_icon-arrow"></use>
                     </svg>
-                </span>
             </span>
         </button>
 
         <div>
-            <div class="erpl_dropdown-content collapse" id="languageSelectorDropdownContent">
-                <div class="border border-light">
-                    <div>
-                        <ul class="erpl_topbar-list list-unstyled erpl_dropdown-menu">
+            <div class="dropdown-menu border border-light" id="languageSelectorDropdownContent">
+                        <ul class="erpl_topbar-list list-unstyled es_dropdown-menu">
                             <li class="t-x-block" data-selected="false">
                                 <!-- localized version URL is here -->
-                                <a class="erpl_dropdown-menu-item"
+                                <a class="es_dropdown-menu-item"
                                    lang="fr"
                                    href="https://oeil.secure.europarl.europa.eu/oeil/fr/procedure-file?reference=2022/2201(INI)">
                                     
@@ -97,7 +93,7 @@
                             </li>
                             <li class="t-x-block" data-selected="true">
                                 <!-- localized version URL is here -->
-                                <a class="erpl_dropdown-menu-item"
+                                <a class="es_dropdown-menu-item"
                                    lang="en"
                                    href="https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2022/2201(INI)">
                                     <span class="t-item">EN - English</span>
@@ -105,14 +101,12 @@
                                 </a>
                             </li>
                         </ul>
-                    </div>
-                </div>
             </div>
         </div>
     </div>
 </div></div>
                 <div class="col">
-                    <nav class="erpl_header-other-websites d-flex justify-content-end align-items-center" aria-label="Other websites">
+                    <nav class="es_header-other-websites d-flex justify-content-end align-items-center" aria-label="Other websites">
                         <ul class="d-flex list-unstyled">
 
                             
@@ -166,24 +160,23 @@
 
                             
                             <li class="d-none d-xl-block">
-                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://elections.europa.eu/en/">
-                                    <span class="t-item">Elections</span>
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://eubudget.europarl.europa.eu/en">
+                                    <span class="t-item">EU budget</span>
                                 </a>
                             </li>
 
 
-                            <li class="erpl_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute">
-                               <button class="erpl_dropdown-btn input-group collapsed d-xl-flex pl-1 align-items-center t-y-block flex-nowrap"
+                            <li class="es_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute">
+                               <button class="es_dropdown-btn input-group collapsed d-xl-flex pl-1 align-items-center t-y-block flex-nowrap"
                                        data-toggle="collapse"
                                        data-target="#otherWebsiteSubmenu"
                                        aria-expanded="false"
                                        aria-controls="otherWebsiteSubmenu" aria-label="More other websites">
-                                    <span class="value">
+                                    <span class="es_dropdown-label">
 											<span class="d-none d-xl-inline">Other websites</span>
 											<span class="d-xl-none">View other websites</span>
                                     </span>
-                                   <span class="input-group-append">
-											<span class="input-group-icon">
+                                   <span class="es_dropdown-icon">
 												<svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false">
 													<use xlink:href="#es_icon-arrow"></use>
 												</svg>
@@ -192,140 +185,153 @@
 													<use xlink:href="#es_icon-arrow"></use>
 												</svg>
 											</span>
-										</span>
                                 </button>
                                 <div>
-                                    <div id="otherWebsiteSubmenu" class="erpl_dropdown-content collapse">
-                                        <ul class="erpl_header-other-websites-submenu list-unstyled erpl_dropdown-menu">
+                                    <div id="otherWebsiteSubmenu" class="dropdown-menu border border-light">
+                                        <ul class="es_header-other-websites-submenu erpl_topbar-list list-unstyled es_dropdown-men">
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/news/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/news/en">
                                                     <span class="t-item">News</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/topics/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/topics/en">
                                                     <span class="t-item">Topics</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/meps/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/meps/en">
                                                     <span class="t-item">MEPs</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/about-parliament/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/about-parliament/en">
                                                     <span class="t-item">About Parliament</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/plenary/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/plenary/en">
                                                     <span class="t-item">Plenary</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/committees/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/committees/en">
                                                     <span class="t-item">Committees</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/delegations/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/delegations/en">
                                                     <span class="t-item">Delegations</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://elections.europa.eu/en/">
-                                                    <span class="t-item">Elections</span>
+                                                <a class="es_dropdown-menu-item" href="https://eubudget.europarl.europa.eu/en">
+                                                    <span class="t-item">EU budget</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://multimedia.europarl.europa.eu/en/home">
+                                                <a class="es_dropdown-menu-item" href="https://multimedia.europarl.europa.eu/en/home">
                                                     <span class="t-item">Multimedia Centre</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/the-president/en">
-                                                    <span class="t-item">President&#39;s website</span>
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/the-president/en">
+                                                    <span class="t-item">Presidency</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/the-secretary-general/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/the-secretary-general/en">
                                                     <span class="t-item">Secretariat-general</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/thinktank/en">
+                                                <a class="es_dropdown-menu-item" href="https://elections.europa.eu/en/">
+                                                    <span class="t-item">Elections</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/thinktank/en">
                                                     <span class="t-item">Thinktank</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.epnewshub.eu">
+                                                <a class="es_dropdown-menu-item" href="https://www.epnewshub.eu">
                                                     <span class="t-item">EP Newshub</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/at-your-service/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/at-your-service/en">
                                                     <span class="t-item">At your service</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/visiting/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/visiting/en">
                                                     <span class="t-item">Visits</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/legislative-train">
+                                                <a class="es_dropdown-menu-item" href="https://oeil.secure.europarl.europa.eu/oeil/en">
+                                                    <span class="t-item">Legislative Observatory</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/legislative-train">
                                                     <span class="t-item">Legislative train</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/contracts-and-grants/en/">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/contracts-and-grants/en/">
                                                     <span class="t-item">Contracts and Grants</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/RegistreWeb/home/welcome.htm?language=en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/RegistreWeb/home/welcome.htm?language=en">
                                                     <span class="t-item">Register</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://data.europarl.europa.eu/en">
+                                                <a class="es_dropdown-menu-item" href="https://data.europarl.europa.eu/en">
                                                     <span class="t-item">Open Data Portal</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://liaison-offices.europarl.europa.eu/en">
+                                                <a class="es_dropdown-menu-item" href="https://liaison-offices.europarl.europa.eu/en">
                                                     <span class="t-item">Liaison offices</span>
                                                 </a>
                                             </li>
@@ -339,17 +345,17 @@
             </div>
         </div>
     </div>
-    <div class="erpl_header-middle mb-3">
+    <div class="es_header-middle mb-3">
         <div class="container">
             <div class="row">
                 <div class="col-12 col-md">
-                    <div class="erpl_header-website-title a-i">
-                        <div class="erpl_header-website-title-main">
+                    <div class="es_header-website-title a-i">
+                        <div class="es_header-website-title-main">
                             <a href="/oeil/en" class="t-x">
                                 <span>Legislative Observatory</span>
                             </a>
                         </div>
-                        <div class="erpl_header-website-title-sub">
+                        <div class="es_header-website-title-sub">
                             <a class="t-x-block" href="https://www.europarl.europa.eu" target="_blank" >
                                 <span class="t-item">European Parliament</span>
                             </a>
@@ -358,17 +364,18 @@
                 </div>
 
                 
-                <div class="col-auto d-none d-xl-flex justify-content-end align-items-center erpl_header-search-container">
-                    <form class="erpl_header-search" method="GET" action="/oeil/en/search"> <label for="mainSearch" class="sr-only">Find a procedure</label>
+                <div class="col-auto d-none d-xl-flex justify-content-end align-items-center es_header-search-container">
+                    <form class="es_header-search" method="GET" action="/oeil/en/search"> <label for="mainSearch" class="sr-only">Find a procedure</label>
                         <div class="input-group" style="width: 300px">
                             <input type="text" class="form-control"
                                    id="mainSearch"
+                                   maxlength="100"
                                    placeholder="Find a procedure..."
                                    name="fullText.term"
                                    aria-describedby="mainSearchHelper">
                             <div class="input-group-append">
                                 <button class="btn btn-primary align-items-center d-flex" title="Start find a procedure" disabled="">
-                                    <svg aria-hidden="true" class="es_icon es_icon-search erpl_header-search-icon">
+                                    <svg aria-hidden="true" class="es_icon es_icon-search es_header-search-icon">
                                         <use xlink:href="#es_icon-search"></use>
                                     </svg>
                                 </button>
@@ -379,64 +386,64 @@
             </div>
         </div>
     </div>
-    <div class="erpl_header-bottom">
-        <div class="erpl_header-menu-container">
-            <div class="container"><nav class="erpl_header-menu" aria-label="Main navigation">
-    <div class="erpl_header-menu-top row align-items-center">
+    <div class="es_header-bottom">
+        <div class="es_header-menu-container">
+            <div class="container"><nav class="es_header-menu" aria-label="Main navigation">
+    <div class="es_header-menu-top row align-items-center">
         <div class="col d-md-none d-flex align-items-center">
-            <svg aria-hidden="true" class="es_icon es_icon-ep-logo-w erpl_header-menu-top-logo">
+            <svg aria-hidden="true" class="es_icon es_icon-ep-logo-w es_header-menu-top-logo">
                 <use xlink:href="#es_icon-ep-logo-w"></use>
             </svg>
         </div>
 
-        <span class="erpl_header-menu-top-title offset-3 col-6 text-center d-none d-md-block" aria-hidden="true">
+        <span class="es_header-menu-top-title offset-3 col-6 text-center d-none d-md-block" aria-hidden="true">
 								<span>European Parliament</span></span>
 
-        <div class="erpl_header-menu-top-controls col-auto col-md-3 text-right">
-            <button type="button" class="btn btn-sm btn-dark-primary erpl_header-menu-top-controls-toggle-search" id="headerMenuToggleSearch" aria-haspopup="true" aria-expanded="false">
+        <div class="es_header-menu-top-controls col-auto col-md-3 text-right">
+            <button type="button" class="btn btn-sm btn-dark-primary es_header-menu-top-controls-toggle-search" id="headerMenuToggleSearch" aria-haspopup="true" aria-expanded="false">
                 <span class="sr-only">Search</span>
                 <svg aria-hidden="true" class="es_icon es_icon-search">
                     <use xlink:href="#es_icon-search"></use>
                 </svg>
             </button>
             <button type="button"
-                    class="btn btn-sm btn-dark-primary erpl_header-menu-top-controls-toggle-menu"
+                    class="btn btn-sm btn-dark-primary es_header-menu-top-controls-toggle-menu"
                     id="headerMenuToggleMenu"
                     aria-haspopup="true"
                     aria-expanded="false">
-                <span class="mr-25">Menu</span> <span class="erpl_header-menu-icon" aria-hidden="true"></span>
+                <span class="mr-25">Menu</span> <span class="es_header-menu-icon" aria-hidden="true"></span>
             </button>
         </div>
     </div>
 
-    <ul class="erpl_header-menu-list list-unstyled">
+    <ul class="es_header-menu-list list-unstyled">
         
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en" data-selected="false">
         <span class="t-y">Home</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/search" data-selected="false">
         <span class="t-y">Search</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/legislative-priorities" data-selected="false">
         <span class="t-y">Legislative priorities</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/find-out-more" data-selected="false">
         <span class="t-y">Find out more</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/contact" data-selected="false">
         <span class="t-y">Contact us</span>
     </a>
@@ -458,10 +465,10 @@
     <div class="row">
         <div class="col-12 col-xl-8">
             <div class="row">
-                <div class="col-12 col-lg"><h2 class="erpl_title-h1 mb-3">2022/2201(INI)</h2>
+                <div class="col-12 col-lg"><h2 class="es_title-h1 mb-3">2022/2201(INI)</h2>
                 </div>
                 <div class="col-12 col-lg-4">
-                    <div class="erpl_links-list text-lg-right my-1">
+                    <div class="es_links-list text-lg-right my-1">
                         <ul>
                             <li>
                                 <a href="/oeil/en/procedure-file/pdf?reference=2022/2201(INI)">
@@ -477,7 +484,7 @@
                 </div>
             </div>
             
-            <h2 class="erpl_title-h2 mb-3">2022 Commission Report on Kosovo</h2>
+            <h2 class="es_title-h2 mb-3">2022 Commission Report on Kosovo</h2>
             <div class="separator border-dark my-3"></div>
 
             
@@ -485,22 +492,22 @@
 
 
             
-            <div class="erpl_product">
+            <div class="es_product">
                 <div class="row">
                     <div class="col">
                         <div class="mb-3">
-                            <div class="erpl_product-body">
+                            <div class="es_product-body">
                                 
                                 <html lang="en">
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div id="section1" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 class="erpl_title-h2 mb-2">Basic information</h2></div>
+                <h2 class="es_title-h2 mb-2">Basic information</h2></div>
                 <div class="col-12 col-lg-4">
-                    <div class="erpl_links-list text-lg-right my-1">
+                    <div class="es_links-list text-lg-right my-1">
                         <ul>
                             <li>
                                 <a href="/oeil/en/procedure-file/pdf?reference=2022/2201(INI)&amp;section=BASIC_INFO">
@@ -562,7 +569,7 @@
         <div class="row">
             <div class="col-12">
                 <div class="separator separator-dotted separator-2x mt-5 mb-3">
-                    <a class="erpl_smooth-scroll btn btn-default" href="#gateway">Please go to Documentation gateway for any follow-up documents.</a>
+                    <a class="es_smooth-scroll btn btn-default" href="#gateway">Please go to Documentation gateway for any follow-up documents.</a>
                 </div>
             </div>
         </div>
@@ -570,15 +577,16 @@
 </div>
 </html>
 
+
                                 
-                                <div class="erpl_product-section">
+                                <div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section2" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
-            <div class="col-12 col-lg"><h2 class="erpl_title-h2 mb-2">Key players</h2>
+            <div class="col-12 col-lg"><h2 class="es_title-h2 mb-2">Key players</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2022/2201(INI)&amp;section=KEY_PLAYERS">
@@ -593,13 +601,13 @@
                 </div>
             </div>
         </div>
-        <div class="erpl_accordion mb-5" id="erplAccordionKeyPlayers">
+        <div class="es_accordion mb-5" id="erplAccordionKeyPlayers">
             <ul class="a-i">
                 
-    <li class="erpl_accordion-item" data-selected="false">
-        <button id="erpl_accordion-committee-title" type="button" class="erpl_accordion-item-title" data-toggle="collapse" data-target="#erpl_accordion-committee" aria-expanded="true" aria-controls="erpl_accordion-committee">
+    <li class="es_accordion-item" data-selected="false">
+        <button id="es_accordion-committee-title" type="button" class="es_accordion-item-title" data-toggle="collapse" data-target="#es_accordion-committee" aria-expanded="true" aria-controls="es_accordion-committee">
             <span class="t-x">European Parliament</span>
-            <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <span class="es_accordion-item-icon es_icon-container text-primary">
             <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
                 <use xlink:href="#es_icon-more"></use>
             </svg>
@@ -608,7 +616,7 @@
             </svg>
         </span>
         </button>
-        <div id="erpl_accordion-committee" class="erpl_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="erpl_accordion-committee-title">
+        <div id="es_accordion-committee" class="es_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="es_accordion-committee-title">
             <div>
                 <a href="http://www.europarl.europa.eu/" target="_blank">
                     <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1">
@@ -638,7 +646,7 @@
     <tr>
         <th scope="row">
             <div class="d-flex align-items-center">
-    <span class="erpl_badge erpl_badge-committee mr-1">AFET</span>
+    <span class="es_badge es_badge-committee mr-1">AFET</span>
     <div>
         <a href="http://www.europarl.europa.eu/committees/EN/afet/home.html" target="_blank">
                 <span class="font-weight-normal">Foreign Affairs
@@ -759,15 +767,15 @@
 
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section3" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 class="erpl_title-h2 mb-2">Key events</h2>
+                <h2 class="es_title-h2 mb-2">Key events</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2022/2201(INI)&amp;section=KEY_EVENTS" target="_blank">
@@ -890,7 +898,7 @@
                             
                                 <a href="https://www.europarl.europa.eu/doceo/document/CRE-9-2023-05-09-TOC_EN.html" title="Go to the page" target="_blank">
                                     <svg aria-hidden="true" class="es_icon es_icon-comment-dots es_icon-24">
-                                        <use xlink:href="#es_icon-comment-dots"></use>
+                                        <use href="#es_icon-comment-dots"></use>
                                     </svg>
                                 </a>
                             
@@ -938,7 +946,8 @@
                             
 
                             
-                                <a href="/oeil/en/sda-vote-result?sdaId=59886" target="_blank">
+                                <a href="https://www.europarl.europa.eu/doceo/document/PV-9-2023-05-10-VOT_EN.html?item=57"
+                                   title="Results of vote in Parliament" target="_blank">
                                     <svg aria-hidden="true" class="es_icon es_icon-vote es_icon-24">
                                         <use xlink:href="#es_icon-vote"></use>
                                     </svg>
@@ -974,15 +983,15 @@
 
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section5" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 class="erpl_title-h2 mb-2">Technical information</h2>
+                <h2 class="es_title-h2 mb-2">Technical information</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2022/2201(INI)&amp;section=TECHNICAL_INFORMATION">
@@ -1000,12 +1009,6 @@
 
         <div class="table-responsive">
             <table class="table table-striped table-bordered">
-                <thead>
-                <tr>
-                    <th class="align-middle" scope="col">Procedure</th>
-                    <th class="align-middle" scope="col">Information</th>
-                </tr>
-                </thead>
                 <tbody>
                 <tr>
                     <th class="align-middle" scope="row">Procedure reference</th>
@@ -1016,7 +1019,7 @@
                     <td class="align-middle">INI - Own-initiative procedure</td>
                 </tr>
                 <tr>
-                    <th class="align-middle" scope="row">Nature of procedure</th>
+                    <th class="align-middle" scope="row">Procedure subtype</th>
                     <td class="align-middle">Annual report</td>
                 </tr>
                 
@@ -1056,15 +1059,15 @@
 
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section6" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 id="gateway" class="erpl_title-h2 mb-2">Documentation gateway</h2>
+                <h2 id="gateway" class="es_title-h2 mb-2">Documentation gateway</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2022/2201(INI)&amp;section=DOCUMENTATION_GATEWAY" target="_blank">
@@ -1079,19 +1082,19 @@
                 </div>
             </div>
         </div>
-        <div class="erpl_accordion mb-5" id="erplAccordionDocGateway">
+        <div class="es_accordion mb-5" id="erplAccordionDocGateway">
             <ul class="a-i">
                 
-                    <li class="erpl_accordion-item" data-selected="false">
+                    <li class="es_accordion-item" data-selected="false">
     <button
-            id="erpl_accordion-item-doc-gateway-EP-title"
+            id="es_accordion-item-doc-gateway-EP-title"
             type="button"
-            class="erpl_accordion-item-title collapsed"
+            class="es_accordion-item-title collapsed"
             data-toggle="collapse"
-            aria-expanded="true" data-target="#erpl_accordion-item-doc-gateway-EP" aria-controls="erpl_accordion-item-doc-gateway-EP"
+            aria-expanded="true" data-target="#es_accordion-item-doc-gateway-EP" aria-controls="es_accordion-item-doc-gateway-EP"
     >
         <span class="t-x">European Parliament</span>
-        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+        <span class="es_accordion-item-icon es_icon-container text-primary">
             <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
                 <use xlink:href="#es_icon-more"></use>
             </svg>
@@ -1100,8 +1103,7 @@
             </svg>
         </span>
     </button>
-    <div id="erpl_accordion-item-doc-gateway-EP" class="collapse erpl_accordion-item-content a-i-none collapse show" aria-labelledby="erpl_accordion-item-doc-gateway-EP-title">
-        <div>
+    <div id="es_accordion-item-doc-gateway-EP" class="collapse es_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="es_accordion-item-doc-gateway-EP-title">
             <div class="table-responsive">
                 <table class="table table-striped table-bordered">
                     <thead>
@@ -1217,20 +1219,19 @@
                     </tbody>
                 </table>
             </div>
-        </div>
     </div>
 </li>
                 
-                    <li class="erpl_accordion-item" data-selected="false">
+                    <li class="es_accordion-item" data-selected="false">
     <button
-            id="erpl_accordion-item-doc-gateway-EC-title"
+            id="es_accordion-item-doc-gateway-EC-title"
             type="button"
-            class="erpl_accordion-item-title collapsed"
+            class="es_accordion-item-title collapsed"
             data-toggle="collapse"
-            aria-expanded="true" data-target="#erpl_accordion-item-doc-gateway-EC" aria-controls="erpl_accordion-item-doc-gateway-EC"
+            aria-expanded="true" data-target="#es_accordion-item-doc-gateway-EC" aria-controls="es_accordion-item-doc-gateway-EC"
     >
         <span class="t-x">European Commission</span>
-        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+        <span class="es_accordion-item-icon es_icon-container text-primary">
             <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
                 <use xlink:href="#es_icon-more"></use>
             </svg>
@@ -1239,8 +1240,7 @@
             </svg>
         </span>
     </button>
-    <div id="erpl_accordion-item-doc-gateway-EC" class="collapse erpl_accordion-item-content a-i-none collapse show" aria-labelledby="erpl_accordion-item-doc-gateway-EC-title">
-        <div>
+    <div id="es_accordion-item-doc-gateway-EC" class="collapse es_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="es_accordion-item-doc-gateway-EC-title">
             <div class="table-responsive">
                 <table class="table table-striped table-bordered">
                     <thead>
@@ -1280,7 +1280,6 @@
                     </tbody>
                 </table>
             </div>
-        </div>
     </div>
 </li>
                 
@@ -1299,173 +1298,7 @@
 
                                 
                                 
-<div class="erpl_product-section">
-    <div id="section8" class="separator border-dark my-3"></div>
-    <div class="erpl-product-content mb-2">
-        <div class="row">
-            <div class="col-12 col-lg"><h2 class="erpl_title-h2 mb-2">Transparency</h2>
-            </div>
-            <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
-                    <ul>
-                        <li>
-                            <a href="/oeil/en/procedure-file/pdf?reference=2022/2201(INI)&amp;section=TRANSPARENCY">
-                                <svg class="es_icon es_icon-pdf mr-1">
-                                    <title>pdf</title>
-                                    <use xlink:href="#es_icon-pdf"></use>
-                                </svg>
-                                <span class="t-x">Transparency</span>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-        </div>
 
-        <p>Meetings with interest representatives published in line with the Rules of Procedure</p>
-        <div class="erpl_accordion mb-5" id="erplAccordionTransparency">
-            <ul class="a-i">
-                <li class="erpl_accordion-item" data-selected="false">
-                    <button id="meetingGroup0-content-title"
-                            type="button"
-                            class="erpl_accordion-item-title collapsed"
-                            data-toggle="collapse"
-                            aria-expanded="false"
-                            data-target="#meetingGroup0-content"
-                            aria-controls="meetingGroup0-content">
-                        <span class="t-x">Rapporteurs, Shadow Rapporteurs and Committee Chairs</span>
-                        <span class="erpl_accordion-item-icon es_icon-container text-primary">
-                            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
-                                <use xlink:href="#es_icon-more"></use>
-                            </svg>
-                            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
-                                <use xlink:href="#es_icon-less"></use>
-                            </svg>
-                        </span>
-                    </button>
-                    <div id="meetingGroup0-content"
-                         class="collapse erpl_accordion-item-content a-i-none"
-                         aria-labelledby="meetingGroup0-content-title">
-                        <div class="oeil-meetings-list-container">
-                            <div class="table-responsive">
-                                <table class="table table-striped table-bordered">
-                                    <thead>
-                                    <tr>
-                                        <th class="align-middle" scope="col">Name</th>
-                                        <th class="align-middle" scope="col">Role</th>
-                                        <th class="align-middle" scope="col">Committee</th>
-                                        <th class="align-middle" scope="col">Date</th>
-                                        <th class="align-middle" scope="col">Interest representatives</th>
-                                    </tr>
-                                    </thead>
-                                    <tbody>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/197451"
-                                               class="font-weight-normal">VON CRAMON-TAUBADEL Viola</a>
-                                        </th>
-                                        <td class="align-middle">Rapporteur</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/AFET"
-                                               title="Committee on Foreign Affairs">AFET</a>
-                                        </td>
-                                        <td class="align-middle">20/03/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                Platforma Civikos
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/197670"
-                                               class="font-weight-normal">SCHIEDER Andreas</a>
-                                        </th>
-                                        <td class="align-middle">Shadow rapporteur</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/AFET"
-                                               title="Committee on Foreign Affairs">AFET</a>
-                                        </td>
-                                        <td class="align-middle">18/01/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                Cabinet to the First Deputy Prime Minister of the Republic of Kosovo
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                            
-                        </div>
-                    </div>
-                </li>
-            </ul>
-            <ul class="a-i">
-                <li class="erpl_accordion-item" data-selected="false">
-                    <button id="meetingGroup1-content-title"
-                            type="button"
-                            class="erpl_accordion-item-title collapsed"
-                            data-toggle="collapse"
-                            aria-expanded="false"
-                            data-target="#meetingGroup1-content"
-                            aria-controls="meetingGroup1-content">
-                        <span class="t-x">Other Members</span>
-                        <span class="erpl_accordion-item-icon es_icon-container text-primary">
-                            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
-                                <use xlink:href="#es_icon-more"></use>
-                            </svg>
-                            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
-                                <use xlink:href="#es_icon-less"></use>
-                            </svg>
-                        </span>
-                    </button>
-                    <div id="meetingGroup1-content"
-                         class="collapse erpl_accordion-item-content a-i-none"
-                         aria-labelledby="meetingGroup1-content-title">
-                        <div class="oeil-meetings-list-container">
-                            <div class="table-responsive">
-                                <table class="table table-striped table-bordered">
-                                    <thead>
-                                    <tr>
-                                        <th class="align-middle" scope="col">Name</th>
-                                        
-                                        
-                                        <th class="align-middle" scope="col">Date</th>
-                                        <th class="align-middle" scope="col">Interest representatives</th>
-                                    </tr>
-                                    </thead>
-                                    <tbody>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/197772"
-                                               class="font-weight-normal">STRIK Tineke</a>
-                                        </th>
-                                        
-                                        
-                                        <td class="align-middle">28/02/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                representative of the government of Kosovo
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                            
-                        </div>
-                    </div>
-                </li>
-            </ul>
-        </div>
-    </div>
-</div>
 
                                 
                                 <html lang="en">
@@ -1503,7 +1336,7 @@
 
 
 
-<div class="card erpl_move"
+<div class="card es_move"
      data-move-lg="#sectionsNavPositionRwd"
      data-move-md="#sectionsNavPositionRwd"
      data-move-sm="#sectionsNavPositionRwd"
@@ -1511,46 +1344,42 @@
      data-move-xs="#sectionsNavPositionRwd"
      data-move-xxl="#sectionsNavPositionInitial">
     <div class="card-body py-0">
-        <nav class="erpl_side-navigation">
-            <h3 class="erpl_title-h3 mb-0 py-2">
+        <nav class="es_side-navigation">
+            <h3 class="es_title-h3 mb-0 py-2">
                 <a class="text-primary" href="#">
                     <span class="t-x">Procedure file</span>
                 </a>
             </h3>
-            <div class="erpl_links-list erpl_links-list-nav">
+            <div class="es_links-list es_links-list-nav">
                 <ul>
                     <li data-selected="true">
-                        <a class="erpl_smooth-scroll" href="#section1">
+                        <a class="es_smooth-scroll" href="#section1">
                             <span class="t-x">Basic information</span>
                         </a>
                     </li>
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section2">
+                        <a class="es_smooth-scroll" href="#section2">
                             <span class="t-x">Key players</span>
                         </a>
                     </li>
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section3">
+                        <a class="es_smooth-scroll" href="#section3">
                             <span class="t-x">Key events</span>
                         </a>
                     </li>
                     
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section5">
+                        <a class="es_smooth-scroll" href="#section5">
                             <span class="t-x">Technical information</span>
                         </a>
                     </li>
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section6">
+                        <a class="es_smooth-scroll" href="#section6">
                             <span class="t-x">Documentation gateway</span>
                         </a>
                     </li>
                     
-                    <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section8">
-                            <span class="t-x">Transparency</span>
-                        </a>
-                    </li>
+                    
                     
                     
                 </ul>
@@ -1573,14 +1402,14 @@
     </button>
 
     
-    <footer class="erpl_footer">
-    <div class="erpl_footer-top mt-8">
+    <footer class="es_footer">
+    <div class="es_footer-top mt-8">
         <div class="container">
-            <div class="erpl_footer-top-content border-top-lg border-secondary text-center d-md-flex justify-content-between pt-md-3 mb-5 a-i">
-                <nav id="share-links" class="erpl_share-links" aria-label="Share links">
-                    <div class="d-md-flex">
-                        <h2 class="erpl_title-h5 mb-2 mb-md-0"><span class="mr-md-1">Share this page</span></h2>
-                        <ul class="erpl_share-links-list d-flex justify-content-center mb-3 mb-md-0">
+            <div class="es_footer-top-content border-top-lg border-secondary text-center d-md-flex justify-content-between pt-md-3 mb-5 a-i">
+                <nav id="share-links" class="es_footer-share-links" aria-label="Share links">
+                    <div class="d-md-flex align-items-center">
+                        <h2 class="es_title-h5 mb-2 mb-md-0"><span class="mr-md-1">Share this page</span></h2>
+                        <ul class="es_social-share-horizontal d-flex justify-content-center align-items-center mb-3 mb-md-0 pl-0">
                             <li class="mr-1">
                                 <a title="Share this page on Facebook" href="https://www.facebook.com/share.php?u=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2022/2201(INI)" target="_blank">
                                     <span class="sr-only">Facebook</span>
@@ -1590,10 +1419,10 @@
                                 </a>
                             </li>
                             <li class="mr-1">
-                                <a title="Share this page on Twitter" href="https://twitter.com/intent/tweet?url=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2022/2201(INI)&amp;text=Procedure%20File:%202022/2201(INI)&amp;via=Europarl_EN" target="_blank">
-                                    <span class="sr-only">Twitter</span>
-                                    <svg aria-hidden="true" class="es_icon es_icon-twitter">
-                                        <use xlink:href="#es_icon-twitter"></use>
+                                <a title="Share this page on X" href="https://x.com/intent/post?url=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2022/2201(INI)&amp;text=Procedure%20File:%202022/2201(INI)&amp;via=Europarl_EN" target="_blank">
+                                    <span class="sr-only">X</span>
+                                    <svg aria-hidden="true" class="es_icon es_icon-twitter-x">
+                                        <use xlink:href="#es_icon-twitter-x"></use>
                                     </svg>
                                 </a>
                             </li>
@@ -1616,7 +1445,7 @@
                         </ul>
                     </div>
                 </nav>
-                <nav class="erpl_horizontal-links" aria-label="data protection link">
+                <nav class="es_horizontal-links" aria-label="data protection link">
                     <div>
                         <a href="https://oeil.secure.europarl.europa.eu/oeil/en/external-documents/download?id=2" target="_blank">
                             <span class="t-y">Data Protection Notice</span>
@@ -1626,28 +1455,28 @@
             </div>
         </div>
     </div>
-    <div class="erpl_footer-bottom bg-black-footer pt-3 pb-3">
+    <div class="es_footer-bottom bg-black-footer pt-3 pb-3">
         <div class="container">
             <div class="row" id="footerLinks">
                 <nav class="col-12 col-xl-9 text-center text-md-left" id="website-links" aria-label="Website links">
-    <h3 class="erpl_title-h3 mb-2 text-white">Legislative Observatory</h3>
+    <h3 class="es_title-h3 mb-2 text-white">Legislative Observatory</h3>
     <div class="collapse show" id="website-links-items">
         <div class="row">
             <div class="col-12 col-md-6 col-xl-4">
                 <div>
                     <div class="subtitle mb-1">Tools</div>
                     <nav class="link-group t-x-mode" aria-label="Tools">
-                        <a href="https://www.europarl.europa.eu/news/en/press-room" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/news/en/press-room" class="link-group-item mb-1 d-block" aria-label="Tools - Press Service">
                             <span>Press Service</span>
-                        </a><a href="https://www.europarl.europa.eu/olp/en/home" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/olp/en/home" class="link-group-item mb-1 d-block" aria-label="Tools - Ordinary legislative procedure">
                             <span>Ordinary legislative procedure</span>
-                        </a><a href="https://www.europarl.europa.eu/RegistreWeb/search/simple.htm?language=en" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/RegistreWeb/search/simple.htm?language=en" class="link-group-item mb-1 d-block" aria-label="Tools - Parliament register">
                             <span>Parliament register</span>
-                        </a><a href="https://eur-lex.europa.eu/en/index.htm" class="link-group-item mb-1 d-block">
+                        </a><a href="https://eur-lex.europa.eu/en/index.htm" class="link-group-item mb-1 d-block" aria-label="Tools - EUR-Lex">
                             <span>EUR-Lex</span>
-                        </a><a href="https://www.consilium.europa.eu/en/documents-publications/public-register/" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.consilium.europa.eu/en/documents-publications/public-register/" class="link-group-item mb-1 d-block" aria-label="Tools - Council register">
                             <span>Council register</span>
-                        </a><a href="https://webgate.ec.europa.eu/regdel/#/home" class="link-group-item mb-1 d-block">
+                        </a><a href="https://webgate.ec.europa.eu/regdel/#/home" class="link-group-item mb-1 d-block" aria-label="Tools - Delegated acts register">
                             <span>Delegated acts register</span>
                         </a>
                     </nav>
@@ -1657,15 +1486,15 @@
                 <div>
                     <div class="subtitle mb-1">Committees</div>
                     <nav class="link-group t-x-mode" aria-label="Committees">
-                        <a href="https://www.europarl.europa.eu/committees/en/home" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/committees/en/home" class="link-group-item mb-1 d-block" aria-label="Committees - Home">
                             <span>Home</span>
-                        </a><a href="https://www.europarl.europa.eu/committees/en/meetings/meeting-documents" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/committees/en/meetings/meeting-documents" class="link-group-item mb-1 d-block" aria-label="Committees - Meetings">
                             <span>Meetings</span>
-                        </a><a href="https://www.europarl.europa.eu/committees/en/documents/search" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/committees/en/documents/search" class="link-group-item mb-1 d-block" aria-label="Committees - Documents">
                             <span>Documents</span>
-                        </a><a href="https://www.europarl.europa.eu/committees/en/events/events-hearings" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/committees/en/events/events-hearings" class="link-group-item mb-1 d-block" aria-label="Committees - Events">
                             <span>Events</span>
-                        </a><a href="https://www.europarl.europa.eu/committees/en/supporting-analyses/sa-highlights" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/committees/en/supporting-analyses/sa-highlights" class="link-group-item mb-1 d-block" aria-label="Committees - Supporting analyses">
                             <span>Supporting analyses</span>
                         </a>
                     </nav>
@@ -1673,16 +1502,16 @@
                 <div>
                     <div class="subtitle mb-1">Plenary</div>
                     <nav class="link-group t-x-mode" aria-label="Plenary">
-                        <a href="https://www.europarl.europa.eu/plenary/en/" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/plenary/en/" class="link-group-item mb-1 d-block" aria-label="Plenary - Plenary sitting">
                             <span>Plenary sitting</span>
-                        </a><a href="https://www.europarl.europa.eu/plenary/en/guide-plenary.html" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/guide-plenary.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Around plenary">
                             <span>Around plenary</span>
-                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliamentary-questions.html" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliamentary-questions.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Questions and declarations">
                             <span>Questions and declarations</span>
-                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliament-positions.html" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliament-positions.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Legislative texts adopted">
                             <span>Legislative texts adopted</span>
-                        </a><a href="https://www.europarl.europa.eu/plenary/en/meetings-search.html" class="link-group-item mb-1 d-block">
-                            <span>Calendar</span>
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/meetings-search.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Plenary calendar">
+                            <span>Plenary calendar</span>
                         </a>
                     </nav>
                 </div>
@@ -1691,9 +1520,9 @@
                 <div>
                     <div class="subtitle mb-1">Delegations</div>
                     <nav class="link-group t-x-mode" aria-label="Delegations">
-                        <a href="https://www.europarl.europa.eu/delegations/en/calendar" class="link-group-item mb-1 d-block">
-                            <span>Calendar</span>
-                        </a><a href="https://www.europarl.europa.eu/delegations/en/home" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/delegations/en/calendar" class="link-group-item mb-1 d-block" aria-label="Delegations - Delegations calendar">
+                            <span>Delegations calendar</span>
+                        </a><a href="https://www.europarl.europa.eu/delegations/en/home" class="link-group-item mb-1 d-block" aria-label="Delegations - Home">
                             <span>Home</span>
                         </a>
                     </nav>
@@ -1701,7 +1530,7 @@
                 <div>
                     <div class="subtitle mb-1">MEPs</div>
                     <nav class="link-group t-x-mode" aria-label="MEPs">
-                        <a href="https://www.europarl.europa.eu/meps/en/search/advanced" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/meps/en/search/advanced" class="link-group-item mb-1 d-block" aria-label="MEPs - Search">
                             <span>Search</span>
                         </a>
                     </nav>
@@ -1709,7 +1538,7 @@
                 <div>
                     <div class="subtitle mb-1">At your service</div>
                     <nav class="link-group t-x-mode" aria-label="At your service">
-                        <a href="https://www.europarl.europa.eu/at-your-service/en" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/at-your-service/en" class="link-group-item mb-1 d-block" aria-label="At your service - Home">
                             <span>Home</span>
                         </a>
                     </nav>
@@ -1720,7 +1549,7 @@
 
     <div class="d-block d-md-none">
         <div class="footerLinkToggle separator separator-dotted separator-2x mb-5 mt-5 collapsed">
-            <a class="erpl_toggle-menu" href="#website-links"
+            <a class="es_toggle-menu" href="#website-links"
                title="Toggle linked links"
                role="button"
                data-toggle="collapse"
@@ -1735,7 +1564,7 @@
                     <use xlink:href="#es_icon-minus"></use>
                 </svg>
             </a>
-            <a class="erpl_nojs-close-menu" href="#website-links-close"
+            <a class="es_nojs-close-menu" href="#website-links-close"
                title="Untoggle linked links"
                role="button"
                data-toggle="collapse"
@@ -1751,18 +1580,18 @@
 </nav>
                 <nav class="col-12 col-xl-3 text-center text-md-left" id="europarl-links" aria-label="Europarl links">
     <div class="separator separator-dotted separator-2x mt-3 mb-4 d-none d-md-flex d-xl-none"></div>
-    <h3 class="erpl_title-h3 mb-2 text-white">European Parliament</h3>
+    <h3 class="es_title-h3 mb-2 text-white">European Parliament</h3>
     <div class="collapse show" id="europarl-links-items">
         <nav class="link-group pt-25 t-x-mode" aria-label="European Parliament">
-            <a href="https://www.europarl.europa.eu/news/en" class="link-group-item mb-1 d-block">
-                <span>News</span></a><a href="https://www.europarl.europa.eu/topics/en" class="link-group-item mb-1 d-block">
-                <span>Topics</span></a><a href="https://www.europarl.europa.eu/meps/en" class="link-group-item mb-1 d-block">
-                <span>MEPs</span></a><a href="https://www.europarl.europa.eu/about-parliament/en" class="link-group-item mb-1 d-block">
-                <span>About Parliament</span></a><a href="https://www.europarl.europa.eu/plenary/en" class="link-group-item mb-1 d-block">
-                <span>Plenary</span></a><a href="https://www.europarl.europa.eu/committees/en" class="link-group-item mb-1 d-block">
-                <span>Committees</span></a><a href="https://www.europarl.europa.eu/delegations/en" class="link-group-item mb-1 d-block">
-                <span>Delegations</span></a><a href="https://elections.europa.eu/en/" class="link-group-item mb-1 d-block">
-                <span>Elections</span></a>
+            <a href="https://www.europarl.europa.eu/news/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - News">
+                <span>News</span></a><a href="https://www.europarl.europa.eu/topics/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Topics">
+                <span>Topics</span></a><a href="https://www.europarl.europa.eu/meps/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - MEPs">
+                <span>MEPs</span></a><a href="https://www.europarl.europa.eu/about-parliament/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - About Parliament">
+                <span>About Parliament</span></a><a href="https://www.europarl.europa.eu/plenary/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Plenary">
+                <span>Plenary</span></a><a href="https://www.europarl.europa.eu/committees/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Committees">
+                <span>Committees</span></a><a href="https://www.europarl.europa.eu/delegations/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Delegations">
+                <span>Delegations</span></a><a href="https://eubudget.europarl.europa.eu/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - EU budget">
+                <span>EU budget</span></a>
         </nav>
     </div>
     <div class="d-block d-md-none">
@@ -1782,7 +1611,7 @@
                     <use xlink:href="#es_icon-minus"></use>
                 </svg>
             </a>
-            <a class="erpl_nojs-close-menu" href="#europarl-links-close"
+            <a class="es_nojs-close-menu" href="#europarl-links-close"
                title="Untoggle European Parliament websites"
                role="button" data-toggle="collapse"
                data-target="#europarl-links-items"
@@ -1800,67 +1629,68 @@
 
             <div class="separator separator-dotted separator-2x mt-3 mb-3 d-none d-md-flex"></div>
             <div class="row">
-                <nav class="col-12" id="social-links" aria-label="Social links">
-                    <div class="erpl_social-links mb-2">
+                <nav class="col-12 d-flex justify-content-center" id="social-links" aria-label="Social links">
+                    <div class="es_footer-social-links mb-2">
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Facebook" href="https://www.facebook.com/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-facebook-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Facebook" href="https://www.facebook.com/europeanparliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-facebook-color">
                                     <use href="#es_icon-facebook-color"></use>
                                 </svg>
                                 <span class="sr-only">Facebook</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Twitter" href="https://twitter.com/Europarl_en" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-twitter-color">
-                                    <use href="#es_icon-twitter-color"></use>
+                            <a  data-toggle="tooltip" title="Check out Parliament on X" href="https://x.com/Europarl_en" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-twitter-x">
+                                    <use href="#es_icon-twitter-x"></use>
                                 </svg>
                                 <span class="sr-only">Twitter</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Flickr" href="https://www.flickr.com/photos/european_parliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-flickr-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Flickr" href="https://www.flickr.com/photos/european_parliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-flickr-color">
                                     <use href="#es_icon-flickr-color"></use>
                                 </svg>
                                 <span class="sr-only">Flickr</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on LinkedIn" href="https://www.linkedin.com/company/european-parliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-linkedin-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on LinkedIn" href="https://www.linkedin.com/company/european-parliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-linkedin-color">
                                     <use href="#es_icon-linkedin-color"></use>
                                 </svg>
                                 <span class="sr-only">LinkedIn</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on YouTube" href="https://www.youtube.com/user/EuropeanParliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-youtube-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on YouTube" href="https://www.youtube.com/user/EuropeanParliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-youtube-color">
                                     <use href="#es_icon-youtube-color"></use>
                                 </svg>
                                 <span class="sr-only">YouTube</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Instagram" href="https://www.instagram.com/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-instagram-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Instagram" href="https://www.instagram.com/europeanparliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-instagram-color">
                                     <use href="#es_icon-instagram-color"></use>
                                 </svg>
                                 <span class="sr-only">Instagram</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Pinterest" href="https://www.pinterest.fr/epinfographics" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-pinterest-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Pinterest" href="https://www.pinterest.fr/epinfographics" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-pinterest-color">
                                     <use href="#es_icon-pinterest-color"></use>
                                 </svg>
                                 <span class="sr-only">Pinterest</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Snapchat" href="https://www.snapchat.com/add/europarl" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-snapchat-color">
-                                    <use href="#es_icon-snapchat-color"></use>
-                                </svg>
-                                <span class="sr-only">Snapchat</span>
-                            </a>
-                        
-                            <a data-toggle="tooltip" title="Check out Parliament on Reddit" href="https://www.reddit.com/r/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-reddit-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Reddit" href="https://www.reddit.com/r/europeanparliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-reddit-color">
                                     <use href="#es_icon-reddit-color"></use>
                                 </svg>
                                 <span class="sr-only">Reddit</span>
@@ -1897,12 +1727,9 @@
         </div>
     </div>
 </footer>
-
     
-    <script src="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/lib/jquery/jquery.min.js"></script>
-    
-    <script id="evostrap" src="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/dist/js/evostrap.js"></script>
-    <script src="https://www.europarl.europa.eu/commonFrontResources/evostrap-oeil/1.0.0//dist/js/oeil.js"></script>
+    <script id="evostrap" type="module" src="https://evokits.europarl.europa.eu/evostrap/7.0.0/lib/dist/js/evostrap.js"></script>
+    <script src="https://evokits.europarl.europa.eu/evostrap-oeil/1.0.1/dist/js/oeil.js"></script>
 
     
     <script src="/oeil/oeil-addons/documents-loading.js"></script>

--- a/backend/tests/scrapers/data/votes/oeil-procedure-file_2022-2852-rsp.html
+++ b/backend/tests/scrapers/data/votes/oeil-procedure-file_2022-2852-rsp.html
@@ -25,9 +25,9 @@
     <meta content="en" http-equiv="Content-Language">
     <meta content="European Parliament Legislative Observatory Procedure" name="description">
     <meta content="index, follow, noodp, noydir, notranslate, noarchive" name="robots">
-    <meta content="European Union, 2024 - Source: European Parliament" name="copyright">
+    <meta content="European Union, 2025 - Source: European Parliament" name="copyright">
     <meta content="Legislative Observatory" name="planet">
-    <meta content="17-11-2024" name="available">
+    <meta content="13-11-2025" name="available">
 
     <!-- Dynamics meta tags -->
     
@@ -35,41 +35,40 @@
     
 
     <!-- HTML <link> tags -->
-    <link rel="icon" href="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/assets/img/favicon.ico">
+    <link rel="icon" href="https://evokits.europarl.europa.eu/evostrap/7.0.0/lib/dist/assets/img/favicon.ico">
 
     
-    <link href="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/dist/css/evostrap.css" rel="stylesheet">
-    <link href="https://www.europarl.europa.eu/commonFrontResources/evostrap-oeil/1.0.0//dist/css/oeil.css" rel="stylesheet">
+    <link href="https://evokits.europarl.europa.eu/evostrap/7.0.0/lib/dist/css/evostrap.css" rel="stylesheet">
+    <link href="https://evokits.europarl.europa.eu/evostrap-oeil/1.0.1/dist/css/oeil.css" rel="stylesheet">
 </head>
 
 <body id="main-content" data-app-context="/oeil/">
 
-    <header class="erpl_header">
-    <nav class="erpl_wai-access" aria-label="Shortcuts">
+    <header class="es_header">
+    <nav class="es_wai-access" aria-label="Shortcuts">
         <ul>
-            <li> <a href="#website-body" class="erpl_smooth-scroll"> <span class="btn btn-primary">Access to page content (press &quot;Enter&quot;)</span> </a> </li>
-            <li> <a href="#languageSelectorDropdownButton" class="erpl_smooth-scroll"> <span class="btn btn-primary">Direct access to language menu (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#website-body" class="es_smooth-scroll"> <span class="btn btn-primary">Access to page content (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#languageSelectorDropdownButton" class="es_smooth-scroll"> <span class="btn btn-primary">Direct access to language menu (press &quot;Enter&quot;)</span> </a> </li>
 
-            <li> <a href="#mainSearch" class="erpl_smooth-scroll"> <span class="btn btn-primary">Direct access to search menu (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#mainSearch" class="es_smooth-scroll"> <span class="btn btn-primary">Direct access to search menu (press &quot;Enter&quot;)</span> </a> </li>
         </ul>
     </nav>
 
     
-    <div class="erpl_header-top border-bottom mb-3 mb-xl-4 a-i">
+    <div class="es_header-top border-bottom mb-3 mb-xl-4 a-i">
         <div class="container">
             <div class="row no-gutters">
-                <div class="col-auto"><div class="erpl_header-language-selector">
-    <div class="erpl_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute"
+                <div class="col-auto"><div class="es_header-language-selector">
+    <div class="es_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute"
          data-content-width="auto">
-        <button class="erpl_dropdown-btn input-group collapsed" type="button" data-toggle="collapse"
+        <button class="es_dropdown-btn input-group collapsed" type="button" data-toggle="collapse"
                 id="languageSelectorDropdownButton"
                 data-target="#languageSelectorDropdownContent"
                 aria-expanded="false"
                 aria-controls="languageSelectorDropdownContent">
-            <span class="value form-control">EN - English</span>
+            <span class="es_dropdown-label">EN - English</span>
             
-            <span class="input-group-append">
-                <span class="input-group-icon">
+            <span class="es_dropdown-icon">
                     <svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false">
                         <use xlink:href="#es_icon-arrow"></use>
                     </svg>
@@ -77,18 +76,15 @@
                          data-show-expanded="true">
                         <use xlink:href="#es_icon-arrow"></use>
                     </svg>
-                </span>
             </span>
         </button>
 
         <div>
-            <div class="erpl_dropdown-content collapse" id="languageSelectorDropdownContent">
-                <div class="border border-light">
-                    <div>
-                        <ul class="erpl_topbar-list list-unstyled erpl_dropdown-menu">
+            <div class="dropdown-menu border border-light" id="languageSelectorDropdownContent">
+                        <ul class="erpl_topbar-list list-unstyled es_dropdown-menu">
                             <li class="t-x-block" data-selected="false">
                                 <!-- localized version URL is here -->
-                                <a class="erpl_dropdown-menu-item"
+                                <a class="es_dropdown-menu-item"
                                    lang="fr"
                                    href="https://oeil.secure.europarl.europa.eu/oeil/fr/procedure-file?reference=2022/2852(RSP)">
                                     
@@ -97,7 +93,7 @@
                             </li>
                             <li class="t-x-block" data-selected="true">
                                 <!-- localized version URL is here -->
-                                <a class="erpl_dropdown-menu-item"
+                                <a class="es_dropdown-menu-item"
                                    lang="en"
                                    href="https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2022/2852(RSP)">
                                     <span class="t-item">EN - English</span>
@@ -105,14 +101,12 @@
                                 </a>
                             </li>
                         </ul>
-                    </div>
-                </div>
             </div>
         </div>
     </div>
 </div></div>
                 <div class="col">
-                    <nav class="erpl_header-other-websites d-flex justify-content-end align-items-center" aria-label="Other websites">
+                    <nav class="es_header-other-websites d-flex justify-content-end align-items-center" aria-label="Other websites">
                         <ul class="d-flex list-unstyled">
 
                             
@@ -166,24 +160,23 @@
 
                             
                             <li class="d-none d-xl-block">
-                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://elections.europa.eu/en/">
-                                    <span class="t-item">Elections</span>
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://eubudget.europarl.europa.eu/en">
+                                    <span class="t-item">EU budget</span>
                                 </a>
                             </li>
 
 
-                            <li class="erpl_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute">
-                               <button class="erpl_dropdown-btn input-group collapsed d-xl-flex pl-1 align-items-center t-y-block flex-nowrap"
+                            <li class="es_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute">
+                               <button class="es_dropdown-btn input-group collapsed d-xl-flex pl-1 align-items-center t-y-block flex-nowrap"
                                        data-toggle="collapse"
                                        data-target="#otherWebsiteSubmenu"
                                        aria-expanded="false"
                                        aria-controls="otherWebsiteSubmenu" aria-label="More other websites">
-                                    <span class="value">
+                                    <span class="es_dropdown-label">
 											<span class="d-none d-xl-inline">Other websites</span>
 											<span class="d-xl-none">View other websites</span>
                                     </span>
-                                   <span class="input-group-append">
-											<span class="input-group-icon">
+                                   <span class="es_dropdown-icon">
 												<svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false">
 													<use xlink:href="#es_icon-arrow"></use>
 												</svg>
@@ -192,140 +185,153 @@
 													<use xlink:href="#es_icon-arrow"></use>
 												</svg>
 											</span>
-										</span>
                                 </button>
                                 <div>
-                                    <div id="otherWebsiteSubmenu" class="erpl_dropdown-content collapse">
-                                        <ul class="erpl_header-other-websites-submenu list-unstyled erpl_dropdown-menu">
+                                    <div id="otherWebsiteSubmenu" class="dropdown-menu border border-light">
+                                        <ul class="es_header-other-websites-submenu erpl_topbar-list list-unstyled es_dropdown-men">
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/news/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/news/en">
                                                     <span class="t-item">News</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/topics/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/topics/en">
                                                     <span class="t-item">Topics</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/meps/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/meps/en">
                                                     <span class="t-item">MEPs</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/about-parliament/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/about-parliament/en">
                                                     <span class="t-item">About Parliament</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/plenary/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/plenary/en">
                                                     <span class="t-item">Plenary</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/committees/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/committees/en">
                                                     <span class="t-item">Committees</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/delegations/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/delegations/en">
                                                     <span class="t-item">Delegations</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://elections.europa.eu/en/">
-                                                    <span class="t-item">Elections</span>
+                                                <a class="es_dropdown-menu-item" href="https://eubudget.europarl.europa.eu/en">
+                                                    <span class="t-item">EU budget</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://multimedia.europarl.europa.eu/en/home">
+                                                <a class="es_dropdown-menu-item" href="https://multimedia.europarl.europa.eu/en/home">
                                                     <span class="t-item">Multimedia Centre</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/the-president/en">
-                                                    <span class="t-item">President&#39;s website</span>
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/the-president/en">
+                                                    <span class="t-item">Presidency</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/the-secretary-general/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/the-secretary-general/en">
                                                     <span class="t-item">Secretariat-general</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/thinktank/en">
+                                                <a class="es_dropdown-menu-item" href="https://elections.europa.eu/en/">
+                                                    <span class="t-item">Elections</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/thinktank/en">
                                                     <span class="t-item">Thinktank</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.epnewshub.eu">
+                                                <a class="es_dropdown-menu-item" href="https://www.epnewshub.eu">
                                                     <span class="t-item">EP Newshub</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/at-your-service/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/at-your-service/en">
                                                     <span class="t-item">At your service</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/visiting/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/visiting/en">
                                                     <span class="t-item">Visits</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/legislative-train">
+                                                <a class="es_dropdown-menu-item" href="https://oeil.secure.europarl.europa.eu/oeil/en">
+                                                    <span class="t-item">Legislative Observatory</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/legislative-train">
                                                     <span class="t-item">Legislative train</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/contracts-and-grants/en/">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/contracts-and-grants/en/">
                                                     <span class="t-item">Contracts and Grants</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/RegistreWeb/home/welcome.htm?language=en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/RegistreWeb/home/welcome.htm?language=en">
                                                     <span class="t-item">Register</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://data.europarl.europa.eu/en">
+                                                <a class="es_dropdown-menu-item" href="https://data.europarl.europa.eu/en">
                                                     <span class="t-item">Open Data Portal</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://liaison-offices.europarl.europa.eu/en">
+                                                <a class="es_dropdown-menu-item" href="https://liaison-offices.europarl.europa.eu/en">
                                                     <span class="t-item">Liaison offices</span>
                                                 </a>
                                             </li>
@@ -339,17 +345,17 @@
             </div>
         </div>
     </div>
-    <div class="erpl_header-middle mb-3">
+    <div class="es_header-middle mb-3">
         <div class="container">
             <div class="row">
                 <div class="col-12 col-md">
-                    <div class="erpl_header-website-title a-i">
-                        <div class="erpl_header-website-title-main">
+                    <div class="es_header-website-title a-i">
+                        <div class="es_header-website-title-main">
                             <a href="/oeil/en" class="t-x">
                                 <span>Legislative Observatory</span>
                             </a>
                         </div>
-                        <div class="erpl_header-website-title-sub">
+                        <div class="es_header-website-title-sub">
                             <a class="t-x-block" href="https://www.europarl.europa.eu" target="_blank" >
                                 <span class="t-item">European Parliament</span>
                             </a>
@@ -358,17 +364,18 @@
                 </div>
 
                 
-                <div class="col-auto d-none d-xl-flex justify-content-end align-items-center erpl_header-search-container">
-                    <form class="erpl_header-search" method="GET" action="/oeil/en/search"> <label for="mainSearch" class="sr-only">Find a procedure</label>
+                <div class="col-auto d-none d-xl-flex justify-content-end align-items-center es_header-search-container">
+                    <form class="es_header-search" method="GET" action="/oeil/en/search"> <label for="mainSearch" class="sr-only">Find a procedure</label>
                         <div class="input-group" style="width: 300px">
                             <input type="text" class="form-control"
                                    id="mainSearch"
+                                   maxlength="100"
                                    placeholder="Find a procedure..."
                                    name="fullText.term"
                                    aria-describedby="mainSearchHelper">
                             <div class="input-group-append">
                                 <button class="btn btn-primary align-items-center d-flex" title="Start find a procedure" disabled="">
-                                    <svg aria-hidden="true" class="es_icon es_icon-search erpl_header-search-icon">
+                                    <svg aria-hidden="true" class="es_icon es_icon-search es_header-search-icon">
                                         <use xlink:href="#es_icon-search"></use>
                                     </svg>
                                 </button>
@@ -379,64 +386,64 @@
             </div>
         </div>
     </div>
-    <div class="erpl_header-bottom">
-        <div class="erpl_header-menu-container">
-            <div class="container"><nav class="erpl_header-menu" aria-label="Main navigation">
-    <div class="erpl_header-menu-top row align-items-center">
+    <div class="es_header-bottom">
+        <div class="es_header-menu-container">
+            <div class="container"><nav class="es_header-menu" aria-label="Main navigation">
+    <div class="es_header-menu-top row align-items-center">
         <div class="col d-md-none d-flex align-items-center">
-            <svg aria-hidden="true" class="es_icon es_icon-ep-logo-w erpl_header-menu-top-logo">
+            <svg aria-hidden="true" class="es_icon es_icon-ep-logo-w es_header-menu-top-logo">
                 <use xlink:href="#es_icon-ep-logo-w"></use>
             </svg>
         </div>
 
-        <span class="erpl_header-menu-top-title offset-3 col-6 text-center d-none d-md-block" aria-hidden="true">
+        <span class="es_header-menu-top-title offset-3 col-6 text-center d-none d-md-block" aria-hidden="true">
 								<span>European Parliament</span></span>
 
-        <div class="erpl_header-menu-top-controls col-auto col-md-3 text-right">
-            <button type="button" class="btn btn-sm btn-dark-primary erpl_header-menu-top-controls-toggle-search" id="headerMenuToggleSearch" aria-haspopup="true" aria-expanded="false">
+        <div class="es_header-menu-top-controls col-auto col-md-3 text-right">
+            <button type="button" class="btn btn-sm btn-dark-primary es_header-menu-top-controls-toggle-search" id="headerMenuToggleSearch" aria-haspopup="true" aria-expanded="false">
                 <span class="sr-only">Search</span>
                 <svg aria-hidden="true" class="es_icon es_icon-search">
                     <use xlink:href="#es_icon-search"></use>
                 </svg>
             </button>
             <button type="button"
-                    class="btn btn-sm btn-dark-primary erpl_header-menu-top-controls-toggle-menu"
+                    class="btn btn-sm btn-dark-primary es_header-menu-top-controls-toggle-menu"
                     id="headerMenuToggleMenu"
                     aria-haspopup="true"
                     aria-expanded="false">
-                <span class="mr-25">Menu</span> <span class="erpl_header-menu-icon" aria-hidden="true"></span>
+                <span class="mr-25">Menu</span> <span class="es_header-menu-icon" aria-hidden="true"></span>
             </button>
         </div>
     </div>
 
-    <ul class="erpl_header-menu-list list-unstyled">
+    <ul class="es_header-menu-list list-unstyled">
         
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en" data-selected="false">
         <span class="t-y">Home</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/search" data-selected="false">
         <span class="t-y">Search</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/legislative-priorities" data-selected="false">
         <span class="t-y">Legislative priorities</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/find-out-more" data-selected="false">
         <span class="t-y">Find out more</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/contact" data-selected="false">
         <span class="t-y">Contact us</span>
     </a>
@@ -458,10 +465,10 @@
     <div class="row">
         <div class="col-12 col-xl-8">
             <div class="row">
-                <div class="col-12 col-lg"><h2 class="erpl_title-h1 mb-3">2022/2852(RSP)</h2>
+                <div class="col-12 col-lg"><h2 class="es_title-h1 mb-3">2022/2852(RSP)</h2>
                 </div>
                 <div class="col-12 col-lg-4">
-                    <div class="erpl_links-list text-lg-right my-1">
+                    <div class="es_links-list text-lg-right my-1">
                         <ul>
                             <li>
                                 <a href="/oeil/en/procedure-file/pdf?reference=2022/2852(RSP)">
@@ -477,7 +484,7 @@
                 </div>
             </div>
             
-            <h2 class="erpl_title-h2 mb-3">Resolution on the accession of Romania and Bulgaria to the Schengen area</h2>
+            <h2 class="es_title-h2 mb-3">Resolution on the accession of Romania and Bulgaria to the Schengen area</h2>
             <div class="separator border-dark my-3"></div>
 
             
@@ -485,22 +492,22 @@
 
 
             
-            <div class="erpl_product">
+            <div class="es_product">
                 <div class="row">
                     <div class="col">
                         <div class="mb-3">
-                            <div class="erpl_product-body">
+                            <div class="es_product-body">
                                 
                                 <html lang="en">
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div id="section1" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 class="erpl_title-h2 mb-2">Basic information</h2></div>
+                <h2 class="es_title-h2 mb-2">Basic information</h2></div>
                 <div class="col-12 col-lg-4">
-                    <div class="erpl_links-list text-lg-right my-1">
+                    <div class="es_links-list text-lg-right my-1">
                         <ul>
                             <li>
                                 <a href="/oeil/en/procedure-file/pdf?reference=2022/2852(RSP)&amp;section=BASIC_INFO">
@@ -565,13 +572,14 @@
         <div class="row">
             <div class="col-12">
                 <div class="separator separator-dotted separator-2x mt-5 mb-3">
-                    <a class="erpl_smooth-scroll btn btn-default" href="#gateway">Please go to Documentation gateway for any follow-up documents.</a>
+                    <a class="es_smooth-scroll btn btn-default" href="#gateway">Please go to Documentation gateway for any follow-up documents.</a>
                 </div>
             </div>
         </div>
     </div>
 </div>
 </html>
+
 
                                 
                                 
@@ -582,15 +590,15 @@
 
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section3" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 class="erpl_title-h2 mb-2">Key events</h2>
+                <h2 class="es_title-h2 mb-2">Key events</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2022/2852(RSP)&amp;section=KEY_EVENTS" target="_blank">
@@ -638,7 +646,7 @@
                             
                                 <a href="https://www.europarl.europa.eu/doceo/document/CRE-9-2022-10-05-TOC_EN.html" title="Go to the page" target="_blank">
                                     <svg aria-hidden="true" class="es_icon es_icon-comment-dots es_icon-24">
-                                        <use xlink:href="#es_icon-comment-dots"></use>
+                                        <use href="#es_icon-comment-dots"></use>
                                     </svg>
                                 </a>
                             
@@ -686,7 +694,8 @@
                             
 
                             
-                                <a href="/oeil/en/sda-vote-result?sdaId=58914" target="_blank">
+                                <a href="https://www.europarl.europa.eu/doceo/document/PV-9-2022-10-18-VOT_EN.html?item=8"
+                                   title="Results of vote in Parliament" target="_blank">
                                     <svg aria-hidden="true" class="es_icon es_icon-vote es_icon-24">
                                         <use xlink:href="#es_icon-vote"></use>
                                     </svg>
@@ -722,15 +731,15 @@
 
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section5" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 class="erpl_title-h2 mb-2">Technical information</h2>
+                <h2 class="es_title-h2 mb-2">Technical information</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2022/2852(RSP)&amp;section=TECHNICAL_INFORMATION">
@@ -748,12 +757,6 @@
 
         <div class="table-responsive">
             <table class="table table-striped table-bordered">
-                <thead>
-                <tr>
-                    <th class="align-middle" scope="col">Procedure</th>
-                    <th class="align-middle" scope="col">Information</th>
-                </tr>
-                </thead>
                 <tbody>
                 <tr>
                     <th class="align-middle" scope="row">Procedure reference</th>
@@ -764,7 +767,7 @@
                     <td class="align-middle">RSP - Resolutions on topical subjects</td>
                 </tr>
                 <tr>
-                    <th class="align-middle" scope="row">Nature of procedure</th>
+                    <th class="align-middle" scope="row">Procedure subtype</th>
                     <td class="align-middle">Resolution on statement</td>
                 </tr>
                 
@@ -796,15 +799,15 @@
 
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section6" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 id="gateway" class="erpl_title-h2 mb-2">Documentation gateway</h2>
+                <h2 id="gateway" class="es_title-h2 mb-2">Documentation gateway</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2022/2852(RSP)&amp;section=DOCUMENTATION_GATEWAY" target="_blank">
@@ -819,19 +822,19 @@
                 </div>
             </div>
         </div>
-        <div class="erpl_accordion mb-5" id="erplAccordionDocGateway">
+        <div class="es_accordion mb-5" id="erplAccordionDocGateway">
             <ul class="a-i">
                 
-                    <li class="erpl_accordion-item" data-selected="false">
+                    <li class="es_accordion-item" data-selected="false">
     <button
-            id="erpl_accordion-item-doc-gateway-EP-title"
+            id="es_accordion-item-doc-gateway-EP-title"
             type="button"
-            class="erpl_accordion-item-title collapsed"
+            class="es_accordion-item-title collapsed"
             data-toggle="collapse"
-            aria-expanded="true" data-target="#erpl_accordion-item-doc-gateway-EP" aria-controls="erpl_accordion-item-doc-gateway-EP"
+            aria-expanded="true" data-target="#es_accordion-item-doc-gateway-EP" aria-controls="es_accordion-item-doc-gateway-EP"
     >
         <span class="t-x">European Parliament</span>
-        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+        <span class="es_accordion-item-icon es_icon-container text-primary">
             <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
                 <use xlink:href="#es_icon-more"></use>
             </svg>
@@ -840,8 +843,7 @@
             </svg>
         </span>
     </button>
-    <div id="erpl_accordion-item-doc-gateway-EP" class="collapse erpl_accordion-item-content a-i-none collapse show" aria-labelledby="erpl_accordion-item-doc-gateway-EP-title">
-        <div>
+    <div id="es_accordion-item-doc-gateway-EP" class="collapse es_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="es_accordion-item-doc-gateway-EP-title">
             <div class="table-responsive">
                 <table class="table table-striped table-bordered">
                     <thead>
@@ -868,7 +870,7 @@
                             
                         </td>
                         <td class="align-middle w-25">
-                            <a href="https://www.europarl.europa.eu/doceo/document/B-9-2022-0463_EN.html" target="_blank">B9-0463/2022</a>
+                            <a href="https://www.europarl.europa.eu/doceo/document/B-9-2022-0462_EN.html" target="_blank">B9-0462/2022</a>
                             
                             
 
@@ -892,7 +894,7 @@
                             
                         </td>
                         <td class="align-middle w-25">
-                            <a href="https://www.europarl.europa.eu/doceo/document/B-9-2022-0462_EN.html" target="_blank">B9-0462/2022</a>
+                            <a href="https://www.europarl.europa.eu/doceo/document/B-9-2022-0463_EN.html" target="_blank">B9-0463/2022</a>
                             
                             
 
@@ -933,20 +935,19 @@
                     </tbody>
                 </table>
             </div>
-        </div>
     </div>
 </li>
                 
-                    <li class="erpl_accordion-item" data-selected="false">
+                    <li class="es_accordion-item" data-selected="false">
     <button
-            id="erpl_accordion-item-doc-gateway-EC-title"
+            id="es_accordion-item-doc-gateway-EC-title"
             type="button"
-            class="erpl_accordion-item-title collapsed"
+            class="es_accordion-item-title collapsed"
             data-toggle="collapse"
-            aria-expanded="true" data-target="#erpl_accordion-item-doc-gateway-EC" aria-controls="erpl_accordion-item-doc-gateway-EC"
+            aria-expanded="true" data-target="#es_accordion-item-doc-gateway-EC" aria-controls="es_accordion-item-doc-gateway-EC"
     >
         <span class="t-x">European Commission</span>
-        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+        <span class="es_accordion-item-icon es_icon-container text-primary">
             <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
                 <use xlink:href="#es_icon-more"></use>
             </svg>
@@ -955,8 +956,7 @@
             </svg>
         </span>
     </button>
-    <div id="erpl_accordion-item-doc-gateway-EC" class="collapse erpl_accordion-item-content a-i-none collapse show" aria-labelledby="erpl_accordion-item-doc-gateway-EC-title">
-        <div>
+    <div id="es_accordion-item-doc-gateway-EC" class="collapse es_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="es_accordion-item-doc-gateway-EC-title">
             <div class="table-responsive">
                 <table class="table table-striped table-bordered">
                     <thead>
@@ -996,7 +996,6 @@
                     </tbody>
                 </table>
             </div>
-        </div>
     </div>
 </li>
                 
@@ -1053,7 +1052,7 @@
 
 
 
-<div class="card erpl_move"
+<div class="card es_move"
      data-move-lg="#sectionsNavPositionRwd"
      data-move-md="#sectionsNavPositionRwd"
      data-move-sm="#sectionsNavPositionRwd"
@@ -1061,33 +1060,33 @@
      data-move-xs="#sectionsNavPositionRwd"
      data-move-xxl="#sectionsNavPositionInitial">
     <div class="card-body py-0">
-        <nav class="erpl_side-navigation">
-            <h3 class="erpl_title-h3 mb-0 py-2">
+        <nav class="es_side-navigation">
+            <h3 class="es_title-h3 mb-0 py-2">
                 <a class="text-primary" href="#">
                     <span class="t-x">Procedure file</span>
                 </a>
             </h3>
-            <div class="erpl_links-list erpl_links-list-nav">
+            <div class="es_links-list es_links-list-nav">
                 <ul>
                     <li data-selected="true">
-                        <a class="erpl_smooth-scroll" href="#section1">
+                        <a class="es_smooth-scroll" href="#section1">
                             <span class="t-x">Basic information</span>
                         </a>
                     </li>
                     
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section3">
+                        <a class="es_smooth-scroll" href="#section3">
                             <span class="t-x">Key events</span>
                         </a>
                     </li>
                     
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section5">
+                        <a class="es_smooth-scroll" href="#section5">
                             <span class="t-x">Technical information</span>
                         </a>
                     </li>
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section6">
+                        <a class="es_smooth-scroll" href="#section6">
                             <span class="t-x">Documentation gateway</span>
                         </a>
                     </li>
@@ -1115,14 +1114,14 @@
     </button>
 
     
-    <footer class="erpl_footer">
-    <div class="erpl_footer-top mt-8">
+    <footer class="es_footer">
+    <div class="es_footer-top mt-8">
         <div class="container">
-            <div class="erpl_footer-top-content border-top-lg border-secondary text-center d-md-flex justify-content-between pt-md-3 mb-5 a-i">
-                <nav id="share-links" class="erpl_share-links" aria-label="Share links">
-                    <div class="d-md-flex">
-                        <h2 class="erpl_title-h5 mb-2 mb-md-0"><span class="mr-md-1">Share this page</span></h2>
-                        <ul class="erpl_share-links-list d-flex justify-content-center mb-3 mb-md-0">
+            <div class="es_footer-top-content border-top-lg border-secondary text-center d-md-flex justify-content-between pt-md-3 mb-5 a-i">
+                <nav id="share-links" class="es_footer-share-links" aria-label="Share links">
+                    <div class="d-md-flex align-items-center">
+                        <h2 class="es_title-h5 mb-2 mb-md-0"><span class="mr-md-1">Share this page</span></h2>
+                        <ul class="es_social-share-horizontal d-flex justify-content-center align-items-center mb-3 mb-md-0 pl-0">
                             <li class="mr-1">
                                 <a title="Share this page on Facebook" href="https://www.facebook.com/share.php?u=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2022/2852(RSP)" target="_blank">
                                     <span class="sr-only">Facebook</span>
@@ -1132,10 +1131,10 @@
                                 </a>
                             </li>
                             <li class="mr-1">
-                                <a title="Share this page on Twitter" href="https://twitter.com/intent/tweet?url=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2022/2852(RSP)&amp;text=Procedure%20File:%202022/2852(RSP)&amp;via=Europarl_EN" target="_blank">
-                                    <span class="sr-only">Twitter</span>
-                                    <svg aria-hidden="true" class="es_icon es_icon-twitter">
-                                        <use xlink:href="#es_icon-twitter"></use>
+                                <a title="Share this page on X" href="https://x.com/intent/post?url=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2022/2852(RSP)&amp;text=Procedure%20File:%202022/2852(RSP)&amp;via=Europarl_EN" target="_blank">
+                                    <span class="sr-only">X</span>
+                                    <svg aria-hidden="true" class="es_icon es_icon-twitter-x">
+                                        <use xlink:href="#es_icon-twitter-x"></use>
                                     </svg>
                                 </a>
                             </li>
@@ -1158,7 +1157,7 @@
                         </ul>
                     </div>
                 </nav>
-                <nav class="erpl_horizontal-links" aria-label="data protection link">
+                <nav class="es_horizontal-links" aria-label="data protection link">
                     <div>
                         <a href="https://oeil.secure.europarl.europa.eu/oeil/en/external-documents/download?id=2" target="_blank">
                             <span class="t-y">Data Protection Notice</span>
@@ -1168,28 +1167,28 @@
             </div>
         </div>
     </div>
-    <div class="erpl_footer-bottom bg-black-footer pt-3 pb-3">
+    <div class="es_footer-bottom bg-black-footer pt-3 pb-3">
         <div class="container">
             <div class="row" id="footerLinks">
                 <nav class="col-12 col-xl-9 text-center text-md-left" id="website-links" aria-label="Website links">
-    <h3 class="erpl_title-h3 mb-2 text-white">Legislative Observatory</h3>
+    <h3 class="es_title-h3 mb-2 text-white">Legislative Observatory</h3>
     <div class="collapse show" id="website-links-items">
         <div class="row">
             <div class="col-12 col-md-6 col-xl-4">
                 <div>
                     <div class="subtitle mb-1">Tools</div>
                     <nav class="link-group t-x-mode" aria-label="Tools">
-                        <a href="https://www.europarl.europa.eu/news/en/press-room" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/news/en/press-room" class="link-group-item mb-1 d-block" aria-label="Tools - Press Service">
                             <span>Press Service</span>
-                        </a><a href="https://www.europarl.europa.eu/olp/en/home" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/olp/en/home" class="link-group-item mb-1 d-block" aria-label="Tools - Ordinary legislative procedure">
                             <span>Ordinary legislative procedure</span>
-                        </a><a href="https://www.europarl.europa.eu/RegistreWeb/search/simple.htm?language=en" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/RegistreWeb/search/simple.htm?language=en" class="link-group-item mb-1 d-block" aria-label="Tools - Parliament register">
                             <span>Parliament register</span>
-                        </a><a href="https://eur-lex.europa.eu/en/index.htm" class="link-group-item mb-1 d-block">
+                        </a><a href="https://eur-lex.europa.eu/en/index.htm" class="link-group-item mb-1 d-block" aria-label="Tools - EUR-Lex">
                             <span>EUR-Lex</span>
-                        </a><a href="https://www.consilium.europa.eu/en/documents-publications/public-register/" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.consilium.europa.eu/en/documents-publications/public-register/" class="link-group-item mb-1 d-block" aria-label="Tools - Council register">
                             <span>Council register</span>
-                        </a><a href="https://webgate.ec.europa.eu/regdel/#/home" class="link-group-item mb-1 d-block">
+                        </a><a href="https://webgate.ec.europa.eu/regdel/#/home" class="link-group-item mb-1 d-block" aria-label="Tools - Delegated acts register">
                             <span>Delegated acts register</span>
                         </a>
                     </nav>
@@ -1199,15 +1198,15 @@
                 <div>
                     <div class="subtitle mb-1">Committees</div>
                     <nav class="link-group t-x-mode" aria-label="Committees">
-                        <a href="https://www.europarl.europa.eu/committees/en/home" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/committees/en/home" class="link-group-item mb-1 d-block" aria-label="Committees - Home">
                             <span>Home</span>
-                        </a><a href="https://www.europarl.europa.eu/committees/en/meetings/meeting-documents" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/committees/en/meetings/meeting-documents" class="link-group-item mb-1 d-block" aria-label="Committees - Meetings">
                             <span>Meetings</span>
-                        </a><a href="https://www.europarl.europa.eu/committees/en/documents/search" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/committees/en/documents/search" class="link-group-item mb-1 d-block" aria-label="Committees - Documents">
                             <span>Documents</span>
-                        </a><a href="https://www.europarl.europa.eu/committees/en/events/events-hearings" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/committees/en/events/events-hearings" class="link-group-item mb-1 d-block" aria-label="Committees - Events">
                             <span>Events</span>
-                        </a><a href="https://www.europarl.europa.eu/committees/en/supporting-analyses/sa-highlights" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/committees/en/supporting-analyses/sa-highlights" class="link-group-item mb-1 d-block" aria-label="Committees - Supporting analyses">
                             <span>Supporting analyses</span>
                         </a>
                     </nav>
@@ -1215,16 +1214,16 @@
                 <div>
                     <div class="subtitle mb-1">Plenary</div>
                     <nav class="link-group t-x-mode" aria-label="Plenary">
-                        <a href="https://www.europarl.europa.eu/plenary/en/" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/plenary/en/" class="link-group-item mb-1 d-block" aria-label="Plenary - Plenary sitting">
                             <span>Plenary sitting</span>
-                        </a><a href="https://www.europarl.europa.eu/plenary/en/guide-plenary.html" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/guide-plenary.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Around plenary">
                             <span>Around plenary</span>
-                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliamentary-questions.html" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliamentary-questions.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Questions and declarations">
                             <span>Questions and declarations</span>
-                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliament-positions.html" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliament-positions.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Legislative texts adopted">
                             <span>Legislative texts adopted</span>
-                        </a><a href="https://www.europarl.europa.eu/plenary/en/meetings-search.html" class="link-group-item mb-1 d-block">
-                            <span>Calendar</span>
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/meetings-search.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Plenary calendar">
+                            <span>Plenary calendar</span>
                         </a>
                     </nav>
                 </div>
@@ -1233,9 +1232,9 @@
                 <div>
                     <div class="subtitle mb-1">Delegations</div>
                     <nav class="link-group t-x-mode" aria-label="Delegations">
-                        <a href="https://www.europarl.europa.eu/delegations/en/calendar" class="link-group-item mb-1 d-block">
-                            <span>Calendar</span>
-                        </a><a href="https://www.europarl.europa.eu/delegations/en/home" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/delegations/en/calendar" class="link-group-item mb-1 d-block" aria-label="Delegations - Delegations calendar">
+                            <span>Delegations calendar</span>
+                        </a><a href="https://www.europarl.europa.eu/delegations/en/home" class="link-group-item mb-1 d-block" aria-label="Delegations - Home">
                             <span>Home</span>
                         </a>
                     </nav>
@@ -1243,7 +1242,7 @@
                 <div>
                     <div class="subtitle mb-1">MEPs</div>
                     <nav class="link-group t-x-mode" aria-label="MEPs">
-                        <a href="https://www.europarl.europa.eu/meps/en/search/advanced" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/meps/en/search/advanced" class="link-group-item mb-1 d-block" aria-label="MEPs - Search">
                             <span>Search</span>
                         </a>
                     </nav>
@@ -1251,7 +1250,7 @@
                 <div>
                     <div class="subtitle mb-1">At your service</div>
                     <nav class="link-group t-x-mode" aria-label="At your service">
-                        <a href="https://www.europarl.europa.eu/at-your-service/en" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/at-your-service/en" class="link-group-item mb-1 d-block" aria-label="At your service - Home">
                             <span>Home</span>
                         </a>
                     </nav>
@@ -1262,7 +1261,7 @@
 
     <div class="d-block d-md-none">
         <div class="footerLinkToggle separator separator-dotted separator-2x mb-5 mt-5 collapsed">
-            <a class="erpl_toggle-menu" href="#website-links"
+            <a class="es_toggle-menu" href="#website-links"
                title="Toggle linked links"
                role="button"
                data-toggle="collapse"
@@ -1277,7 +1276,7 @@
                     <use xlink:href="#es_icon-minus"></use>
                 </svg>
             </a>
-            <a class="erpl_nojs-close-menu" href="#website-links-close"
+            <a class="es_nojs-close-menu" href="#website-links-close"
                title="Untoggle linked links"
                role="button"
                data-toggle="collapse"
@@ -1293,18 +1292,18 @@
 </nav>
                 <nav class="col-12 col-xl-3 text-center text-md-left" id="europarl-links" aria-label="Europarl links">
     <div class="separator separator-dotted separator-2x mt-3 mb-4 d-none d-md-flex d-xl-none"></div>
-    <h3 class="erpl_title-h3 mb-2 text-white">European Parliament</h3>
+    <h3 class="es_title-h3 mb-2 text-white">European Parliament</h3>
     <div class="collapse show" id="europarl-links-items">
         <nav class="link-group pt-25 t-x-mode" aria-label="European Parliament">
-            <a href="https://www.europarl.europa.eu/news/en" class="link-group-item mb-1 d-block">
-                <span>News</span></a><a href="https://www.europarl.europa.eu/topics/en" class="link-group-item mb-1 d-block">
-                <span>Topics</span></a><a href="https://www.europarl.europa.eu/meps/en" class="link-group-item mb-1 d-block">
-                <span>MEPs</span></a><a href="https://www.europarl.europa.eu/about-parliament/en" class="link-group-item mb-1 d-block">
-                <span>About Parliament</span></a><a href="https://www.europarl.europa.eu/plenary/en" class="link-group-item mb-1 d-block">
-                <span>Plenary</span></a><a href="https://www.europarl.europa.eu/committees/en" class="link-group-item mb-1 d-block">
-                <span>Committees</span></a><a href="https://www.europarl.europa.eu/delegations/en" class="link-group-item mb-1 d-block">
-                <span>Delegations</span></a><a href="https://elections.europa.eu/en/" class="link-group-item mb-1 d-block">
-                <span>Elections</span></a>
+            <a href="https://www.europarl.europa.eu/news/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - News">
+                <span>News</span></a><a href="https://www.europarl.europa.eu/topics/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Topics">
+                <span>Topics</span></a><a href="https://www.europarl.europa.eu/meps/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - MEPs">
+                <span>MEPs</span></a><a href="https://www.europarl.europa.eu/about-parliament/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - About Parliament">
+                <span>About Parliament</span></a><a href="https://www.europarl.europa.eu/plenary/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Plenary">
+                <span>Plenary</span></a><a href="https://www.europarl.europa.eu/committees/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Committees">
+                <span>Committees</span></a><a href="https://www.europarl.europa.eu/delegations/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Delegations">
+                <span>Delegations</span></a><a href="https://eubudget.europarl.europa.eu/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - EU budget">
+                <span>EU budget</span></a>
         </nav>
     </div>
     <div class="d-block d-md-none">
@@ -1324,7 +1323,7 @@
                     <use xlink:href="#es_icon-minus"></use>
                 </svg>
             </a>
-            <a class="erpl_nojs-close-menu" href="#europarl-links-close"
+            <a class="es_nojs-close-menu" href="#europarl-links-close"
                title="Untoggle European Parliament websites"
                role="button" data-toggle="collapse"
                data-target="#europarl-links-items"
@@ -1342,67 +1341,68 @@
 
             <div class="separator separator-dotted separator-2x mt-3 mb-3 d-none d-md-flex"></div>
             <div class="row">
-                <nav class="col-12" id="social-links" aria-label="Social links">
-                    <div class="erpl_social-links mb-2">
+                <nav class="col-12 d-flex justify-content-center" id="social-links" aria-label="Social links">
+                    <div class="es_footer-social-links mb-2">
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Facebook" href="https://www.facebook.com/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-facebook-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Facebook" href="https://www.facebook.com/europeanparliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-facebook-color">
                                     <use href="#es_icon-facebook-color"></use>
                                 </svg>
                                 <span class="sr-only">Facebook</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Twitter" href="https://twitter.com/Europarl_en" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-twitter-color">
-                                    <use href="#es_icon-twitter-color"></use>
+                            <a  data-toggle="tooltip" title="Check out Parliament on X" href="https://x.com/Europarl_en" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-twitter-x">
+                                    <use href="#es_icon-twitter-x"></use>
                                 </svg>
                                 <span class="sr-only">Twitter</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Flickr" href="https://www.flickr.com/photos/european_parliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-flickr-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Flickr" href="https://www.flickr.com/photos/european_parliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-flickr-color">
                                     <use href="#es_icon-flickr-color"></use>
                                 </svg>
                                 <span class="sr-only">Flickr</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on LinkedIn" href="https://www.linkedin.com/company/european-parliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-linkedin-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on LinkedIn" href="https://www.linkedin.com/company/european-parliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-linkedin-color">
                                     <use href="#es_icon-linkedin-color"></use>
                                 </svg>
                                 <span class="sr-only">LinkedIn</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on YouTube" href="https://www.youtube.com/user/EuropeanParliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-youtube-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on YouTube" href="https://www.youtube.com/user/EuropeanParliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-youtube-color">
                                     <use href="#es_icon-youtube-color"></use>
                                 </svg>
                                 <span class="sr-only">YouTube</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Instagram" href="https://www.instagram.com/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-instagram-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Instagram" href="https://www.instagram.com/europeanparliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-instagram-color">
                                     <use href="#es_icon-instagram-color"></use>
                                 </svg>
                                 <span class="sr-only">Instagram</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Pinterest" href="https://www.pinterest.fr/epinfographics" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-pinterest-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Pinterest" href="https://www.pinterest.fr/epinfographics" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-pinterest-color">
                                     <use href="#es_icon-pinterest-color"></use>
                                 </svg>
                                 <span class="sr-only">Pinterest</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Snapchat" href="https://www.snapchat.com/add/europarl" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-snapchat-color">
-                                    <use href="#es_icon-snapchat-color"></use>
-                                </svg>
-                                <span class="sr-only">Snapchat</span>
-                            </a>
-                        
-                            <a data-toggle="tooltip" title="Check out Parliament on Reddit" href="https://www.reddit.com/r/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-reddit-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Reddit" href="https://www.reddit.com/r/europeanparliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-reddit-color">
                                     <use href="#es_icon-reddit-color"></use>
                                 </svg>
                                 <span class="sr-only">Reddit</span>
@@ -1439,12 +1439,9 @@
         </div>
     </div>
 </footer>
-
     
-    <script src="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/lib/jquery/jquery.min.js"></script>
-    
-    <script id="evostrap" src="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/dist/js/evostrap.js"></script>
-    <script src="https://www.europarl.europa.eu/commonFrontResources/evostrap-oeil/1.0.0//dist/js/oeil.js"></script>
+    <script id="evostrap" type="module" src="https://evokits.europarl.europa.eu/evostrap/7.0.0/lib/dist/js/evostrap.js"></script>
+    <script src="https://evokits.europarl.europa.eu/evostrap-oeil/1.0.1/dist/js/oeil.js"></script>
 
     
     <script src="/oeil/oeil-addons/documents-loading.js"></script>

--- a/backend/tests/scrapers/data/votes/oeil-procedure-file_2023-2019-ini.html
+++ b/backend/tests/scrapers/data/votes/oeil-procedure-file_2023-2019-ini.html
@@ -25,9 +25,9 @@
     <meta content="en" http-equiv="Content-Language">
     <meta content="European Parliament Legislative Observatory Procedure" name="description">
     <meta content="index, follow, noodp, noydir, notranslate, noarchive" name="robots">
-    <meta content="European Union, 2024 - Source: European Parliament" name="copyright">
+    <meta content="European Union, 2025 - Source: European Parliament" name="copyright">
     <meta content="Legislative Observatory" name="planet">
-    <meta content="14-11-2024" name="available">
+    <meta content="13-11-2025" name="available">
 
     <!-- Dynamics meta tags -->
     
@@ -35,41 +35,40 @@
     
 
     <!-- HTML <link> tags -->
-    <link rel="icon" href="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/assets/img/favicon.ico">
+    <link rel="icon" href="https://evokits.europarl.europa.eu/evostrap/7.0.0/lib/dist/assets/img/favicon.ico">
 
     
-    <link href="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/dist/css/evostrap.css" rel="stylesheet">
-    <link href="https://www.europarl.europa.eu/commonFrontResources/evostrap-oeil/1.0.0//dist/css/oeil.css" rel="stylesheet">
+    <link href="https://evokits.europarl.europa.eu/evostrap/7.0.0/lib/dist/css/evostrap.css" rel="stylesheet">
+    <link href="https://evokits.europarl.europa.eu/evostrap-oeil/1.0.1/dist/css/oeil.css" rel="stylesheet">
 </head>
 
 <body id="main-content" data-app-context="/oeil/">
 
-    <header class="erpl_header">
-    <nav class="erpl_wai-access" aria-label="Shortcuts">
+    <header class="es_header">
+    <nav class="es_wai-access" aria-label="Shortcuts">
         <ul>
-            <li> <a href="#website-body" class="erpl_smooth-scroll"> <span class="btn btn-primary">Access to page content (press &quot;Enter&quot;)</span> </a> </li>
-            <li> <a href="#languageSelectorDropdownButton" class="erpl_smooth-scroll"> <span class="btn btn-primary">Direct access to language menu (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#website-body" class="es_smooth-scroll"> <span class="btn btn-primary">Access to page content (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#languageSelectorDropdownButton" class="es_smooth-scroll"> <span class="btn btn-primary">Direct access to language menu (press &quot;Enter&quot;)</span> </a> </li>
 
-            <li> <a href="#mainSearch" class="erpl_smooth-scroll"> <span class="btn btn-primary">Direct access to search menu (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#mainSearch" class="es_smooth-scroll"> <span class="btn btn-primary">Direct access to search menu (press &quot;Enter&quot;)</span> </a> </li>
         </ul>
     </nav>
 
     
-    <div class="erpl_header-top border-bottom mb-3 mb-xl-4 a-i">
+    <div class="es_header-top border-bottom mb-3 mb-xl-4 a-i">
         <div class="container">
             <div class="row no-gutters">
-                <div class="col-auto"><div class="erpl_header-language-selector">
-    <div class="erpl_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute"
+                <div class="col-auto"><div class="es_header-language-selector">
+    <div class="es_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute"
          data-content-width="auto">
-        <button class="erpl_dropdown-btn input-group collapsed" type="button" data-toggle="collapse"
+        <button class="es_dropdown-btn input-group collapsed" type="button" data-toggle="collapse"
                 id="languageSelectorDropdownButton"
                 data-target="#languageSelectorDropdownContent"
                 aria-expanded="false"
                 aria-controls="languageSelectorDropdownContent">
-            <span class="value form-control">EN - English</span>
+            <span class="es_dropdown-label">EN - English</span>
             
-            <span class="input-group-append">
-                <span class="input-group-icon">
+            <span class="es_dropdown-icon">
                     <svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false">
                         <use xlink:href="#es_icon-arrow"></use>
                     </svg>
@@ -77,18 +76,15 @@
                          data-show-expanded="true">
                         <use xlink:href="#es_icon-arrow"></use>
                     </svg>
-                </span>
             </span>
         </button>
 
         <div>
-            <div class="erpl_dropdown-content collapse" id="languageSelectorDropdownContent">
-                <div class="border border-light">
-                    <div>
-                        <ul class="erpl_topbar-list list-unstyled erpl_dropdown-menu">
+            <div class="dropdown-menu border border-light" id="languageSelectorDropdownContent">
+                        <ul class="erpl_topbar-list list-unstyled es_dropdown-menu">
                             <li class="t-x-block" data-selected="false">
                                 <!-- localized version URL is here -->
-                                <a class="erpl_dropdown-menu-item"
+                                <a class="es_dropdown-menu-item"
                                    lang="fr"
                                    href="https://oeil.secure.europarl.europa.eu/oeil/fr/procedure-file?reference=2023/2019(INI)">
                                     
@@ -97,7 +93,7 @@
                             </li>
                             <li class="t-x-block" data-selected="true">
                                 <!-- localized version URL is here -->
-                                <a class="erpl_dropdown-menu-item"
+                                <a class="es_dropdown-menu-item"
                                    lang="en"
                                    href="https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2023/2019(INI)">
                                     <span class="t-item">EN - English</span>
@@ -105,14 +101,12 @@
                                 </a>
                             </li>
                         </ul>
-                    </div>
-                </div>
             </div>
         </div>
     </div>
 </div></div>
                 <div class="col">
-                    <nav class="erpl_header-other-websites d-flex justify-content-end align-items-center" aria-label="Other websites">
+                    <nav class="es_header-other-websites d-flex justify-content-end align-items-center" aria-label="Other websites">
                         <ul class="d-flex list-unstyled">
 
                             
@@ -166,24 +160,23 @@
 
                             
                             <li class="d-none d-xl-block">
-                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://elections.europa.eu/en/">
-                                    <span class="t-item">Elections</span>
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://eubudget.europarl.europa.eu/en">
+                                    <span class="t-item">EU budget</span>
                                 </a>
                             </li>
 
 
-                            <li class="erpl_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute">
-                               <button class="erpl_dropdown-btn input-group collapsed d-xl-flex pl-1 align-items-center t-y-block flex-nowrap"
+                            <li class="es_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute">
+                               <button class="es_dropdown-btn input-group collapsed d-xl-flex pl-1 align-items-center t-y-block flex-nowrap"
                                        data-toggle="collapse"
                                        data-target="#otherWebsiteSubmenu"
                                        aria-expanded="false"
                                        aria-controls="otherWebsiteSubmenu" aria-label="More other websites">
-                                    <span class="value">
+                                    <span class="es_dropdown-label">
 											<span class="d-none d-xl-inline">Other websites</span>
 											<span class="d-xl-none">View other websites</span>
                                     </span>
-                                   <span class="input-group-append">
-											<span class="input-group-icon">
+                                   <span class="es_dropdown-icon">
 												<svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false">
 													<use xlink:href="#es_icon-arrow"></use>
 												</svg>
@@ -192,140 +185,153 @@
 													<use xlink:href="#es_icon-arrow"></use>
 												</svg>
 											</span>
-										</span>
                                 </button>
                                 <div>
-                                    <div id="otherWebsiteSubmenu" class="erpl_dropdown-content collapse">
-                                        <ul class="erpl_header-other-websites-submenu list-unstyled erpl_dropdown-menu">
+                                    <div id="otherWebsiteSubmenu" class="dropdown-menu border border-light">
+                                        <ul class="es_header-other-websites-submenu erpl_topbar-list list-unstyled es_dropdown-men">
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/news/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/news/en">
                                                     <span class="t-item">News</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/topics/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/topics/en">
                                                     <span class="t-item">Topics</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/meps/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/meps/en">
                                                     <span class="t-item">MEPs</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/about-parliament/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/about-parliament/en">
                                                     <span class="t-item">About Parliament</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/plenary/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/plenary/en">
                                                     <span class="t-item">Plenary</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/committees/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/committees/en">
                                                     <span class="t-item">Committees</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/delegations/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/delegations/en">
                                                     <span class="t-item">Delegations</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://elections.europa.eu/en/">
-                                                    <span class="t-item">Elections</span>
+                                                <a class="es_dropdown-menu-item" href="https://eubudget.europarl.europa.eu/en">
+                                                    <span class="t-item">EU budget</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://multimedia.europarl.europa.eu/en/home">
+                                                <a class="es_dropdown-menu-item" href="https://multimedia.europarl.europa.eu/en/home">
                                                     <span class="t-item">Multimedia Centre</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/the-president/en">
-                                                    <span class="t-item">President&#39;s website</span>
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/the-president/en">
+                                                    <span class="t-item">Presidency</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/the-secretary-general/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/the-secretary-general/en">
                                                     <span class="t-item">Secretariat-general</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/thinktank/en">
+                                                <a class="es_dropdown-menu-item" href="https://elections.europa.eu/en/">
+                                                    <span class="t-item">Elections</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/thinktank/en">
                                                     <span class="t-item">Thinktank</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.epnewshub.eu">
+                                                <a class="es_dropdown-menu-item" href="https://www.epnewshub.eu">
                                                     <span class="t-item">EP Newshub</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/at-your-service/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/at-your-service/en">
                                                     <span class="t-item">At your service</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/visiting/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/visiting/en">
                                                     <span class="t-item">Visits</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/legislative-train">
+                                                <a class="es_dropdown-menu-item" href="https://oeil.secure.europarl.europa.eu/oeil/en">
+                                                    <span class="t-item">Legislative Observatory</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/legislative-train">
                                                     <span class="t-item">Legislative train</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/contracts-and-grants/en/">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/contracts-and-grants/en/">
                                                     <span class="t-item">Contracts and Grants</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/RegistreWeb/home/welcome.htm?language=en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/RegistreWeb/home/welcome.htm?language=en">
                                                     <span class="t-item">Register</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://data.europarl.europa.eu/en">
+                                                <a class="es_dropdown-menu-item" href="https://data.europarl.europa.eu/en">
                                                     <span class="t-item">Open Data Portal</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://liaison-offices.europarl.europa.eu/en">
+                                                <a class="es_dropdown-menu-item" href="https://liaison-offices.europarl.europa.eu/en">
                                                     <span class="t-item">Liaison offices</span>
                                                 </a>
                                             </li>
@@ -339,17 +345,17 @@
             </div>
         </div>
     </div>
-    <div class="erpl_header-middle mb-3">
+    <div class="es_header-middle mb-3">
         <div class="container">
             <div class="row">
                 <div class="col-12 col-md">
-                    <div class="erpl_header-website-title a-i">
-                        <div class="erpl_header-website-title-main">
+                    <div class="es_header-website-title a-i">
+                        <div class="es_header-website-title-main">
                             <a href="/oeil/en" class="t-x">
                                 <span>Legislative Observatory</span>
                             </a>
                         </div>
-                        <div class="erpl_header-website-title-sub">
+                        <div class="es_header-website-title-sub">
                             <a class="t-x-block" href="https://www.europarl.europa.eu" target="_blank" >
                                 <span class="t-item">European Parliament</span>
                             </a>
@@ -358,17 +364,18 @@
                 </div>
 
                 
-                <div class="col-auto d-none d-xl-flex justify-content-end align-items-center erpl_header-search-container">
-                    <form class="erpl_header-search" method="GET" action="/oeil/en/search"> <label for="mainSearch" class="sr-only">Find a procedure</label>
+                <div class="col-auto d-none d-xl-flex justify-content-end align-items-center es_header-search-container">
+                    <form class="es_header-search" method="GET" action="/oeil/en/search"> <label for="mainSearch" class="sr-only">Find a procedure</label>
                         <div class="input-group" style="width: 300px">
                             <input type="text" class="form-control"
                                    id="mainSearch"
+                                   maxlength="100"
                                    placeholder="Find a procedure..."
                                    name="fullText.term"
                                    aria-describedby="mainSearchHelper">
                             <div class="input-group-append">
                                 <button class="btn btn-primary align-items-center d-flex" title="Start find a procedure" disabled="">
-                                    <svg aria-hidden="true" class="es_icon es_icon-search erpl_header-search-icon">
+                                    <svg aria-hidden="true" class="es_icon es_icon-search es_header-search-icon">
                                         <use xlink:href="#es_icon-search"></use>
                                     </svg>
                                 </button>
@@ -379,64 +386,64 @@
             </div>
         </div>
     </div>
-    <div class="erpl_header-bottom">
-        <div class="erpl_header-menu-container">
-            <div class="container"><nav class="erpl_header-menu" aria-label="Main navigation">
-    <div class="erpl_header-menu-top row align-items-center">
+    <div class="es_header-bottom">
+        <div class="es_header-menu-container">
+            <div class="container"><nav class="es_header-menu" aria-label="Main navigation">
+    <div class="es_header-menu-top row align-items-center">
         <div class="col d-md-none d-flex align-items-center">
-            <svg aria-hidden="true" class="es_icon es_icon-ep-logo-w erpl_header-menu-top-logo">
+            <svg aria-hidden="true" class="es_icon es_icon-ep-logo-w es_header-menu-top-logo">
                 <use xlink:href="#es_icon-ep-logo-w"></use>
             </svg>
         </div>
 
-        <span class="erpl_header-menu-top-title offset-3 col-6 text-center d-none d-md-block" aria-hidden="true">
+        <span class="es_header-menu-top-title offset-3 col-6 text-center d-none d-md-block" aria-hidden="true">
 								<span>European Parliament</span></span>
 
-        <div class="erpl_header-menu-top-controls col-auto col-md-3 text-right">
-            <button type="button" class="btn btn-sm btn-dark-primary erpl_header-menu-top-controls-toggle-search" id="headerMenuToggleSearch" aria-haspopup="true" aria-expanded="false">
+        <div class="es_header-menu-top-controls col-auto col-md-3 text-right">
+            <button type="button" class="btn btn-sm btn-dark-primary es_header-menu-top-controls-toggle-search" id="headerMenuToggleSearch" aria-haspopup="true" aria-expanded="false">
                 <span class="sr-only">Search</span>
                 <svg aria-hidden="true" class="es_icon es_icon-search">
                     <use xlink:href="#es_icon-search"></use>
                 </svg>
             </button>
             <button type="button"
-                    class="btn btn-sm btn-dark-primary erpl_header-menu-top-controls-toggle-menu"
+                    class="btn btn-sm btn-dark-primary es_header-menu-top-controls-toggle-menu"
                     id="headerMenuToggleMenu"
                     aria-haspopup="true"
                     aria-expanded="false">
-                <span class="mr-25">Menu</span> <span class="erpl_header-menu-icon" aria-hidden="true"></span>
+                <span class="mr-25">Menu</span> <span class="es_header-menu-icon" aria-hidden="true"></span>
             </button>
         </div>
     </div>
 
-    <ul class="erpl_header-menu-list list-unstyled">
+    <ul class="es_header-menu-list list-unstyled">
         
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en" data-selected="false">
         <span class="t-y">Home</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/search" data-selected="false">
         <span class="t-y">Search</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/legislative-priorities" data-selected="false">
         <span class="t-y">Legislative priorities</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/find-out-more" data-selected="false">
         <span class="t-y">Find out more</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/contact" data-selected="false">
         <span class="t-y">Contact us</span>
     </a>
@@ -458,10 +465,10 @@
     <div class="row">
         <div class="col-12 col-xl-8">
             <div class="row">
-                <div class="col-12 col-lg"><h2 class="erpl_title-h1 mb-3">2023/2019(INI)</h2>
+                <div class="col-12 col-lg"><h2 class="es_title-h1 mb-3">2023/2019(INI)</h2>
                 </div>
                 <div class="col-12 col-lg-4">
-                    <div class="erpl_links-list text-lg-right my-1">
+                    <div class="es_links-list text-lg-right my-1">
                         <ul>
                             <li>
                                 <a href="/oeil/en/procedure-file/pdf?reference=2023/2019(INI)">
@@ -477,7 +484,7 @@
                 </div>
             </div>
             
-            <h2 class="erpl_title-h2 mb-3">Implementation of the 2018 Geoblocking Regulation in the Digital Single Market</h2>
+            <h2 class="es_title-h2 mb-3">Implementation of the 2018 Geoblocking Regulation in the Digital Single Market</h2>
             <div class="separator border-dark my-3"></div>
 
             
@@ -485,22 +492,22 @@
 
 
             
-            <div class="erpl_product">
+            <div class="es_product">
                 <div class="row">
                     <div class="col">
                         <div class="mb-3">
-                            <div class="erpl_product-body">
+                            <div class="es_product-body">
                                 
                                 <html lang="en">
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div id="section1" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 class="erpl_title-h2 mb-2">Basic information</h2></div>
+                <h2 class="es_title-h2 mb-2">Basic information</h2></div>
                 <div class="col-12 col-lg-4">
-                    <div class="erpl_links-list text-lg-right my-1">
+                    <div class="es_links-list text-lg-right my-1">
                         <ul>
                             <li>
                                 <a href="/oeil/en/procedure-file/pdf?reference=2023/2019(INI)&amp;section=BASIC_INFO">
@@ -566,7 +573,7 @@
         <div class="row">
             <div class="col-12">
                 <div class="separator separator-dotted separator-2x mt-5 mb-3">
-                    <a class="erpl_smooth-scroll btn btn-default" href="#gateway">Please go to Documentation gateway for any follow-up documents.</a>
+                    <a class="es_smooth-scroll btn btn-default" href="#gateway">Please go to Documentation gateway for any follow-up documents.</a>
                 </div>
             </div>
         </div>
@@ -574,15 +581,16 @@
 </div>
 </html>
 
+
                                 
-                                <div class="erpl_product-section">
+                                <div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section2" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
-            <div class="col-12 col-lg"><h2 class="erpl_title-h2 mb-2">Key players</h2>
+            <div class="col-12 col-lg"><h2 class="es_title-h2 mb-2">Key players</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2023/2019(INI)&amp;section=KEY_PLAYERS">
@@ -597,13 +605,13 @@
                 </div>
             </div>
         </div>
-        <div class="erpl_accordion mb-5" id="erplAccordionKeyPlayers">
+        <div class="es_accordion mb-5" id="erplAccordionKeyPlayers">
             <ul class="a-i">
                 
-    <li class="erpl_accordion-item" data-selected="false">
-        <button id="erpl_accordion-committee-title" type="button" class="erpl_accordion-item-title" data-toggle="collapse" data-target="#erpl_accordion-committee" aria-expanded="true" aria-controls="erpl_accordion-committee">
+    <li class="es_accordion-item" data-selected="false">
+        <button id="es_accordion-committee-title" type="button" class="es_accordion-item-title" data-toggle="collapse" data-target="#es_accordion-committee" aria-expanded="true" aria-controls="es_accordion-committee">
             <span class="t-x">European Parliament</span>
-            <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <span class="es_accordion-item-icon es_icon-container text-primary">
             <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
                 <use xlink:href="#es_icon-more"></use>
             </svg>
@@ -612,7 +620,7 @@
             </svg>
         </span>
         </button>
-        <div id="erpl_accordion-committee" class="erpl_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="erpl_accordion-committee-title">
+        <div id="es_accordion-committee" class="es_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="es_accordion-committee-title">
             <div>
                 <a href="http://www.europarl.europa.eu/" target="_blank">
                     <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1">
@@ -642,7 +650,7 @@
     <tr>
         <th scope="row">
             <div class="d-flex align-items-center">
-    <span class="erpl_badge erpl_badge-committee mr-1">IMCO</span>
+    <span class="es_badge es_badge-committee mr-1">IMCO</span>
     <div>
         <a href="http://www.europarl.europa.eu/committees/EN/imco/home.html" target="_blank">
                 <span class="font-weight-normal">Internal Market and Consumer Protection</span>
@@ -762,7 +770,7 @@
     <tr>
         <th scope="row">
             <div class="d-flex align-items-center">
-    <span class="erpl_badge erpl_badge-committee mr-1">CULT</span>
+    <span class="es_badge es_badge-committee mr-1">CULT</span>
     <div>
         <a href="http://www.europarl.europa.eu/committees/EN/cult/home.html" target="_blank">
                 <span class="font-weight-normal">Culture and Education
@@ -804,7 +812,7 @@
     <tr>
         <th scope="row">
             <div class="d-flex align-items-center">
-    <span class="erpl_badge erpl_badge-committee mr-1">JURI</span>
+    <span class="es_badge es_badge-committee mr-1">JURI</span>
     <div>
         <a href="http://www.europarl.europa.eu/committees/EN/juri/home.html" target="_blank">
                 <span class="font-weight-normal">Legal Affairs
@@ -865,10 +873,10 @@
                 
 
                 
-    <li class="erpl_accordion-item" data-selected="false">
-        <button id="erpl_accordion-item3-title" type="button" class="erpl_accordion-item-title collapsed" data-toggle="collapse" data-target="#erpl_accordion-item3" aria-expanded="false" aria-controls="erpl_accordion-item3">
+    <li class="es_accordion-item" data-selected="false">
+        <button id="es_accordion-item3-title" type="button" class="es_accordion-item-title collapsed" data-toggle="collapse" data-target="#es_accordion-item3" aria-expanded="false" aria-controls="es_accordion-item3">
             <span class="t-x">European Commission</span>
-            <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <span class="es_accordion-item-icon es_icon-container text-primary">
             <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
                 <use xlink:href="#es_icon-more"></use>
             </svg>
@@ -877,7 +885,7 @@
             </svg>
         </span>
         </button>
-        <div id="erpl_accordion-item3" class="collapse erpl_accordion-item-content a-i-none" aria-labelledby="erpl_accordion-item3-title">
+        <div id="es_accordion-item3" class="collapse es_accordion-item-content a-i-none" aria-labelledby="es_accordion-item3-title">
             <div>
                 <a href="http://ec.europa.eu/" target="_blank">
                     <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1">
@@ -930,15 +938,15 @@
 
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section3" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 class="erpl_title-h2 mb-2">Key events</h2>
+                <h2 class="es_title-h2 mb-2">Key events</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2023/2019(INI)&amp;section=KEY_EVENTS" target="_blank">
@@ -1105,7 +1113,8 @@
                             
 
                             
-                                <a href="/oeil/en/sda-vote-result?sdaId=60860" target="_blank">
+                                <a href="https://www.europarl.europa.eu/doceo/document/PV-9-2023-12-13-VOT_EN.html?item=13"
+                                   title="Results of vote in Parliament" target="_blank">
                                     <svg aria-hidden="true" class="es_icon es_icon-vote es_icon-24">
                                         <use xlink:href="#es_icon-vote"></use>
                                     </svg>
@@ -1141,15 +1150,15 @@
 
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section5" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 class="erpl_title-h2 mb-2">Technical information</h2>
+                <h2 class="es_title-h2 mb-2">Technical information</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2023/2019(INI)&amp;section=TECHNICAL_INFORMATION">
@@ -1167,12 +1176,6 @@
 
         <div class="table-responsive">
             <table class="table table-striped table-bordered">
-                <thead>
-                <tr>
-                    <th class="align-middle" scope="col">Procedure</th>
-                    <th class="align-middle" scope="col">Information</th>
-                </tr>
-                </thead>
                 <tbody>
                 <tr>
                     <th class="align-middle" scope="row">Procedure reference</th>
@@ -1183,7 +1186,7 @@
                     <td class="align-middle">INI - Own-initiative procedure</td>
                 </tr>
                 <tr>
-                    <th class="align-middle" scope="row">Nature of procedure</th>
+                    <th class="align-middle" scope="row">Procedure subtype</th>
                     <td class="align-middle">Implementation</td>
                 </tr>
                 
@@ -1192,9 +1195,9 @@
                     <th class="align-middle" scope="row">Legal basis</th>
                     <td class="align-middle">
                         
-                            <span class="d-block">Rules of Procedure EP 55  </span>
-                        
                             <span class="d-block">Rules of Procedure EP 57_o  </span>
+                        
+                            <span class="d-block">Rules of Procedure EP 55  </span>
                         
                     </td>
                 </tr>
@@ -1232,15 +1235,15 @@
 
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section6" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 id="gateway" class="erpl_title-h2 mb-2">Documentation gateway</h2>
+                <h2 id="gateway" class="es_title-h2 mb-2">Documentation gateway</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2023/2019(INI)&amp;section=DOCUMENTATION_GATEWAY" target="_blank">
@@ -1255,19 +1258,19 @@
                 </div>
             </div>
         </div>
-        <div class="erpl_accordion mb-5" id="erplAccordionDocGateway">
+        <div class="es_accordion mb-5" id="erplAccordionDocGateway">
             <ul class="a-i">
                 
-                    <li class="erpl_accordion-item" data-selected="false">
+                    <li class="es_accordion-item" data-selected="false">
     <button
-            id="erpl_accordion-item-doc-gateway-EP-title"
+            id="es_accordion-item-doc-gateway-EP-title"
             type="button"
-            class="erpl_accordion-item-title collapsed"
+            class="es_accordion-item-title collapsed"
             data-toggle="collapse"
-            aria-expanded="true" data-target="#erpl_accordion-item-doc-gateway-EP" aria-controls="erpl_accordion-item-doc-gateway-EP"
+            aria-expanded="true" data-target="#es_accordion-item-doc-gateway-EP" aria-controls="es_accordion-item-doc-gateway-EP"
     >
         <span class="t-x">European Parliament</span>
-        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+        <span class="es_accordion-item-icon es_icon-container text-primary">
             <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
                 <use xlink:href="#es_icon-more"></use>
             </svg>
@@ -1276,8 +1279,7 @@
             </svg>
         </span>
     </button>
-    <div id="erpl_accordion-item-doc-gateway-EP" class="collapse erpl_accordion-item-content a-i-none collapse show" aria-labelledby="erpl_accordion-item-doc-gateway-EP-title">
-        <div>
+    <div id="es_accordion-item-doc-gateway-EP" class="collapse es_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="es_accordion-item-doc-gateway-EP-title">
             <div class="table-responsive">
                 <table class="table table-striped table-bordered">
                     <thead>
@@ -1297,30 +1299,6 @@
                         
 
                         <th class="align-middle" scope="row">
-                            <span class="font-weight-normal">Amendments tabled in committee</span>
-                        </th>
-
-                        <td class="align-middle">
-                            
-                        </td>
-                        <td class="align-middle w-25">
-                            <a href="https://www.europarl.europa.eu/doceo/document/CULT-AM-749201_EN.html" target="_blank">PE749.201</a>
-                            
-                            
-
-                            
-                        </td>
-                        <td class="align-middle" >30/05/2023</td>
-
-                        <td class="align-middle">
-                            
-                        </td>
-                    </tr>
-                    <tr>
-
-                        
-
-                        <th class="align-middle" scope="row">
                             <span class="font-weight-normal">Committee draft report</span>
                         </th>
 
@@ -1335,30 +1313,6 @@
                             
                         </td>
                         <td class="align-middle" >15/06/2023</td>
-
-                        <td class="align-middle">
-                            
-                        </td>
-                    </tr>
-                    <tr>
-
-                        
-
-                        <th class="align-middle" scope="row">
-                            <span class="font-weight-normal">Amendments tabled in committee</span>
-                        </th>
-
-                        <td class="align-middle">
-                            
-                        </td>
-                        <td class="align-middle w-25">
-                            <a href="https://www.europarl.europa.eu/doceo/document/JURI-AM-751728_EN.html" target="_blank">PE751.728</a>
-                            
-                            
-
-                            
-                        </td>
-                        <td class="align-middle" >11/07/2023</td>
 
                         <td class="align-middle">
                             
@@ -1397,7 +1351,10 @@
                         </th>
 
                         <td class="align-middle">
-                            <span class="erpl_badge erpl_badge-committee mr-25">CULT</span>
+                            <span class="es_badge es_badge-committee mr-25"
+                               title="Culture and Education
+
+">CULT</span>
                         </td>
                         <td class="align-middle w-25">
                             <a href="https://www.europarl.europa.eu/doceo/document/CULT-AD-746896_EN.html" target="_blank">PE746.896</a>
@@ -1421,7 +1378,10 @@
                         </th>
 
                         <td class="align-middle">
-                            <span class="erpl_badge erpl_badge-committee mr-25">JURI</span>
+                            <span class="es_badge es_badge-committee mr-25"
+                               title="Legal Affairs
+
+">JURI</span>
                         </td>
                         <td class="align-middle w-25">
                             <a href="https://www.europarl.europa.eu/doceo/document/JURI-AD-749286_EN.html" target="_blank">PE749.286</a>
@@ -1491,20 +1451,19 @@
                     </tbody>
                 </table>
             </div>
-        </div>
     </div>
 </li>
                 
-                    <li class="erpl_accordion-item" data-selected="false">
+                    <li class="es_accordion-item" data-selected="false">
     <button
-            id="erpl_accordion-item-doc-gateway-EC-title"
+            id="es_accordion-item-doc-gateway-EC-title"
             type="button"
-            class="erpl_accordion-item-title collapsed"
+            class="es_accordion-item-title collapsed"
             data-toggle="collapse"
-            aria-expanded="true" data-target="#erpl_accordion-item-doc-gateway-EC" aria-controls="erpl_accordion-item-doc-gateway-EC"
+            aria-expanded="true" data-target="#es_accordion-item-doc-gateway-EC" aria-controls="es_accordion-item-doc-gateway-EC"
     >
         <span class="t-x">European Commission</span>
-        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+        <span class="es_accordion-item-icon es_icon-container text-primary">
             <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
                 <use xlink:href="#es_icon-more"></use>
             </svg>
@@ -1513,8 +1472,7 @@
             </svg>
         </span>
     </button>
-    <div id="erpl_accordion-item-doc-gateway-EC" class="collapse erpl_accordion-item-content a-i-none collapse show" aria-labelledby="erpl_accordion-item-doc-gateway-EC-title">
-        <div>
+    <div id="es_accordion-item-doc-gateway-EC" class="collapse es_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="es_accordion-item-doc-gateway-EC-title">
             <div class="table-responsive">
                 <table class="table table-striped table-bordered">
                     <thead>
@@ -1554,7 +1512,6 @@
                     </tbody>
                 </table>
             </div>
-        </div>
     </div>
 </li>
                 
@@ -1573,480 +1530,7 @@
 
                                 
                                 
-<div class="erpl_product-section">
-    <div id="section8" class="separator border-dark my-3"></div>
-    <div class="erpl-product-content mb-2">
-        <div class="row">
-            <div class="col-12 col-lg"><h2 class="erpl_title-h2 mb-2">Transparency</h2>
-            </div>
-            <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
-                    <ul>
-                        <li>
-                            <a href="/oeil/en/procedure-file/pdf?reference=2023/2019(INI)&amp;section=TRANSPARENCY">
-                                <svg class="es_icon es_icon-pdf mr-1">
-                                    <title>pdf</title>
-                                    <use xlink:href="#es_icon-pdf"></use>
-                                </svg>
-                                <span class="t-x">Transparency</span>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-        </div>
 
-        <p>Meetings with interest representatives published in line with the Rules of Procedure</p>
-        <div class="erpl_accordion mb-5" id="erplAccordionTransparency">
-            <ul class="a-i">
-                <li class="erpl_accordion-item" data-selected="false">
-                    <button id="meetingGroup0-content-title"
-                            type="button"
-                            class="erpl_accordion-item-title collapsed"
-                            data-toggle="collapse"
-                            aria-expanded="false"
-                            data-target="#meetingGroup0-content"
-                            aria-controls="meetingGroup0-content">
-                        <span class="t-x">Rapporteurs, Shadow Rapporteurs and Committee Chairs</span>
-                        <span class="erpl_accordion-item-icon es_icon-container text-primary">
-                            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
-                                <use xlink:href="#es_icon-more"></use>
-                            </svg>
-                            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
-                                <use xlink:href="#es_icon-less"></use>
-                            </svg>
-                        </span>
-                    </button>
-                    <div id="meetingGroup0-content"
-                         class="collapse erpl_accordion-item-content a-i-none"
-                         aria-labelledby="meetingGroup0-content-title">
-                        <div class="oeil-meetings-list-container">
-                            <div class="table-responsive">
-                                <table class="table table-striped table-bordered">
-                                    <thead>
-                                    <tr>
-                                        <th class="align-middle" scope="col">Name</th>
-                                        <th class="align-middle" scope="col">Role</th>
-                                        <th class="align-middle" scope="col">Committee</th>
-                                        <th class="align-middle" scope="col">Date</th>
-                                        <th class="align-middle" scope="col">Interest representatives</th>
-                                    </tr>
-                                    </thead>
-                                    <tbody>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/24922"
-                                               class="font-weight-normal">ARIMONT Pascal</a>
-                                        </th>
-                                        <td class="align-middle">Shadow rapporteur for opinion</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/JURI"
-                                               title="Committee on Legal Affairs">JURI</a>
-                                        </td>
-                                        <td class="align-middle">30/11/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                ARD-Verbindungsbüro Brüssel
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/24505"
-                                               class="font-weight-normal">MAUREL Emmanuel</a>
-                                        </th>
-                                        <td class="align-middle">Shadow rapporteur for opinion</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/CULT"
-                                               title="Committee on Culture and Education">CULT</a>
-                                        </td>
-                                        <td class="align-middle">29/11/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                Société civile des Auteurs Réalisateurs Producteurs
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/237224"
-                                               class="font-weight-normal">ALBUQUERQUE João</a>
-                                        </th>
-                                        <td class="align-middle">Shadow rapporteur for opinion</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/CULT"
-                                               title="Committee on Culture and Education">CULT</a>
-                                        </td>
-                                        <td class="align-middle">23/11/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                EUROCINEMA, Association de producteurs de cinéma et de télévision
-                                                <br/>
-                                            
-                                                Europa Distribution
-                                                <br/>
-                                            
-                                                Europa International
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/24922"
-                                               class="font-weight-normal">ARIMONT Pascal</a>
-                                        </th>
-                                        <td class="align-middle">Rapporteur for opinion</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/JURI"
-                                               title="Committee on Legal Affairs">JURI</a>
-                                        </td>
-                                        <td class="align-middle">21/11/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                DFL Deutsche Fußball Liga GmbH
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/24922"
-                                               class="font-weight-normal">ARIMONT Pascal</a>
-                                        </th>
-                                        <td class="align-middle">Shadow rapporteur for opinion</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/JURI"
-                                               title="Committee on Legal Affairs">JURI</a>
-                                        </td>
-                                        <td class="align-middle">18/10/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                DFL Deutsche Fußball Liga GmbH
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/202073"
-                                               class="font-weight-normal">ANGEL Marc</a>
-                                        </th>
-                                        <td class="align-middle">Shadow rapporteur</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/IMCO"
-                                               title="Committee on the Internal Market and Consumer Protection">IMCO</a>
-                                        </td>
-                                        <td class="align-middle">12/10/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                Motion Picture Association EMEA
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/202073"
-                                               class="font-weight-normal">ANGEL Marc</a>
-                                        </th>
-                                        <td class="align-middle">Shadow rapporteur</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/IMCO"
-                                               title="Committee on the Internal Market and Consumer Protection">IMCO</a>
-                                        </td>
-                                        <td class="align-middle">12/07/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                ACT group
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/24922"
-                                               class="font-weight-normal">ARIMONT Pascal</a>
-                                        </th>
-                                        <td class="align-middle">Shadow rapporteur for opinion</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/JURI"
-                                               title="Committee on Legal Affairs">JURI</a>
-                                        </td>
-                                        <td class="align-middle">12/07/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                Eleven Sports
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/24922"
-                                               class="font-weight-normal">ARIMONT Pascal</a>
-                                        </th>
-                                        <td class="align-middle">Shadow rapporteur for opinion</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/JURI"
-                                               title="Committee on Legal Affairs">JURI</a>
-                                        </td>
-                                        <td class="align-middle">10/07/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                EBU-UER (European Broadcasting Union)
-                                                <br/>
-                                            
-                                                ACT
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/24922"
-                                               class="font-weight-normal">ARIMONT Pascal</a>
-                                        </th>
-                                        <td class="align-middle">Shadow rapporteur for opinion</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/JURI"
-                                               title="Committee on Legal Affairs">JURI</a>
-                                        </td>
-                                        <td class="align-middle">07/07/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                EUROCINEMA, Association de producteurs de cinéma et de télévision
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                            <div class="separator separator-dotted separator-2x my-5">
-                                <button data-next-page-url="/oeil/en/procedure-meetings/?reference=2023/2019(INI)&amp;type=SPECIAL_ROLES&amp;page=1"
-                                        class="btn btn-default oei-loadmore-button"
-                                        title="Load more">Load more</button>
-                            </div>
-                        </div>
-                    </div>
-                </li>
-            </ul>
-            <ul class="a-i">
-                <li class="erpl_accordion-item" data-selected="false">
-                    <button id="meetingGroup1-content-title"
-                            type="button"
-                            class="erpl_accordion-item-title collapsed"
-                            data-toggle="collapse"
-                            aria-expanded="false"
-                            data-target="#meetingGroup1-content"
-                            aria-controls="meetingGroup1-content">
-                        <span class="t-x">Other Members</span>
-                        <span class="erpl_accordion-item-icon es_icon-container text-primary">
-                            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
-                                <use xlink:href="#es_icon-more"></use>
-                            </svg>
-                            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
-                                <use xlink:href="#es_icon-less"></use>
-                            </svg>
-                        </span>
-                    </button>
-                    <div id="meetingGroup1-content"
-                         class="collapse erpl_accordion-item-content a-i-none"
-                         aria-labelledby="meetingGroup1-content-title">
-                        <div class="oeil-meetings-list-container">
-                            <div class="table-responsive">
-                                <table class="table table-striped table-bordered">
-                                    <thead>
-                                    <tr>
-                                        <th class="align-middle" scope="col">Name</th>
-                                        
-                                        
-                                        <th class="align-middle" scope="col">Date</th>
-                                        <th class="align-middle" scope="col">Interest representatives</th>
-                                    </tr>
-                                    </thead>
-                                    <tbody>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/197791"
-                                               class="font-weight-normal">SMERIGLIO Massimiliano</a>
-                                        </th>
-                                        
-                                        
-                                        <td class="align-middle">12/12/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                EUROCINEMA, Association de producteurs de cinéma et de télévision
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/96653"
-                                               class="font-weight-normal">ROTH NEVEĎALOVÁ Katarína</a>
-                                        </th>
-                                        
-                                        
-                                        <td class="align-middle">11/12/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                Association of Commercial Television and Video on Demand Services in Europe
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/197417"
-                                               class="font-weight-normal">SOKOL Tomislav</a>
-                                        </th>
-                                        
-                                        
-                                        <td class="align-middle">08/12/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                the Association of Commercial Television and Video on Demand Services in Europe (ACT)
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/96922"
-                                               class="font-weight-normal">BILBAO BARANDICA Izaskun</a>
-                                        </th>
-                                        
-                                        
-                                        <td class="align-middle">07/12/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                La Liga española de fútbol
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/197536"
-                                               class="font-weight-normal">COLIN-OESTERLÉ Nathalie</a>
-                                        </th>
-                                        
-                                        
-                                        <td class="align-middle">16/11/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                EUROCINEMA, Association de producteurs de cinéma et de télévision
-                                                <br/>
-                                            
-                                                Syndicat des producteurs indépendants
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/96775"
-                                               class="font-weight-normal">COMI Lara</a>
-                                        </th>
-                                        
-                                        
-                                        <td class="align-middle">15/11/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                Anica - Associazione Nazionale Industrie Cinematografiche Audiovisive Digitali
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/96775"
-                                               class="font-weight-normal">COMI Lara</a>
-                                        </th>
-                                        
-                                        
-                                        <td class="align-middle">15/11/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                European Leagues
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/247735"
-                                               class="font-weight-normal">BALLARÍN CEREZA Laura</a>
-                                        </th>
-                                        
-                                        
-                                        <td class="align-middle">08/11/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                Filmin
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/197832"
-                                               class="font-weight-normal">RIBA I GINER Diana</a>
-                                        </th>
-                                        
-                                        
-                                        <td class="align-middle">08/11/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                La Liga
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/247735"
-                                               class="font-weight-normal">BALLARÍN CEREZA Laura</a>
-                                        </th>
-                                        
-                                        
-                                        <td class="align-middle">08/11/2023</td>
-                                        <td class="align-middle">
-                                            
-                                                Laliga
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                            <div class="separator separator-dotted separator-2x my-5">
-                                <button data-next-page-url="/oeil/en/procedure-meetings/?reference=2023/2019(INI)&amp;type=REGULAR_MEMBERS&amp;page=1"
-                                        class="btn btn-default oei-loadmore-button"
-                                        title="Load more">Load more</button>
-                            </div>
-                        </div>
-                    </div>
-                </li>
-            </ul>
-        </div>
-    </div>
-</div>
 
                                 
                                 <html lang="en">
@@ -2084,7 +1568,7 @@
 
 
 
-<div class="card erpl_move"
+<div class="card es_move"
      data-move-lg="#sectionsNavPositionRwd"
      data-move-md="#sectionsNavPositionRwd"
      data-move-sm="#sectionsNavPositionRwd"
@@ -2092,46 +1576,42 @@
      data-move-xs="#sectionsNavPositionRwd"
      data-move-xxl="#sectionsNavPositionInitial">
     <div class="card-body py-0">
-        <nav class="erpl_side-navigation">
-            <h3 class="erpl_title-h3 mb-0 py-2">
+        <nav class="es_side-navigation">
+            <h3 class="es_title-h3 mb-0 py-2">
                 <a class="text-primary" href="#">
                     <span class="t-x">Procedure file</span>
                 </a>
             </h3>
-            <div class="erpl_links-list erpl_links-list-nav">
+            <div class="es_links-list es_links-list-nav">
                 <ul>
                     <li data-selected="true">
-                        <a class="erpl_smooth-scroll" href="#section1">
+                        <a class="es_smooth-scroll" href="#section1">
                             <span class="t-x">Basic information</span>
                         </a>
                     </li>
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section2">
+                        <a class="es_smooth-scroll" href="#section2">
                             <span class="t-x">Key players</span>
                         </a>
                     </li>
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section3">
+                        <a class="es_smooth-scroll" href="#section3">
                             <span class="t-x">Key events</span>
                         </a>
                     </li>
                     
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section5">
+                        <a class="es_smooth-scroll" href="#section5">
                             <span class="t-x">Technical information</span>
                         </a>
                     </li>
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section6">
+                        <a class="es_smooth-scroll" href="#section6">
                             <span class="t-x">Documentation gateway</span>
                         </a>
                     </li>
                     
-                    <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section8">
-                            <span class="t-x">Transparency</span>
-                        </a>
-                    </li>
+                    
                     
                     
                 </ul>
@@ -2154,14 +1634,14 @@
     </button>
 
     
-    <footer class="erpl_footer">
-    <div class="erpl_footer-top mt-8">
+    <footer class="es_footer">
+    <div class="es_footer-top mt-8">
         <div class="container">
-            <div class="erpl_footer-top-content border-top-lg border-secondary text-center d-md-flex justify-content-between pt-md-3 mb-5 a-i">
-                <nav id="share-links" class="erpl_share-links" aria-label="Share links">
-                    <div class="d-md-flex">
-                        <h2 class="erpl_title-h5 mb-2 mb-md-0"><span class="mr-md-1">Share this page</span></h2>
-                        <ul class="erpl_share-links-list d-flex justify-content-center mb-3 mb-md-0">
+            <div class="es_footer-top-content border-top-lg border-secondary text-center d-md-flex justify-content-between pt-md-3 mb-5 a-i">
+                <nav id="share-links" class="es_footer-share-links" aria-label="Share links">
+                    <div class="d-md-flex align-items-center">
+                        <h2 class="es_title-h5 mb-2 mb-md-0"><span class="mr-md-1">Share this page</span></h2>
+                        <ul class="es_social-share-horizontal d-flex justify-content-center align-items-center mb-3 mb-md-0 pl-0">
                             <li class="mr-1">
                                 <a title="Share this page on Facebook" href="https://www.facebook.com/share.php?u=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2023/2019(INI)" target="_blank">
                                     <span class="sr-only">Facebook</span>
@@ -2171,10 +1651,10 @@
                                 </a>
                             </li>
                             <li class="mr-1">
-                                <a title="Share this page on Twitter" href="https://twitter.com/intent/tweet?url=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2023/2019(INI)&amp;text=Procedure%20File:%202023/2019(INI)&amp;via=Europarl_EN" target="_blank">
-                                    <span class="sr-only">Twitter</span>
-                                    <svg aria-hidden="true" class="es_icon es_icon-twitter">
-                                        <use xlink:href="#es_icon-twitter"></use>
+                                <a title="Share this page on X" href="https://x.com/intent/post?url=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2023/2019(INI)&amp;text=Procedure%20File:%202023/2019(INI)&amp;via=Europarl_EN" target="_blank">
+                                    <span class="sr-only">X</span>
+                                    <svg aria-hidden="true" class="es_icon es_icon-twitter-x">
+                                        <use xlink:href="#es_icon-twitter-x"></use>
                                     </svg>
                                 </a>
                             </li>
@@ -2197,7 +1677,7 @@
                         </ul>
                     </div>
                 </nav>
-                <nav class="erpl_horizontal-links" aria-label="data protection link">
+                <nav class="es_horizontal-links" aria-label="data protection link">
                     <div>
                         <a href="https://oeil.secure.europarl.europa.eu/oeil/en/external-documents/download?id=2" target="_blank">
                             <span class="t-y">Data Protection Notice</span>
@@ -2207,28 +1687,28 @@
             </div>
         </div>
     </div>
-    <div class="erpl_footer-bottom bg-black-footer pt-3 pb-3">
+    <div class="es_footer-bottom bg-black-footer pt-3 pb-3">
         <div class="container">
             <div class="row" id="footerLinks">
                 <nav class="col-12 col-xl-9 text-center text-md-left" id="website-links" aria-label="Website links">
-    <h3 class="erpl_title-h3 mb-2 text-white">Legislative Observatory</h3>
+    <h3 class="es_title-h3 mb-2 text-white">Legislative Observatory</h3>
     <div class="collapse show" id="website-links-items">
         <div class="row">
             <div class="col-12 col-md-6 col-xl-4">
                 <div>
                     <div class="subtitle mb-1">Tools</div>
                     <nav class="link-group t-x-mode" aria-label="Tools">
-                        <a href="https://www.europarl.europa.eu/news/en/press-room" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/news/en/press-room" class="link-group-item mb-1 d-block" aria-label="Tools - Press Service">
                             <span>Press Service</span>
-                        </a><a href="https://www.europarl.europa.eu/olp/en/home" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/olp/en/home" class="link-group-item mb-1 d-block" aria-label="Tools - Ordinary legislative procedure">
                             <span>Ordinary legislative procedure</span>
-                        </a><a href="https://www.europarl.europa.eu/RegistreWeb/search/simple.htm?language=en" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/RegistreWeb/search/simple.htm?language=en" class="link-group-item mb-1 d-block" aria-label="Tools - Parliament register">
                             <span>Parliament register</span>
-                        </a><a href="https://eur-lex.europa.eu/en/index.htm" class="link-group-item mb-1 d-block">
+                        </a><a href="https://eur-lex.europa.eu/en/index.htm" class="link-group-item mb-1 d-block" aria-label="Tools - EUR-Lex">
                             <span>EUR-Lex</span>
-                        </a><a href="https://www.consilium.europa.eu/en/documents-publications/public-register/" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.consilium.europa.eu/en/documents-publications/public-register/" class="link-group-item mb-1 d-block" aria-label="Tools - Council register">
                             <span>Council register</span>
-                        </a><a href="https://webgate.ec.europa.eu/regdel/#/home" class="link-group-item mb-1 d-block">
+                        </a><a href="https://webgate.ec.europa.eu/regdel/#/home" class="link-group-item mb-1 d-block" aria-label="Tools - Delegated acts register">
                             <span>Delegated acts register</span>
                         </a>
                     </nav>
@@ -2238,15 +1718,15 @@
                 <div>
                     <div class="subtitle mb-1">Committees</div>
                     <nav class="link-group t-x-mode" aria-label="Committees">
-                        <a href="https://www.europarl.europa.eu/committees/en/home" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/committees/en/home" class="link-group-item mb-1 d-block" aria-label="Committees - Home">
                             <span>Home</span>
-                        </a><a href="https://www.europarl.europa.eu/committees/en/meetings/meeting-documents" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/committees/en/meetings/meeting-documents" class="link-group-item mb-1 d-block" aria-label="Committees - Meetings">
                             <span>Meetings</span>
-                        </a><a href="https://www.europarl.europa.eu/committees/en/documents/search" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/committees/en/documents/search" class="link-group-item mb-1 d-block" aria-label="Committees - Documents">
                             <span>Documents</span>
-                        </a><a href="https://www.europarl.europa.eu/committees/en/events/events-hearings" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/committees/en/events/events-hearings" class="link-group-item mb-1 d-block" aria-label="Committees - Events">
                             <span>Events</span>
-                        </a><a href="https://www.europarl.europa.eu/committees/en/supporting-analyses/sa-highlights" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/committees/en/supporting-analyses/sa-highlights" class="link-group-item mb-1 d-block" aria-label="Committees - Supporting analyses">
                             <span>Supporting analyses</span>
                         </a>
                     </nav>
@@ -2254,16 +1734,16 @@
                 <div>
                     <div class="subtitle mb-1">Plenary</div>
                     <nav class="link-group t-x-mode" aria-label="Plenary">
-                        <a href="https://www.europarl.europa.eu/plenary/en/" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/plenary/en/" class="link-group-item mb-1 d-block" aria-label="Plenary - Plenary sitting">
                             <span>Plenary sitting</span>
-                        </a><a href="https://www.europarl.europa.eu/plenary/en/guide-plenary.html" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/guide-plenary.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Around plenary">
                             <span>Around plenary</span>
-                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliamentary-questions.html" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliamentary-questions.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Questions and declarations">
                             <span>Questions and declarations</span>
-                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliament-positions.html" class="link-group-item mb-1 d-block">
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/parliament-positions.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Legislative texts adopted">
                             <span>Legislative texts adopted</span>
-                        </a><a href="https://www.europarl.europa.eu/plenary/en/meetings-search.html" class="link-group-item mb-1 d-block">
-                            <span>Calendar</span>
+                        </a><a href="https://www.europarl.europa.eu/plenary/en/meetings-search.html" class="link-group-item mb-1 d-block" aria-label="Plenary - Plenary calendar">
+                            <span>Plenary calendar</span>
                         </a>
                     </nav>
                 </div>
@@ -2272,9 +1752,9 @@
                 <div>
                     <div class="subtitle mb-1">Delegations</div>
                     <nav class="link-group t-x-mode" aria-label="Delegations">
-                        <a href="https://www.europarl.europa.eu/delegations/en/calendar" class="link-group-item mb-1 d-block">
-                            <span>Calendar</span>
-                        </a><a href="https://www.europarl.europa.eu/delegations/en/home" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/delegations/en/calendar" class="link-group-item mb-1 d-block" aria-label="Delegations - Delegations calendar">
+                            <span>Delegations calendar</span>
+                        </a><a href="https://www.europarl.europa.eu/delegations/en/home" class="link-group-item mb-1 d-block" aria-label="Delegations - Home">
                             <span>Home</span>
                         </a>
                     </nav>
@@ -2282,7 +1762,7 @@
                 <div>
                     <div class="subtitle mb-1">MEPs</div>
                     <nav class="link-group t-x-mode" aria-label="MEPs">
-                        <a href="https://www.europarl.europa.eu/meps/en/search/advanced" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/meps/en/search/advanced" class="link-group-item mb-1 d-block" aria-label="MEPs - Search">
                             <span>Search</span>
                         </a>
                     </nav>
@@ -2290,7 +1770,7 @@
                 <div>
                     <div class="subtitle mb-1">At your service</div>
                     <nav class="link-group t-x-mode" aria-label="At your service">
-                        <a href="https://www.europarl.europa.eu/at-your-service/en" class="link-group-item mb-1 d-block">
+                        <a href="https://www.europarl.europa.eu/at-your-service/en" class="link-group-item mb-1 d-block" aria-label="At your service - Home">
                             <span>Home</span>
                         </a>
                     </nav>
@@ -2301,7 +1781,7 @@
 
     <div class="d-block d-md-none">
         <div class="footerLinkToggle separator separator-dotted separator-2x mb-5 mt-5 collapsed">
-            <a class="erpl_toggle-menu" href="#website-links"
+            <a class="es_toggle-menu" href="#website-links"
                title="Toggle linked links"
                role="button"
                data-toggle="collapse"
@@ -2316,7 +1796,7 @@
                     <use xlink:href="#es_icon-minus"></use>
                 </svg>
             </a>
-            <a class="erpl_nojs-close-menu" href="#website-links-close"
+            <a class="es_nojs-close-menu" href="#website-links-close"
                title="Untoggle linked links"
                role="button"
                data-toggle="collapse"
@@ -2332,18 +1812,18 @@
 </nav>
                 <nav class="col-12 col-xl-3 text-center text-md-left" id="europarl-links" aria-label="Europarl links">
     <div class="separator separator-dotted separator-2x mt-3 mb-4 d-none d-md-flex d-xl-none"></div>
-    <h3 class="erpl_title-h3 mb-2 text-white">European Parliament</h3>
+    <h3 class="es_title-h3 mb-2 text-white">European Parliament</h3>
     <div class="collapse show" id="europarl-links-items">
         <nav class="link-group pt-25 t-x-mode" aria-label="European Parliament">
-            <a href="https://www.europarl.europa.eu/news/en" class="link-group-item mb-1 d-block">
-                <span>News</span></a><a href="https://www.europarl.europa.eu/topics/en" class="link-group-item mb-1 d-block">
-                <span>Topics</span></a><a href="https://www.europarl.europa.eu/meps/en" class="link-group-item mb-1 d-block">
-                <span>MEPs</span></a><a href="https://www.europarl.europa.eu/about-parliament/en" class="link-group-item mb-1 d-block">
-                <span>About Parliament</span></a><a href="https://www.europarl.europa.eu/plenary/en" class="link-group-item mb-1 d-block">
-                <span>Plenary</span></a><a href="https://www.europarl.europa.eu/committees/en" class="link-group-item mb-1 d-block">
-                <span>Committees</span></a><a href="https://www.europarl.europa.eu/delegations/en" class="link-group-item mb-1 d-block">
-                <span>Delegations</span></a><a href="https://elections.europa.eu/en/" class="link-group-item mb-1 d-block">
-                <span>Elections</span></a>
+            <a href="https://www.europarl.europa.eu/news/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - News">
+                <span>News</span></a><a href="https://www.europarl.europa.eu/topics/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Topics">
+                <span>Topics</span></a><a href="https://www.europarl.europa.eu/meps/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - MEPs">
+                <span>MEPs</span></a><a href="https://www.europarl.europa.eu/about-parliament/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - About Parliament">
+                <span>About Parliament</span></a><a href="https://www.europarl.europa.eu/plenary/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Plenary">
+                <span>Plenary</span></a><a href="https://www.europarl.europa.eu/committees/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Committees">
+                <span>Committees</span></a><a href="https://www.europarl.europa.eu/delegations/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Delegations">
+                <span>Delegations</span></a><a href="https://eubudget.europarl.europa.eu/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - EU budget">
+                <span>EU budget</span></a>
         </nav>
     </div>
     <div class="d-block d-md-none">
@@ -2363,7 +1843,7 @@
                     <use xlink:href="#es_icon-minus"></use>
                 </svg>
             </a>
-            <a class="erpl_nojs-close-menu" href="#europarl-links-close"
+            <a class="es_nojs-close-menu" href="#europarl-links-close"
                title="Untoggle European Parliament websites"
                role="button" data-toggle="collapse"
                data-target="#europarl-links-items"
@@ -2381,67 +1861,68 @@
 
             <div class="separator separator-dotted separator-2x mt-3 mb-3 d-none d-md-flex"></div>
             <div class="row">
-                <nav class="col-12" id="social-links" aria-label="Social links">
-                    <div class="erpl_social-links mb-2">
+                <nav class="col-12 d-flex justify-content-center" id="social-links" aria-label="Social links">
+                    <div class="es_footer-social-links mb-2">
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Facebook" href="https://www.facebook.com/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-facebook-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Facebook" href="https://www.facebook.com/europeanparliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-facebook-color">
                                     <use href="#es_icon-facebook-color"></use>
                                 </svg>
                                 <span class="sr-only">Facebook</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Twitter" href="https://twitter.com/Europarl_en" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-twitter-color">
-                                    <use href="#es_icon-twitter-color"></use>
+                            <a  data-toggle="tooltip" title="Check out Parliament on X" href="https://x.com/Europarl_en" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-twitter-x">
+                                    <use href="#es_icon-twitter-x"></use>
                                 </svg>
                                 <span class="sr-only">Twitter</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Flickr" href="https://www.flickr.com/photos/european_parliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-flickr-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Flickr" href="https://www.flickr.com/photos/european_parliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-flickr-color">
                                     <use href="#es_icon-flickr-color"></use>
                                 </svg>
                                 <span class="sr-only">Flickr</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on LinkedIn" href="https://www.linkedin.com/company/european-parliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-linkedin-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on LinkedIn" href="https://www.linkedin.com/company/european-parliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-linkedin-color">
                                     <use href="#es_icon-linkedin-color"></use>
                                 </svg>
                                 <span class="sr-only">LinkedIn</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on YouTube" href="https://www.youtube.com/user/EuropeanParliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-youtube-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on YouTube" href="https://www.youtube.com/user/EuropeanParliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-youtube-color">
                                     <use href="#es_icon-youtube-color"></use>
                                 </svg>
                                 <span class="sr-only">YouTube</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Instagram" href="https://www.instagram.com/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-instagram-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Instagram" href="https://www.instagram.com/europeanparliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-instagram-color">
                                     <use href="#es_icon-instagram-color"></use>
                                 </svg>
                                 <span class="sr-only">Instagram</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Pinterest" href="https://www.pinterest.fr/epinfographics" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-pinterest-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Pinterest" href="https://www.pinterest.fr/epinfographics" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-pinterest-color">
                                     <use href="#es_icon-pinterest-color"></use>
                                 </svg>
                                 <span class="sr-only">Pinterest</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Snapchat" href="https://www.snapchat.com/add/europarl" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-snapchat-color">
-                                    <use href="#es_icon-snapchat-color"></use>
-                                </svg>
-                                <span class="sr-only">Snapchat</span>
-                            </a>
-                        
-                            <a data-toggle="tooltip" title="Check out Parliament on Reddit" href="https://www.reddit.com/r/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-reddit-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Reddit" href="https://www.reddit.com/r/europeanparliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-reddit-color">
                                     <use href="#es_icon-reddit-color"></use>
                                 </svg>
                                 <span class="sr-only">Reddit</span>
@@ -2478,12 +1959,9 @@
         </div>
     </div>
 </footer>
-
     
-    <script src="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/lib/jquery/jquery.min.js"></script>
-    
-    <script id="evostrap" src="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/dist/js/evostrap.js"></script>
-    <script src="https://www.europarl.europa.eu/commonFrontResources/evostrap-oeil/1.0.0//dist/js/oeil.js"></script>
+    <script id="evostrap" type="module" src="https://evokits.europarl.europa.eu/evostrap/7.0.0/lib/dist/js/evostrap.js"></script>
+    <script src="https://evokits.europarl.europa.eu/evostrap-oeil/1.0.1/dist/js/oeil.js"></script>
 
     
     <script src="/oeil/oeil-addons/documents-loading.js"></script>

--- a/backend/tests/scrapers/data/votes/oeil-procedure-file_2024-0258-cod.html
+++ b/backend/tests/scrapers/data/votes/oeil-procedure-file_2024-0258-cod.html
@@ -27,49 +27,48 @@
     <meta content="index, follow, noodp, noydir, notranslate, noarchive" name="robots">
     <meta content="European Union, 2025 - Source: European Parliament" name="copyright">
     <meta content="Legislative Observatory" name="planet">
-    <meta content="16-03-2025" name="available">
+    <meta content="13-11-2025" name="available">
 
     <!-- Dynamics meta tags -->
     
-        <meta content="OEIL, Legislative Observatory, Observatoire législatif, 2024/0258(COD), MIKSER Sven, S&amp;D, MUREŞAN Siegfried, EPP, ZDROJEWSKI Bogdan Andrzej, EPP, SJÖSTEDT Jonas, The Left, 6.30.02 Financial and technical cooperation and assistance, 6.40.02 Relations with central and eastern Europe, 8.20.01 Candidate countries, 8.20.04 Pre-accession and partnership, COM(2024)0469, A10-0006/2025" name="keywords">
+        <meta content="OEIL, Legislative Observatory, Observatoire législatif, 2024/0258(COD), MIKSER Sven, S&amp;D, MUREŞAN Siegfried, EPP, ZDROJEWSKI Bogdan Andrzej, EPP, SJÖSTEDT Jonas, The Left, 6.30.02 Financial and technical cooperation and assistance, 6.40.02 Relations with central and eastern Europe, 8.20.01 Candidate countries, 8.20.04 Pre-accession and partnership, COM(2024)0469, A10-0006/2025, T10-0022/2025" name="keywords">
     
 
     <!-- HTML <link> tags -->
-    <link rel="icon" href="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/assets/img/favicon.ico">
+    <link rel="icon" href="https://evokits.europarl.europa.eu/evostrap/7.0.0/lib/dist/assets/img/favicon.ico">
 
     
-    <link href="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/dist/css/evostrap.css" rel="stylesheet">
-    <link href="https://www.europarl.europa.eu/commonFrontResources/evostrap-oeil/1.0.0//dist/css/oeil.css" rel="stylesheet">
+    <link href="https://evokits.europarl.europa.eu/evostrap/7.0.0/lib/dist/css/evostrap.css" rel="stylesheet">
+    <link href="https://evokits.europarl.europa.eu/evostrap-oeil/1.0.1/dist/css/oeil.css" rel="stylesheet">
 </head>
 
 <body id="main-content" data-app-context="/oeil/">
 
-    <header class="erpl_header">
-    <nav class="erpl_wai-access" aria-label="Shortcuts">
+    <header class="es_header">
+    <nav class="es_wai-access" aria-label="Shortcuts">
         <ul>
-            <li> <a href="#website-body" class="erpl_smooth-scroll"> <span class="btn btn-primary">Access to page content (press &quot;Enter&quot;)</span> </a> </li>
-            <li> <a href="#languageSelectorDropdownButton" class="erpl_smooth-scroll"> <span class="btn btn-primary">Direct access to language menu (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#website-body" class="es_smooth-scroll"> <span class="btn btn-primary">Access to page content (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#languageSelectorDropdownButton" class="es_smooth-scroll"> <span class="btn btn-primary">Direct access to language menu (press &quot;Enter&quot;)</span> </a> </li>
 
-            <li> <a href="#mainSearch" class="erpl_smooth-scroll"> <span class="btn btn-primary">Direct access to search menu (press &quot;Enter&quot;)</span> </a> </li>
+            <li> <a href="#mainSearch" class="es_smooth-scroll"> <span class="btn btn-primary">Direct access to search menu (press &quot;Enter&quot;)</span> </a> </li>
         </ul>
     </nav>
 
     
-    <div class="erpl_header-top border-bottom mb-3 mb-xl-4 a-i">
+    <div class="es_header-top border-bottom mb-3 mb-xl-4 a-i">
         <div class="container">
             <div class="row no-gutters">
-                <div class="col-auto"><div class="erpl_header-language-selector">
-    <div class="erpl_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute"
+                <div class="col-auto"><div class="es_header-language-selector">
+    <div class="es_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute"
          data-content-width="auto">
-        <button class="erpl_dropdown-btn input-group collapsed" type="button" data-toggle="collapse"
+        <button class="es_dropdown-btn input-group collapsed" type="button" data-toggle="collapse"
                 id="languageSelectorDropdownButton"
                 data-target="#languageSelectorDropdownContent"
                 aria-expanded="false"
                 aria-controls="languageSelectorDropdownContent">
-            <span class="value form-control">EN - English</span>
+            <span class="es_dropdown-label">EN - English</span>
             
-            <span class="input-group-append">
-                <span class="input-group-icon">
+            <span class="es_dropdown-icon">
                     <svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false">
                         <use xlink:href="#es_icon-arrow"></use>
                     </svg>
@@ -77,42 +76,37 @@
                          data-show-expanded="true">
                         <use xlink:href="#es_icon-arrow"></use>
                     </svg>
-                </span>
             </span>
         </button>
 
         <div>
-            <div class="erpl_dropdown-content collapse" id="languageSelectorDropdownContent">
-                <div class="border border-light">
-                    <div>
-                        <ul class="erpl_topbar-list list-unstyled erpl_dropdown-menu">
-                            <li class="t-x-block" data-selected="true">
-                                <!-- localized version URL is here -->
-                                <a class="erpl_dropdown-menu-item"
-                                   lang="en"
-                                   href="https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2024/0258(COD)">
-                                    <span class="t-item">EN - English</span>
-                                    
-                                </a>
-                            </li>
+            <div class="dropdown-menu border border-light" id="languageSelectorDropdownContent">
+                        <ul class="erpl_topbar-list list-unstyled es_dropdown-menu">
                             <li class="t-x-block" data-selected="false">
                                 <!-- localized version URL is here -->
-                                <a class="erpl_dropdown-menu-item"
+                                <a class="es_dropdown-menu-item"
                                    lang="fr"
                                    href="https://oeil.secure.europarl.europa.eu/oeil/fr/procedure-file?reference=2024/0258(COD)">
                                     
                                     <span class="t-item">FR - français</span>
                                 </a>
                             </li>
+                            <li class="t-x-block" data-selected="true">
+                                <!-- localized version URL is here -->
+                                <a class="es_dropdown-menu-item"
+                                   lang="en"
+                                   href="https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2024/0258(COD)">
+                                    <span class="t-item">EN - English</span>
+                                    
+                                </a>
+                            </li>
                         </ul>
-                    </div>
-                </div>
             </div>
         </div>
     </div>
 </div></div>
                 <div class="col">
-                    <nav class="erpl_header-other-websites d-flex justify-content-end align-items-center" aria-label="Other websites">
+                    <nav class="es_header-other-websites d-flex justify-content-end align-items-center" aria-label="Other websites">
                         <ul class="d-flex list-unstyled">
 
                             
@@ -166,24 +160,23 @@
 
                             
                             <li class="d-none d-xl-block">
-                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://elections.europa.eu/en/">
-                                    <span class="t-item">Elections</span>
+                                <a class="d-xl-flex px-1 align-items-center t-y-block" href="https://eubudget.europarl.europa.eu/en">
+                                    <span class="t-item">EU budget</span>
                                 </a>
                             </li>
 
 
-                            <li class="erpl_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute">
-                               <button class="erpl_dropdown-btn input-group collapsed d-xl-flex pl-1 align-items-center t-y-block flex-nowrap"
+                            <li class="es_dropdown" data-auto-close="true" data-auto-focus="true" data-position="absolute">
+                               <button class="es_dropdown-btn input-group collapsed d-xl-flex pl-1 align-items-center t-y-block flex-nowrap"
                                        data-toggle="collapse"
                                        data-target="#otherWebsiteSubmenu"
                                        aria-expanded="false"
                                        aria-controls="otherWebsiteSubmenu" aria-label="More other websites">
-                                    <span class="value">
+                                    <span class="es_dropdown-label">
 											<span class="d-none d-xl-inline">Other websites</span>
 											<span class="d-xl-none">View other websites</span>
                                     </span>
-                                   <span class="input-group-append">
-											<span class="input-group-icon">
+                                   <span class="es_dropdown-icon">
 												<svg aria-hidden="true" class="es_icon es_icon-arrow" data-show-expanded="false">
 													<use xlink:href="#es_icon-arrow"></use>
 												</svg>
@@ -192,140 +185,153 @@
 													<use xlink:href="#es_icon-arrow"></use>
 												</svg>
 											</span>
-										</span>
                                 </button>
                                 <div>
-                                    <div id="otherWebsiteSubmenu" class="erpl_dropdown-content collapse">
-                                        <ul class="erpl_header-other-websites-submenu list-unstyled erpl_dropdown-menu">
+                                    <div id="otherWebsiteSubmenu" class="dropdown-menu border border-light">
+                                        <ul class="es_header-other-websites-submenu erpl_topbar-list list-unstyled es_dropdown-men">
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/news/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/news/en">
                                                     <span class="t-item">News</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/topics/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/topics/en">
                                                     <span class="t-item">Topics</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/meps/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/meps/en">
                                                     <span class="t-item">MEPs</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/about-parliament/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/about-parliament/en">
                                                     <span class="t-item">About Parliament</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/plenary/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/plenary/en">
                                                     <span class="t-item">Plenary</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/committees/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/committees/en">
                                                     <span class="t-item">Committees</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/delegations/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/delegations/en">
                                                     <span class="t-item">Delegations</span>
                                                 </a>
                                             </li>
                                             
                                             <li class="d-xl-none t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://elections.europa.eu/en/">
-                                                    <span class="t-item">Elections</span>
+                                                <a class="es_dropdown-menu-item" href="https://eubudget.europarl.europa.eu/en">
+                                                    <span class="t-item">EU budget</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://multimedia.europarl.europa.eu/en/home">
+                                                <a class="es_dropdown-menu-item" href="https://multimedia.europarl.europa.eu/en/home">
                                                     <span class="t-item">Multimedia Centre</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/the-president/en">
-                                                    <span class="t-item">President&#39;s website</span>
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/the-president/en">
+                                                    <span class="t-item">Presidency</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/the-secretary-general/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/the-secretary-general/en">
                                                     <span class="t-item">Secretariat-general</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/thinktank/en">
+                                                <a class="es_dropdown-menu-item" href="https://elections.europa.eu/en/">
+                                                    <span class="t-item">Elections</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/thinktank/en">
                                                     <span class="t-item">Thinktank</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.epnewshub.eu">
+                                                <a class="es_dropdown-menu-item" href="https://www.epnewshub.eu">
                                                     <span class="t-item">EP Newshub</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/at-your-service/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/at-your-service/en">
                                                     <span class="t-item">At your service</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/visiting/en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/visiting/en">
                                                     <span class="t-item">Visits</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/legislative-train">
+                                                <a class="es_dropdown-menu-item" href="https://oeil.secure.europarl.europa.eu/oeil/en">
+                                                    <span class="t-item">Legislative Observatory</span>
+                                                </a>
+                                            </li>
+
+                                            
+                                            <li class="t-x-block">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/legislative-train">
                                                     <span class="t-item">Legislative train</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/contracts-and-grants/en/">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/contracts-and-grants/en/">
                                                     <span class="t-item">Contracts and Grants</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://www.europarl.europa.eu/RegistreWeb/home/welcome.htm?language=en">
+                                                <a class="es_dropdown-menu-item" href="https://www.europarl.europa.eu/RegistreWeb/home/welcome.htm?language=en">
                                                     <span class="t-item">Register</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://data.europarl.europa.eu/en">
+                                                <a class="es_dropdown-menu-item" href="https://data.europarl.europa.eu/en">
                                                     <span class="t-item">Open Data Portal</span>
                                                 </a>
                                             </li>
 
                                             
                                             <li class="t-x-block">
-                                                <a class="erpl_dropdown-menu-item" href="https://liaison-offices.europarl.europa.eu/en">
+                                                <a class="es_dropdown-menu-item" href="https://liaison-offices.europarl.europa.eu/en">
                                                     <span class="t-item">Liaison offices</span>
                                                 </a>
                                             </li>
@@ -339,17 +345,17 @@
             </div>
         </div>
     </div>
-    <div class="erpl_header-middle mb-3">
+    <div class="es_header-middle mb-3">
         <div class="container">
             <div class="row">
                 <div class="col-12 col-md">
-                    <div class="erpl_header-website-title a-i">
-                        <div class="erpl_header-website-title-main">
+                    <div class="es_header-website-title a-i">
+                        <div class="es_header-website-title-main">
                             <a href="/oeil/en" class="t-x">
                                 <span>Legislative Observatory</span>
                             </a>
                         </div>
-                        <div class="erpl_header-website-title-sub">
+                        <div class="es_header-website-title-sub">
                             <a class="t-x-block" href="https://www.europarl.europa.eu" target="_blank" >
                                 <span class="t-item">European Parliament</span>
                             </a>
@@ -358,17 +364,18 @@
                 </div>
 
                 
-                <div class="col-auto d-none d-xl-flex justify-content-end align-items-center erpl_header-search-container">
-                    <form class="erpl_header-search" method="GET" action="/oeil/en/search"> <label for="mainSearch" class="sr-only">Find a procedure</label>
+                <div class="col-auto d-none d-xl-flex justify-content-end align-items-center es_header-search-container">
+                    <form class="es_header-search" method="GET" action="/oeil/en/search"> <label for="mainSearch" class="sr-only">Find a procedure</label>
                         <div class="input-group" style="width: 300px">
                             <input type="text" class="form-control"
                                    id="mainSearch"
+                                   maxlength="100"
                                    placeholder="Find a procedure..."
                                    name="fullText.term"
                                    aria-describedby="mainSearchHelper">
                             <div class="input-group-append">
                                 <button class="btn btn-primary align-items-center d-flex" title="Start find a procedure" disabled="">
-                                    <svg aria-hidden="true" class="es_icon es_icon-search erpl_header-search-icon">
+                                    <svg aria-hidden="true" class="es_icon es_icon-search es_header-search-icon">
                                         <use xlink:href="#es_icon-search"></use>
                                     </svg>
                                 </button>
@@ -379,64 +386,64 @@
             </div>
         </div>
     </div>
-    <div class="erpl_header-bottom">
-        <div class="erpl_header-menu-container">
-            <div class="container"><nav class="erpl_header-menu" aria-label="Main navigation">
-    <div class="erpl_header-menu-top row align-items-center">
+    <div class="es_header-bottom">
+        <div class="es_header-menu-container">
+            <div class="container"><nav class="es_header-menu" aria-label="Main navigation">
+    <div class="es_header-menu-top row align-items-center">
         <div class="col d-md-none d-flex align-items-center">
-            <svg aria-hidden="true" class="es_icon es_icon-ep-logo-w erpl_header-menu-top-logo">
+            <svg aria-hidden="true" class="es_icon es_icon-ep-logo-w es_header-menu-top-logo">
                 <use xlink:href="#es_icon-ep-logo-w"></use>
             </svg>
         </div>
 
-        <span class="erpl_header-menu-top-title offset-3 col-6 text-center d-none d-md-block" aria-hidden="true">
+        <span class="es_header-menu-top-title offset-3 col-6 text-center d-none d-md-block" aria-hidden="true">
 								<span>European Parliament</span></span>
 
-        <div class="erpl_header-menu-top-controls col-auto col-md-3 text-right">
-            <button type="button" class="btn btn-sm btn-dark-primary erpl_header-menu-top-controls-toggle-search" id="headerMenuToggleSearch" aria-haspopup="true" aria-expanded="false">
+        <div class="es_header-menu-top-controls col-auto col-md-3 text-right">
+            <button type="button" class="btn btn-sm btn-dark-primary es_header-menu-top-controls-toggle-search" id="headerMenuToggleSearch" aria-haspopup="true" aria-expanded="false">
                 <span class="sr-only">Search</span>
                 <svg aria-hidden="true" class="es_icon es_icon-search">
                     <use xlink:href="#es_icon-search"></use>
                 </svg>
             </button>
             <button type="button"
-                    class="btn btn-sm btn-dark-primary erpl_header-menu-top-controls-toggle-menu"
+                    class="btn btn-sm btn-dark-primary es_header-menu-top-controls-toggle-menu"
                     id="headerMenuToggleMenu"
                     aria-haspopup="true"
                     aria-expanded="false">
-                <span class="mr-25">Menu</span> <span class="erpl_header-menu-icon" aria-hidden="true"></span>
+                <span class="mr-25">Menu</span> <span class="es_header-menu-icon" aria-hidden="true"></span>
             </button>
         </div>
     </div>
 
-    <ul class="erpl_header-menu-list list-unstyled">
+    <ul class="es_header-menu-list list-unstyled">
         
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en" data-selected="false">
         <span class="t-y">Home</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/search" data-selected="false">
         <span class="t-y">Search</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/legislative-priorities" data-selected="false">
         <span class="t-y">Legislative priorities</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/find-out-more" data-selected="false">
         <span class="t-y">Find out more</span>
     </a>
 </li>
-<li class="erpl_header-menu-item">
-    <a class="erpl_header-menu-item-title"
+<li class="es_header-menu-item">
+    <a class="es_header-menu-item-title"
        href="/oeil/en/contact" data-selected="false">
         <span class="t-y">Contact us</span>
     </a>
@@ -458,10 +465,10 @@
     <div class="row">
         <div class="col-12 col-xl-8">
             <div class="row">
-                <div class="col-12 col-lg"><h2 class="erpl_title-h1 mb-3">2024/0258(COD)</h2>
+                <div class="col-12 col-lg"><h2 class="es_title-h1 mb-3">2024/0258(COD)</h2>
                 </div>
                 <div class="col-12 col-lg-4">
-                    <div class="erpl_links-list text-lg-right my-1">
+                    <div class="es_links-list text-lg-right my-1">
                         <ul>
                             <li>
                                 <a href="/oeil/en/procedure-file/pdf?reference=2024/0258(COD)">
@@ -477,7 +484,7 @@
                 </div>
             </div>
             
-            <h2 class="erpl_title-h2 mb-3">Establishing the Reform and Growth Facility for Moldova</h2>
+            <h2 class="es_title-h2 mb-3">Establishing the Reform and Growth Facility for Moldova</h2>
             <div class="separator border-dark my-3"></div>
 
             
@@ -485,22 +492,22 @@
 
 
             
-            <div class="erpl_product">
+            <div class="es_product">
                 <div class="row">
                     <div class="col">
                         <div class="mb-3">
-                            <div class="erpl_product-body">
+                            <div class="es_product-body">
                                 
                                 <html lang="en">
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div id="section1" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 class="erpl_title-h2 mb-2">Basic information</h2></div>
+                <h2 class="es_title-h2 mb-2">Basic information</h2></div>
                 <div class="col-12 col-lg-4">
-                    <div class="erpl_links-list text-lg-right my-1">
+                    <div class="es_links-list text-lg-right my-1">
                         <ul>
                             <li>
                                 <a href="/oeil/en/procedure-file/pdf?reference=2024/0258(COD)&amp;section=BASIC_INFO">
@@ -561,7 +568,7 @@
             <div class="col-6">
                 
                     <p class="font-weight-bold mb-1">Status</p>
-                    <p class="text-danger">Awaiting Council&#39;s 1st reading position</p>
+                    <p class="text-danger">Procedure completed</p>
                 
 
                 
@@ -571,7 +578,7 @@
         <div class="row">
             <div class="col-12">
                 <div class="separator separator-dotted separator-2x mt-5 mb-3">
-                    <a class="erpl_smooth-scroll btn btn-default" href="#gateway">Please go to Documentation gateway for any follow-up documents.</a>
+                    <a class="es_smooth-scroll btn btn-default" href="#gateway">Please go to Documentation gateway for any follow-up documents.</a>
                 </div>
             </div>
         </div>
@@ -581,14 +588,14 @@
 
 
                                 
-                                <div class="erpl_product-section">
+                                <div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section2" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
-            <div class="col-12 col-lg"><h2 class="erpl_title-h2 mb-2">Key players</h2>
+            <div class="col-12 col-lg"><h2 class="es_title-h2 mb-2">Key players</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2024/0258(COD)&amp;section=KEY_PLAYERS">
@@ -603,13 +610,13 @@
                 </div>
             </div>
         </div>
-        <div class="erpl_accordion mb-5" id="erplAccordionKeyPlayers">
+        <div class="es_accordion mb-5" id="erplAccordionKeyPlayers">
             <ul class="a-i">
                 
-    <li class="erpl_accordion-item" data-selected="false">
-        <button id="erpl_accordion-committee-title" type="button" class="erpl_accordion-item-title" data-toggle="collapse" data-target="#erpl_accordion-committee" aria-expanded="true" aria-controls="erpl_accordion-committee">
+    <li class="es_accordion-item" data-selected="false">
+        <button id="es_accordion-committee-title" type="button" class="es_accordion-item-title" data-toggle="collapse" data-target="#es_accordion-committee" aria-expanded="true" aria-controls="es_accordion-committee">
             <span class="t-x">European Parliament</span>
-            <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <span class="es_accordion-item-icon es_icon-container text-primary">
             <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
                 <use xlink:href="#es_icon-more"></use>
             </svg>
@@ -618,7 +625,7 @@
             </svg>
         </span>
         </button>
-        <div id="erpl_accordion-committee" class="erpl_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="erpl_accordion-committee-title">
+        <div id="es_accordion-committee" class="es_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="es_accordion-committee-title">
             <div>
                 <a href="http://www.europarl.europa.eu/" target="_blank">
                     <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1">
@@ -650,7 +657,7 @@
     <tr>
         <th scope="row">
             <div class="d-flex align-items-center">
-    <span class="erpl_badge erpl_badge-committee mr-1">AFET</span>
+    <span class="es_badge es_badge-committee mr-1">AFET</span>
     <div>
         <a href="http://www.europarl.europa.eu/committees/EN/afet/home.html" target="_blank">
                 <span class="font-weight-normal">Foreign Affairs
@@ -690,7 +697,7 @@
     <tr>
         <th scope="row">
             <div class="d-flex align-items-center">
-    <span class="erpl_badge erpl_badge-committee mr-1">BUDG</span>
+    <span class="es_badge es_badge-committee mr-1">BUDG</span>
     <div>
         <a href="http://www.europarl.europa.eu/committees/EN/budg/home.html" target="_blank">
                 <span class="font-weight-normal">Budgets
@@ -764,29 +771,29 @@
                title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/103246.jpg&quot; alt=&quot;Photo ZIJLSTRA Auke &quot;&gt;">
                 <span>ZIJLSTRA Auke (PfE)</span>
             </a><a class="rapporteur mb-25"
-               href="https://www.europarl.europa.eu/meps/en/197655" target="_blank"
-               data-toggle="tooltip-rapporteur"
-               data-placement="bottom"
-               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/197655.jpg&quot; alt=&quot;Photo TERHEŞ Cristian &quot;&gt;">
-                <span>TERHEŞ Cristian (ECR)</span>
-            </a><a class="rapporteur mb-25"
                href="https://www.europarl.europa.eu/meps/en/28615" target="_blank"
                data-toggle="tooltip-rapporteur"
                data-placement="bottom"
                title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/28615.jpg&quot; alt=&quot;Photo ZĪLE Roberts &quot;&gt;">
                 <span>ZĪLE Roberts (ECR)</span>
             </a><a class="rapporteur mb-25"
-               href="https://www.europarl.europa.eu/meps/en/257438" target="_blank"
+               href="https://www.europarl.europa.eu/meps/en/197655" target="_blank"
                data-toggle="tooltip-rapporteur"
                data-placement="bottom"
-               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/257438.jpg&quot; alt=&quot;Photo VAN BRUG Anouk &quot;&gt;">
-                <span>VAN BRUG Anouk (Renew)</span>
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/197655.jpg&quot; alt=&quot;Photo TERHEŞ Cristian &quot;&gt;">
+                <span>TERHEŞ Cristian (ECR)</span>
             </a><a class="rapporteur mb-25"
                href="https://www.europarl.europa.eu/meps/en/257110" target="_blank"
                data-toggle="tooltip-rapporteur"
                data-placement="bottom"
                title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/257110.jpg&quot; alt=&quot;Photo BARNA Dan &quot;&gt;">
                 <span>BARNA Dan (Renew)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/257438" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/257438.jpg&quot; alt=&quot;Photo VAN BRUG Anouk &quot;&gt;">
+                <span>VAN BRUG Anouk (Renew)</span>
             </a><a class="rapporteur mb-25"
                href="https://www.europarl.europa.eu/meps/en/256978" target="_blank"
                data-toggle="tooltip-rapporteur"
@@ -800,17 +807,17 @@
                title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/256965.jpg&quot; alt=&quot;Photo TEGETHOFF Kai &quot;&gt;">
                 <span>TEGETHOFF Kai (Greens/EFA)</span>
             </a><a class="rapporteur mb-25"
-               href="https://www.europarl.europa.eu/meps/en/257083" target="_blank"
-               data-toggle="tooltip-rapporteur"
-               data-placement="bottom"
-               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/257083.jpg&quot; alt=&quot;Photo OLIVEIRA João &quot;&gt;">
-                <span>OLIVEIRA João (The Left)</span>
-            </a><a class="rapporteur mb-25"
                href="https://www.europarl.europa.eu/meps/en/2268" target="_blank"
                data-toggle="tooltip-rapporteur"
                data-placement="bottom"
                title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/2268.jpg&quot; alt=&quot;Photo SJÖSTEDT Jonas &quot;&gt;">
                 <span>SJÖSTEDT Jonas (The Left)</span>
+            </a><a class="rapporteur mb-25"
+               href="https://www.europarl.europa.eu/meps/en/257083" target="_blank"
+               data-toggle="tooltip-rapporteur"
+               data-placement="bottom"
+               title="&lt;img src=&quot;https://www.europarl.europa.eu/mepphoto/257083.jpg&quot; alt=&quot;Photo OLIVEIRA João &quot;&gt;">
+                <span>OLIVEIRA João (The Left)</span>
             </a><a class="rapporteur mb-25"
                href="https://www.europarl.europa.eu/meps/en/256959" target="_blank"
                data-toggle="tooltip-rapporteur"
@@ -854,7 +861,7 @@
     <tr>
         <th scope="row">
             <div class="d-flex align-items-center">
-    <span class="erpl_badge erpl_badge-committee mr-1">INTA</span>
+    <span class="es_badge es_badge-committee mr-1">INTA</span>
     <div>
         <a href="http://www.europarl.europa.eu/committees/EN/inta/home.html" target="_blank">
                 <span class="font-weight-normal">International Trade
@@ -895,7 +902,7 @@
     <tr>
         <th scope="row">
             <div class="d-flex align-items-center">
-    <span class="erpl_badge erpl_badge-committee mr-1">CONT</span>
+    <span class="es_badge es_badge-committee mr-1">CONT</span>
     <div>
         <a href="http://www.europarl.europa.eu/committees/EN/cont/home.html" target="_blank">
                 <span class="font-weight-normal">Budgetary Control
@@ -954,10 +961,10 @@
 
 
                 
-    <li class="erpl_accordion-item" data-selected="false">
-        <button id="erpl_accordion-item2-title" type="button" class="erpl_accordion-item-title collapsed" data-toggle="collapse" data-target="#erpl_accordion-item2" aria-expanded="false" aria-controls="erpl_accordion-item2">
+    <li class="es_accordion-item" data-selected="false">
+        <button id="es_accordion-item2-title" type="button" class="es_accordion-item-title collapsed" data-toggle="collapse" data-target="#es_accordion-item2" aria-expanded="false" aria-controls="es_accordion-item2">
             <span class="t-x">Council of the European Union</span>
-            <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <span class="es_accordion-item-icon es_icon-container text-primary">
                 <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
                     <use xlink:href="#es_icon-more"></use>
                 </svg>
@@ -967,7 +974,7 @@
             </span>
         </button>
 
-        <div id="erpl_accordion-item2" class="collapse erpl_accordion-item-content a-i-none" aria-labelledby="erpl_accordion-item2-title">
+        <div id="es_accordion-item2" class="collapse es_accordion-item-content a-i-none" aria-labelledby="es_accordion-item2-title">
             <div>
                 <a href="http://www.consilium.europa.eu" target="_blank">
                     <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1">
@@ -975,17 +982,45 @@
                     </svg>
                     <span class="t-x">Council of the European Union</span>
                 </a>
-                
+                <div class="table-responsive mt-2">
+                    <table class="table table-striped table-bordered">
+                        <thead>
+                        <tr>
+                            <th class="align-middle" scope="col">Council configuration</th>
+                            <th class="align-middle" scope="col">Meetings</th>
+                            <th class="align-middle" scope="col">Date</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <th class="align-middle" scope="row">
+                                <a href="http://www.consilium.europa.eu/en/council-eu/configurations/gac?lang=EN" target="_blank"
+                                   class="font-weight-normal">
+                                    <span>General Affairs</span>
+                                </a>
+                            </th>
+                            <td class="align-middle">
+                                <a href="https://www.consilium.europa.eu/en/meetings/calendar/?Category=meeting&amp;Page=1&amp;daterange=&amp;dateFrom=2025-03-18&amp;dateTo=2025-03-18" target="_blank"
+                                   class="font-weight-normal">
+                                    <span>4087</span>
+                                </a>
+                                
+                            </td>
+                            <td class="align-middle">18/03/2025</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
     </li>
 
 
                 
-    <li class="erpl_accordion-item" data-selected="false">
-        <button id="erpl_accordion-item3-title" type="button" class="erpl_accordion-item-title collapsed" data-toggle="collapse" data-target="#erpl_accordion-item3" aria-expanded="false" aria-controls="erpl_accordion-item3">
+    <li class="es_accordion-item" data-selected="false">
+        <button id="es_accordion-item3-title" type="button" class="es_accordion-item-title collapsed" data-toggle="collapse" data-target="#es_accordion-item3" aria-expanded="false" aria-controls="es_accordion-item3">
             <span class="t-x">European Commission</span>
-            <span class="erpl_accordion-item-icon es_icon-container text-primary">
+            <span class="es_accordion-item-icon es_icon-container text-primary">
             <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
                 <use xlink:href="#es_icon-more"></use>
             </svg>
@@ -994,7 +1029,7 @@
             </svg>
         </span>
         </button>
-        <div id="erpl_accordion-item3" class="collapse erpl_accordion-item-content a-i-none" aria-labelledby="erpl_accordion-item3-title">
+        <div id="es_accordion-item3" class="collapse es_accordion-item-content a-i-none" aria-labelledby="es_accordion-item3-title">
             <div>
                 <a href="http://ec.europa.eu/" target="_blank">
                     <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1">
@@ -1047,15 +1082,15 @@
 
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section3" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 class="erpl_title-h2 mb-2">Key events</h2>
+                <h2 class="es_title-h2 mb-2">Key events</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2024/0258(COD)&amp;section=KEY_EVENTS" target="_blank">
@@ -1321,9 +1356,138 @@
                             
                                 <a href="https://www.europarl.europa.eu/doceo/document/CRE-10-2025-03-10-TOC_EN.html" title="Go to the page" target="_blank">
                                     <svg aria-hidden="true" class="es_icon es_icon-comment-dots es_icon-24">
-                                        <use xlink:href="#es_icon-comment-dots"></use>
+                                        <use href="#es_icon-comment-dots"></use>
                                     </svg>
                                 </a>
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >11/03/2025</td>
+                        <td class="align-middle">Decision by Parliament, 1st reading</td>
+                        <td class="align-middle text-center">
+                            
+                                <a href="https://www.europarl.europa.eu/doceo/document/TA-10-2025-0022_EN.html" target="_blank">T10-0022/2025</a>
+                                
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            <a href="/oeil/en/document-summary?id=1806477" target="_blank">
+                                <button class="btn btn-success btn-sm" type="button">Summary</button>
+                            </a>
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >11/03/2025</td>
+                        <td class="align-middle">Results of vote in Parliament</td>
+                        <td class="align-middle text-center">
+                            
+
+                            
+
+                            
+                                <a href="https://www.europarl.europa.eu/doceo/document/PV-10-2025-03-11-VOT_EN.html?item=2"
+                                   title="Results of vote in Parliament" target="_blank">
+                                    <svg aria-hidden="true" class="es_icon es_icon-vote es_icon-24">
+                                        <use xlink:href="#es_icon-vote"></use>
+                                    </svg>
+                                </a>
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >18/03/2025</td>
+                        <td class="align-middle">Act adopted by Council after Parliament&#39;s 1st reading</td>
+                        <td class="align-middle text-center">
+                            
+                                
+                                <span></span>
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >18/03/2025</td>
+                        <td class="align-middle">Final act signed</td>
+                        <td class="align-middle text-center">
+                            
+                                
+                                <span></span>
+                                
+                            
+
+                            
+                                
+                            
+
+                            
+
+                            
+
+                        </td>
+                        <td class="align-middle">
+                            
+                        </td>
+                    
+                </tr>
+                <tr>
+                    
+                        <td class="align-middle" >21/03/2025</td>
+                        <td class="align-middle">Final act published in Official Journal</td>
+                        <td class="align-middle text-center">
+                            
+
+                            
+                                
+                                    
+                                    <span></span>
+                                    
+
+                                
+                            
+
+                            
+
                             
 
                         </td>
@@ -1353,15 +1517,15 @@
 
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section5" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 class="erpl_title-h2 mb-2">Technical information</h2>
+                <h2 class="es_title-h2 mb-2">Technical information</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2024/0258(COD)&amp;section=TECHNICAL_INFORMATION">
@@ -1379,8 +1543,6 @@
 
         <div class="table-responsive">
             <table class="table table-striped table-bordered">
-                <thead>
-                </thead>
                 <tbody>
                 <tr>
                     <th class="align-middle" scope="row">Procedure reference</th>
@@ -1399,12 +1561,19 @@
                     <td class="align-middle">Regulation</td>
                 </tr>
                 
-                
+                <tr>
+                    <th class="align-middle" scope="row">Legal basis</th>
+                    <td class="align-middle">
+                        
+                            <span class="d-block">Rules of Procedure EP 59  </span>
+                        
+                    </td>
+                </tr>
                 
                 
                 <tr>
                     <th class="align-middle" scope="row">Stage reached in procedure</th>
-                    <td class="align-middle">Awaiting Council&#39;s 1st reading position</td>
+                    <td class="align-middle">Procedure completed</td>
                 </tr>
                 <tr>
                     <th class="align-middle" scope="row">Committee dossier</th>
@@ -1427,15 +1596,15 @@
 
 
 
-<div class="erpl_product-section">
+<div class="es_product-section">
     <div class="separator border-dark my-3"></div>
     <div id="section6" class="erpl-product-content oeil-spy-section mb-2">
         <div class="row">
             <div class="col-12 col-lg">
-                <h2 id="gateway" class="erpl_title-h2 mb-2">Documentation gateway</h2>
+                <h2 id="gateway" class="es_title-h2 mb-2">Documentation gateway</h2>
             </div>
             <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
+                <div class="es_links-list text-lg-right my-1">
                     <ul>
                         <li>
                             <a href="/oeil/en/procedure-file/pdf?reference=2024/0258(COD)&amp;section=DOCUMENTATION_GATEWAY" target="_blank">
@@ -1450,19 +1619,19 @@
                 </div>
             </div>
         </div>
-        <div class="erpl_accordion mb-5" id="erplAccordionDocGateway">
+        <div class="es_accordion mb-5" id="erplAccordionDocGateway">
             <ul class="a-i">
                 
-                    <li class="erpl_accordion-item" data-selected="false">
+                    <li class="es_accordion-item" data-selected="false">
     <button
-            id="erpl_accordion-item-doc-gateway-EP-title"
+            id="es_accordion-item-doc-gateway-EP-title"
             type="button"
-            class="erpl_accordion-item-title collapsed"
+            class="es_accordion-item-title collapsed"
             data-toggle="collapse"
-            aria-expanded="true" data-target="#erpl_accordion-item-doc-gateway-EP" aria-controls="erpl_accordion-item-doc-gateway-EP"
+            aria-expanded="true" data-target="#es_accordion-item-doc-gateway-EP" aria-controls="es_accordion-item-doc-gateway-EP"
     >
         <span class="t-x">European Parliament</span>
-        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+        <span class="es_accordion-item-icon es_icon-container text-primary">
             <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
                 <use xlink:href="#es_icon-more"></use>
             </svg>
@@ -1471,8 +1640,7 @@
             </svg>
         </span>
     </button>
-    <div id="erpl_accordion-item-doc-gateway-EP" class="collapse erpl_accordion-item-content a-i-none collapse show" aria-labelledby="erpl_accordion-item-doc-gateway-EP-title">
-        <div>
+    <div id="es_accordion-item-doc-gateway-EP" class="collapse es_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="es_accordion-item-doc-gateway-EP-title">
             <div class="table-responsive">
                 <table class="table table-striped table-bordered">
                     <thead>
@@ -1523,54 +1691,6 @@
                             
                         </td>
                         <td class="align-middle w-25">
-                            <a href="https://www.europarl.europa.eu/doceo/document/INTA-AM-766791_EN.html" target="_blank">PE766.791</a>
-                            
-                            
-
-                            
-                        </td>
-                        <td class="align-middle" >06/12/2024</td>
-
-                        <td class="align-middle">
-                            
-                        </td>
-                    </tr>
-                    <tr>
-
-                        
-
-                        <th class="align-middle" scope="row">
-                            <span class="font-weight-normal">Amendments tabled in committee</span>
-                        </th>
-
-                        <td class="align-middle">
-                            
-                        </td>
-                        <td class="align-middle w-25">
-                            <a href="https://www.europarl.europa.eu/doceo/document/CONT-AM-766858_EN.html" target="_blank">PE766.858</a>
-                            
-                            
-
-                            
-                        </td>
-                        <td class="align-middle" >18/12/2024</td>
-
-                        <td class="align-middle">
-                            
-                        </td>
-                    </tr>
-                    <tr>
-
-                        
-
-                        <th class="align-middle" scope="row">
-                            <span class="font-weight-normal">Amendments tabled in committee</span>
-                        </th>
-
-                        <td class="align-middle">
-                            
-                        </td>
-                        <td class="align-middle w-25">
                             <a href="https://www.europarl.europa.eu/doceo/document/CJ15-AM-766941_EN.html" target="_blank">PE766.941</a>
                             
                             
@@ -1592,7 +1712,9 @@
                         </th>
 
                         <td class="align-middle">
-                            <span class="erpl_badge erpl_badge-committee mr-25">INTA</span>
+                            <span class="es_badge es_badge-committee mr-25"
+                               title="International Trade
+">INTA</span>
                         </td>
                         <td class="align-middle w-25">
                             <a href="https://www.europarl.europa.eu/doceo/document/INTA-AD-766713_EN.html" target="_blank">PE766.713</a>
@@ -1616,7 +1738,10 @@
                         </th>
 
                         <td class="align-middle">
-                            <span class="erpl_badge erpl_badge-committee mr-25">CONT</span>
+                            <span class="es_badge es_badge-committee mr-25"
+                               title="Budgetary Control
+
+">CONT</span>
                         </td>
                         <td class="align-middle w-25">
                             <a href="https://www.europarl.europa.eu/doceo/document/CONT-AD-766703_EN.html" target="_blank">PE766.703</a>
@@ -1702,26 +1827,27 @@
                         <td class="align-middle" >11/03/2025</td>
 
                         <td class="align-middle">
-                            
+                            <a href="/oeil/en/document-summary?id=1806477" target="_blank">
+                                <button class="btn btn-success btn-sm" type="button">Summary</button>
+                            </a>
                         </td>
                     </tr>
                     </tbody>
                 </table>
             </div>
-        </div>
     </div>
 </li>
                 
-                    <li class="erpl_accordion-item" data-selected="false">
+                    <li class="es_accordion-item" data-selected="false">
     <button
-            id="erpl_accordion-item-doc-gateway-CSL-title"
+            id="es_accordion-item-doc-gateway-CSL-title"
             type="button"
-            class="erpl_accordion-item-title collapsed"
+            class="es_accordion-item-title collapsed"
             data-toggle="collapse"
-            aria-expanded="true" data-target="#erpl_accordion-item-doc-gateway-CSL" aria-controls="erpl_accordion-item-doc-gateway-CSL"
+            aria-expanded="true" data-target="#es_accordion-item-doc-gateway-CSL" aria-controls="es_accordion-item-doc-gateway-CSL"
     >
         <span class="t-x">Council of the EU</span>
-        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+        <span class="es_accordion-item-icon es_icon-container text-primary">
             <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
                 <use xlink:href="#es_icon-more"></use>
             </svg>
@@ -1730,8 +1856,7 @@
             </svg>
         </span>
     </button>
-    <div id="erpl_accordion-item-doc-gateway-CSL" class="collapse erpl_accordion-item-content a-i-none collapse show" aria-labelledby="erpl_accordion-item-doc-gateway-CSL-title">
-        <div>
+    <div id="es_accordion-item-doc-gateway-CSL" class="collapse es_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="es_accordion-item-doc-gateway-CSL-title">
             <div class="table-responsive">
                 <table class="table table-striped table-bordered">
                     <thead>
@@ -1768,23 +1893,44 @@
                             
                         </td>
                     </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Draft final act</span>
+                        </th>
+
+                        
+                        <td class="align-middle w-25">
+                            
+                            <span>00001/2025/LEX</span>
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >18/03/2025</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
                     </tbody>
                 </table>
             </div>
-        </div>
     </div>
 </li>
                 
-                    <li class="erpl_accordion-item" data-selected="false">
+                    <li class="es_accordion-item" data-selected="false">
     <button
-            id="erpl_accordion-item-doc-gateway-EC-title"
+            id="es_accordion-item-doc-gateway-EC-title"
             type="button"
-            class="erpl_accordion-item-title collapsed"
+            class="es_accordion-item-title collapsed"
             data-toggle="collapse"
-            aria-expanded="true" data-target="#erpl_accordion-item-doc-gateway-EC" aria-controls="erpl_accordion-item-doc-gateway-EC"
+            aria-expanded="true" data-target="#es_accordion-item-doc-gateway-EC" aria-controls="es_accordion-item-doc-gateway-EC"
     >
         <span class="t-x">European Commission</span>
-        <span class="erpl_accordion-item-icon es_icon-container text-primary">
+        <span class="es_accordion-item-icon es_icon-container text-primary">
             <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
                 <use xlink:href="#es_icon-more"></use>
             </svg>
@@ -1793,8 +1939,7 @@
             </svg>
         </span>
     </button>
-    <div id="erpl_accordion-item-doc-gateway-EC" class="collapse erpl_accordion-item-content a-i-none collapse show" aria-labelledby="erpl_accordion-item-doc-gateway-EC-title">
-        <div>
+    <div id="es_accordion-item-doc-gateway-EC" class="collapse es_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="es_accordion-item-doc-gateway-EC-title">
             <div class="table-responsive">
                 <table class="table table-striped table-bordered">
                     <thead>
@@ -1835,10 +1980,95 @@
                             </a>
                         </td>
                     </tr>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Commission response to text adopted in plenary</span>
+                        </th>
+
+                        
+                        <td class="align-middle w-25">
+                            <a href="https://data.europarl.europa.eu/distribution/doc/SP-2025-04-30-TA-10-2025-0022_en.docx" target="_blank">SP(2025)04</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >30/04/2025</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
                     </tbody>
                 </table>
             </div>
-        </div>
+    </div>
+</li>
+                
+                    <li class="es_accordion-item" data-selected="false">
+    <button
+            id="es_accordion-item-doc-gateway-NP-title"
+            type="button"
+            class="es_accordion-item-title collapsed"
+            data-toggle="collapse"
+            aria-expanded="true" data-target="#es_accordion-item-doc-gateway-NP" aria-controls="es_accordion-item-doc-gateway-NP"
+    >
+        <span class="t-x">National parliaments</span>
+        <span class="es_accordion-item-icon es_icon-container text-primary">
+            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
+                <use xlink:href="#es_icon-more"></use>
+            </svg>
+            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
+                <use xlink:href="#es_icon-less"></use>
+            </svg>
+        </span>
+    </button>
+    <div id="es_accordion-item-doc-gateway-NP" class="collapse es_accordion-item-content a-i-none collapse show" role="region" aria-labelledby="es_accordion-item-doc-gateway-NP-title">
+            <div class="table-responsive">
+                <table class="table table-striped table-bordered">
+                    <thead>
+                    <tr>
+                        
+
+                        <th class="align-middle" scope="col">Document type</th>
+                        <th class="align-middle" scope="col">Parliament/Chamber</th>
+                        <th class="align-middle w-25" scope="col">Reference</th>
+                        <th class="align-middle" scope="col">Date</th>
+                        <th class="align-middle" scope="col">Summary</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+
+                        
+
+                        <th class="align-middle" scope="row">
+                            <span class="font-weight-normal">Contribution</span>
+                        </th>
+
+                        <td class="align-middle">
+                            <span class="es_badge es_badge-committee mr-25"
+                               title="Spanish Parliament (Cortes Generales)">ES_PARLIAMENT</span>
+                        </td>
+                        <td class="align-middle w-25">
+                            <a href="https://connectfolx.europarl.europa.eu/connefof/app/exp/COM(2024)0469" target="_blank">COM(2024)0469</a>
+                            
+                            
+
+                            
+                        </td>
+                        <td class="align-middle" >18/02/2025</td>
+
+                        <td class="align-middle">
+                            
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
     </div>
 </li>
                 
@@ -1857,229 +2087,7 @@
 
                                 
                                 
-<div class="erpl_product-section">
-    <div id="section8" class="separator border-dark my-3"></div>
-    <div class="erpl-product-content mb-2">
-        <div class="row">
-            <div class="col-12 col-lg"><h2 class="erpl_title-h2 mb-2">Transparency</h2>
-            </div>
-            <div class="col-12 col-lg-4">
-                <div class="erpl_links-list text-lg-right my-1">
-                    <ul>
-                        <li>
-                            <a href="/oeil/en/procedure-file/pdf?reference=2024/0258(COD)&amp;section=TRANSPARENCY">
-                                <svg class="es_icon es_icon-pdf mr-1">
-                                    <title>pdf</title>
-                                    <use xlink:href="#es_icon-pdf"></use>
-                                </svg>
-                                <span class="t-x">Transparency</span>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-        </div>
 
-        <p>Meetings with interest representatives published in line with the Rules of Procedure</p>
-        <div class="erpl_accordion mb-5" id="erplAccordionTransparency">
-            <ul class="a-i">
-                <li class="erpl_accordion-item" data-selected="false">
-                    <button id="meetingGroup0-content-title"
-                            type="button"
-                            class="erpl_accordion-item-title collapsed"
-                            data-toggle="collapse"
-                            aria-expanded="false"
-                            data-target="#meetingGroup0-content"
-                            aria-controls="meetingGroup0-content">
-                        <span class="t-x">Rapporteurs, Shadow Rapporteurs and Committee Chairs</span>
-                        <span class="erpl_accordion-item-icon es_icon-container text-primary">
-                            <svg aria-hidden="true" class="es_icon es_icon-more" data-show-expanded="false">
-                                <use xlink:href="#es_icon-more"></use>
-                            </svg>
-                            <svg aria-hidden="true" class="es_icon es_icon-less" data-show-expanded="true">
-                                <use xlink:href="#es_icon-less"></use>
-                            </svg>
-                        </span>
-                    </button>
-                    <div id="meetingGroup0-content"
-                         class="collapse erpl_accordion-item-content a-i-none"
-                         aria-labelledby="meetingGroup0-content-title">
-                        <div class="oeil-meetings-list-container">
-                            <div class="table-responsive">
-                                <table class="table table-striped table-bordered">
-                                    <thead>
-                                    <tr>
-                                        <th class="align-middle" scope="col">Name</th>
-                                        <th class="align-middle" scope="col">Role</th>
-                                        <th class="align-middle" scope="col">Committee</th>
-                                        <th class="align-middle" scope="col">Date</th>
-                                        <th class="align-middle" scope="col">Interest representatives</th>
-                                    </tr>
-                                    </thead>
-                                    <tbody>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/197655"
-                                               class="font-weight-normal">TERHEŞ Cristian</a>
-                                        </th>
-                                        <td class="align-middle">Shadow rapporteur</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/AFET"
-                                               title="Committee on Foreign Affairs">AFET</a>
-                                        </td>
-                                        <td class="align-middle">24/01/2025</td>
-                                        <td class="align-middle">
-                                            
-                                                Mission of the Republic of Moldova to the European Union
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/197497"
-                                               class="font-weight-normal">MIKSER Sven</a>
-                                        </th>
-                                        <td class="align-middle">Rapporteur</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/AFET"
-                                               title="Committee on Foreign Affairs">AFET</a>
-                                        </td>
-                                        <td class="align-middle">12/12/2024</td>
-                                        <td class="align-middle">
-                                            
-                                                Ms Daniela Morari, Ambassador of the Republic of Moldova to the European Union
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/197655"
-                                               class="font-weight-normal">TERHEŞ Cristian</a>
-                                        </th>
-                                        <td class="align-middle">Shadow rapporteur</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/AFET"
-                                               title="Committee on Foreign Affairs">AFET</a>
-                                        </td>
-                                        <td class="align-middle">05/12/2024</td>
-                                        <td class="align-middle">
-                                            
-                                                Mission of the Republic of Moldova to the European Union
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/2268"
-                                               class="font-weight-normal">SJÖSTEDT Jonas</a>
-                                        </th>
-                                        <td class="align-middle">Rapporteur for opinion</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/CONT"
-                                               title="Committee on Budgetary Control">CONT</a>
-                                        </td>
-                                        <td class="align-middle">03/12/2024</td>
-                                        <td class="align-middle">
-                                            
-                                                ECA
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/2268"
-                                               class="font-weight-normal">SJÖSTEDT Jonas</a>
-                                        </th>
-                                        <td class="align-middle">Rapporteur for opinion</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/CONT"
-                                               title="Committee on Budgetary Control">CONT</a>
-                                        </td>
-                                        <td class="align-middle">29/11/2024</td>
-                                        <td class="align-middle">
-                                            
-                                                Moldova Ministry for Economic Development and Digitalization
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/2268"
-                                               class="font-weight-normal">SJÖSTEDT Jonas</a>
-                                        </th>
-                                        <td class="align-middle">Rapporteur for opinion</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/CONT"
-                                               title="Committee on Budgetary Control">CONT</a>
-                                        </td>
-                                        <td class="align-middle">29/11/2024</td>
-                                        <td class="align-middle">
-                                            
-                                                Swedish Emabssy
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/2268"
-                                               class="font-weight-normal">SJÖSTEDT Jonas</a>
-                                        </th>
-                                        <td class="align-middle">Rapporteur for opinion</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/CONT"
-                                               title="Committee on Budgetary Control">CONT</a>
-                                        </td>
-                                        <td class="align-middle">29/11/2024</td>
-                                        <td class="align-middle">
-                                            
-                                                EUDEL Chisinau
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th class="align-middle" scope="row">
-                                            <a href="https://www.europarl.europa.eu/meps/en/197497"
-                                               class="font-weight-normal">MIKSER Sven</a>
-                                        </th>
-                                        <td class="align-middle">Rapporteur</td>
-                                        <td class="align-middle">
-                                            <a class="erpl_badge erpl_badge-committee mr-25"
-                                               href="https://www.europarl.europa.eu/committes/en/AFET"
-                                               title="Committee on Foreign Affairs">AFET</a>
-                                        </td>
-                                        <td class="align-middle">20/11/2024</td>
-                                        <td class="align-middle">
-                                            
-                                                Deputy Prime Minister, Minister of Economic Development and Digitalization, Mr. Dumitru Alaiba,
-                                                
-                                            
-                                        </td>
-                                    </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                            
-                        </div>
-                    </div>
-                </li>
-            </ul>
-        </div>
-    </div>
-</div>
 
                                 
                                 <html lang="en">
@@ -2088,7 +2096,67 @@
 
 
 
+<div class="es_product-section">
+    <div class="separator border-dark my-3"></div>
+    <div id="section9" class="erpl-product-content oeil-spy-section mb-2">
+        <div class="row">
+            <div class="col-12 col-lg">
+                <h2 class="es_title-h2 mb-2">Final act</h2>
+            </div>
+            <div class="col-12 col-lg-4">
+                <div class="es_links-list text-lg-right my-1">
+                    <ul>
+                        <li>
+                            <a href="/oeil/en/procedure-file/pdf?reference=2024/0258(COD)&amp;section=FINAL_ACT" target="_blank">
+                                <svg class="es_icon es_icon-pdf mr-1">
+                                    <title>pdf</title>
+                                    <use xlink:href="#es_icon-pdf"></use>
+                                </svg>
+                                <span class="t-x">Final act</span>
+                            </a>
+                        </li>
+                    </ul>
 
+                </div>
+            </div>
+        </div>
+
+        <div class="es_links-list">
+            <ul>
+                <li class="d-flex justify-content-between">
+                    <p>
+                        
+    <a href="https://eur-lex.europa.eu/smartapi/cgi/sga_doc?smartapi!celexplus!prod!CELEXnumdoc&amp;lg=EN&amp;numdoc=32025R0535" target="_blank">
+        <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1">
+            <use xlink:href="#es_icon-arrow"></use>
+        </svg>
+        <span class="t-x">Regulation 2025/0535</span>
+    </a>
+    
+
+
+                        
+                            <br/>
+                            
+    <a href="https://eur-lex.europa.eu/oj/daily-view/L-series/default.html?&amp;ojDate=21032025" target="_blank">
+        <svg aria-hidden="true" class="es_icon es_icon-arrow es_icon-rotate-270 mr-1">
+            <use xlink:href="#es_icon-arrow"></use>
+        </svg>
+        <span class="t-x">OJ OJ L 21.03.2025</span>
+    </a>
+    
+
+                        
+                    </p>
+
+                    <a href="/oeil/en/document-summary?id=1808028" target="_blank">
+                        <button class="btn btn-success btn-sm" type="button">Summary</button>
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </div>
+</div>
 </html>
 
                                 
@@ -2117,7 +2185,7 @@
 
 
 
-<div class="card erpl_move"
+<div class="card es_move"
      data-move-lg="#sectionsNavPositionRwd"
      data-move-md="#sectionsNavPositionRwd"
      data-move-sm="#sectionsNavPositionRwd"
@@ -2125,47 +2193,47 @@
      data-move-xs="#sectionsNavPositionRwd"
      data-move-xxl="#sectionsNavPositionInitial">
     <div class="card-body py-0">
-        <nav class="erpl_side-navigation">
-            <h3 class="erpl_title-h3 mb-0 py-2">
+        <nav class="es_side-navigation">
+            <h3 class="es_title-h3 mb-0 py-2">
                 <a class="text-primary" href="#">
                     <span class="t-x">Procedure file</span>
                 </a>
             </h3>
-            <div class="erpl_links-list erpl_links-list-nav">
+            <div class="es_links-list es_links-list-nav">
                 <ul>
                     <li data-selected="true">
-                        <a class="erpl_smooth-scroll" href="#section1">
+                        <a class="es_smooth-scroll" href="#section1">
                             <span class="t-x">Basic information</span>
                         </a>
                     </li>
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section2">
+                        <a class="es_smooth-scroll" href="#section2">
                             <span class="t-x">Key players</span>
                         </a>
                     </li>
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section3">
+                        <a class="es_smooth-scroll" href="#section3">
                             <span class="t-x">Key events</span>
                         </a>
                     </li>
                     
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section5">
+                        <a class="es_smooth-scroll" href="#section5">
                             <span class="t-x">Technical information</span>
                         </a>
                     </li>
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section6">
+                        <a class="es_smooth-scroll" href="#section6">
                             <span class="t-x">Documentation gateway</span>
                         </a>
                     </li>
                     
+                    
                     <li data-selected="false">
-                        <a class="erpl_smooth-scroll" href="#section8">
-                            <span class="t-x">Transparency</span>
+                        <a class="es_smooth-scroll" href="#section9">
+                            <span class="t-x">Final act</span>
                         </a>
                     </li>
-                    
                     
                 </ul>
             </div>
@@ -2187,14 +2255,14 @@
     </button>
 
     
-    <footer class="erpl_footer">
-    <div class="erpl_footer-top mt-8">
+    <footer class="es_footer">
+    <div class="es_footer-top mt-8">
         <div class="container">
-            <div class="erpl_footer-top-content border-top-lg border-secondary text-center d-md-flex justify-content-between pt-md-3 mb-5 a-i">
-                <nav id="share-links" class="erpl_share-links" aria-label="Share links">
-                    <div class="d-md-flex">
-                        <h2 class="erpl_title-h5 mb-2 mb-md-0"><span class="mr-md-1">Share this page</span></h2>
-                        <ul class="erpl_share-links-list d-flex justify-content-center mb-3 mb-md-0">
+            <div class="es_footer-top-content border-top-lg border-secondary text-center d-md-flex justify-content-between pt-md-3 mb-5 a-i">
+                <nav id="share-links" class="es_footer-share-links" aria-label="Share links">
+                    <div class="d-md-flex align-items-center">
+                        <h2 class="es_title-h5 mb-2 mb-md-0"><span class="mr-md-1">Share this page</span></h2>
+                        <ul class="es_social-share-horizontal d-flex justify-content-center align-items-center mb-3 mb-md-0 pl-0">
                             <li class="mr-1">
                                 <a title="Share this page on Facebook" href="https://www.facebook.com/share.php?u=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2024/0258(COD)" target="_blank">
                                     <span class="sr-only">Facebook</span>
@@ -2204,10 +2272,10 @@
                                 </a>
                             </li>
                             <li class="mr-1">
-                                <a title="Share this page on Twitter" href="https://twitter.com/intent/tweet?url=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2024/0258(COD)&amp;text=Procedure%20File:%202024/0258(COD)&amp;via=Europarl_EN" target="_blank">
-                                    <span class="sr-only">Twitter</span>
-                                    <svg aria-hidden="true" class="es_icon es_icon-twitter">
-                                        <use xlink:href="#es_icon-twitter"></use>
+                                <a title="Share this page on X" href="https://x.com/intent/post?url=https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference%3D2024/0258(COD)&amp;text=Procedure%20File:%202024/0258(COD)&amp;via=Europarl_EN" target="_blank">
+                                    <span class="sr-only">X</span>
+                                    <svg aria-hidden="true" class="es_icon es_icon-twitter-x">
+                                        <use xlink:href="#es_icon-twitter-x"></use>
                                     </svg>
                                 </a>
                             </li>
@@ -2230,7 +2298,7 @@
                         </ul>
                     </div>
                 </nav>
-                <nav class="erpl_horizontal-links" aria-label="data protection link">
+                <nav class="es_horizontal-links" aria-label="data protection link">
                     <div>
                         <a href="https://oeil.secure.europarl.europa.eu/oeil/en/external-documents/download?id=2" target="_blank">
                             <span class="t-y">Data Protection Notice</span>
@@ -2240,11 +2308,11 @@
             </div>
         </div>
     </div>
-    <div class="erpl_footer-bottom bg-black-footer pt-3 pb-3">
+    <div class="es_footer-bottom bg-black-footer pt-3 pb-3">
         <div class="container">
             <div class="row" id="footerLinks">
                 <nav class="col-12 col-xl-9 text-center text-md-left" id="website-links" aria-label="Website links">
-    <h3 class="erpl_title-h3 mb-2 text-white">Legislative Observatory</h3>
+    <h3 class="es_title-h3 mb-2 text-white">Legislative Observatory</h3>
     <div class="collapse show" id="website-links-items">
         <div class="row">
             <div class="col-12 col-md-6 col-xl-4">
@@ -2334,7 +2402,7 @@
 
     <div class="d-block d-md-none">
         <div class="footerLinkToggle separator separator-dotted separator-2x mb-5 mt-5 collapsed">
-            <a class="erpl_toggle-menu" href="#website-links"
+            <a class="es_toggle-menu" href="#website-links"
                title="Toggle linked links"
                role="button"
                data-toggle="collapse"
@@ -2349,7 +2417,7 @@
                     <use xlink:href="#es_icon-minus"></use>
                 </svg>
             </a>
-            <a class="erpl_nojs-close-menu" href="#website-links-close"
+            <a class="es_nojs-close-menu" href="#website-links-close"
                title="Untoggle linked links"
                role="button"
                data-toggle="collapse"
@@ -2365,7 +2433,7 @@
 </nav>
                 <nav class="col-12 col-xl-3 text-center text-md-left" id="europarl-links" aria-label="Europarl links">
     <div class="separator separator-dotted separator-2x mt-3 mb-4 d-none d-md-flex d-xl-none"></div>
-    <h3 class="erpl_title-h3 mb-2 text-white">European Parliament</h3>
+    <h3 class="es_title-h3 mb-2 text-white">European Parliament</h3>
     <div class="collapse show" id="europarl-links-items">
         <nav class="link-group pt-25 t-x-mode" aria-label="European Parliament">
             <a href="https://www.europarl.europa.eu/news/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - News">
@@ -2375,8 +2443,8 @@
                 <span>About Parliament</span></a><a href="https://www.europarl.europa.eu/plenary/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Plenary">
                 <span>Plenary</span></a><a href="https://www.europarl.europa.eu/committees/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Committees">
                 <span>Committees</span></a><a href="https://www.europarl.europa.eu/delegations/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - Delegations">
-                <span>Delegations</span></a><a href="https://elections.europa.eu/en/" class="link-group-item mb-1 d-block" aria-label="European Parliament - Elections">
-                <span>Elections</span></a>
+                <span>Delegations</span></a><a href="https://eubudget.europarl.europa.eu/en" class="link-group-item mb-1 d-block" aria-label="European Parliament - EU budget">
+                <span>EU budget</span></a>
         </nav>
     </div>
     <div class="d-block d-md-none">
@@ -2396,7 +2464,7 @@
                     <use xlink:href="#es_icon-minus"></use>
                 </svg>
             </a>
-            <a class="erpl_nojs-close-menu" href="#europarl-links-close"
+            <a class="es_nojs-close-menu" href="#europarl-links-close"
                title="Untoggle European Parliament websites"
                role="button" data-toggle="collapse"
                data-target="#europarl-links-items"
@@ -2414,67 +2482,68 @@
 
             <div class="separator separator-dotted separator-2x mt-3 mb-3 d-none d-md-flex"></div>
             <div class="row">
-                <nav class="col-12" id="social-links" aria-label="Social links">
-                    <div class="erpl_social-links mb-2">
+                <nav class="col-12 d-flex justify-content-center" id="social-links" aria-label="Social links">
+                    <div class="es_footer-social-links mb-2">
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Facebook" href="https://www.facebook.com/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-facebook-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Facebook" href="https://www.facebook.com/europeanparliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-facebook-color">
                                     <use href="#es_icon-facebook-color"></use>
                                 </svg>
                                 <span class="sr-only">Facebook</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Twitter" href="https://twitter.com/Europarl_en" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-twitter-color">
-                                    <use href="#es_icon-twitter-color"></use>
+                            <a  data-toggle="tooltip" title="Check out Parliament on X" href="https://x.com/Europarl_en" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-twitter-x">
+                                    <use href="#es_icon-twitter-x"></use>
                                 </svg>
                                 <span class="sr-only">Twitter</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Flickr" href="https://www.flickr.com/photos/european_parliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-flickr-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Flickr" href="https://www.flickr.com/photos/european_parliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-flickr-color">
                                     <use href="#es_icon-flickr-color"></use>
                                 </svg>
                                 <span class="sr-only">Flickr</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on LinkedIn" href="https://www.linkedin.com/company/european-parliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-linkedin-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on LinkedIn" href="https://www.linkedin.com/company/european-parliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-linkedin-color">
                                     <use href="#es_icon-linkedin-color"></use>
                                 </svg>
                                 <span class="sr-only">LinkedIn</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on YouTube" href="https://www.youtube.com/user/EuropeanParliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-youtube-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on YouTube" href="https://www.youtube.com/user/EuropeanParliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-youtube-color">
                                     <use href="#es_icon-youtube-color"></use>
                                 </svg>
                                 <span class="sr-only">YouTube</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Instagram" href="https://www.instagram.com/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-instagram-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Instagram" href="https://www.instagram.com/europeanparliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-instagram-color">
                                     <use href="#es_icon-instagram-color"></use>
                                 </svg>
                                 <span class="sr-only">Instagram</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Pinterest" href="https://www.pinterest.fr/epinfographics" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-pinterest-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Pinterest" href="https://www.pinterest.fr/epinfographics" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-pinterest-color">
                                     <use href="#es_icon-pinterest-color"></use>
                                 </svg>
                                 <span class="sr-only">Pinterest</span>
                             </a>
                         
-                            <a data-toggle="tooltip" title="Check out Parliament on Snapchat" href="https://www.snapchat.com/add/europarl" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-snapchat-color">
-                                    <use href="#es_icon-snapchat-color"></use>
-                                </svg>
-                                <span class="sr-only">Snapchat</span>
-                            </a>
-                        
-                            <a data-toggle="tooltip" title="Check out Parliament on Reddit" href="https://www.reddit.com/r/europeanparliament" target="_blank" class="mr-1 ml-1 mb-2">
-                                <svg aria-hidden="true" class="es_icon es_icon-reddit-color">
+                            <a  data-toggle="tooltip" title="Check out Parliament on Reddit" href="https://www.reddit.com/r/europeanparliament" target="_blank" style="color:black" class="mr-1 ml-1 mb-2">
+                                <svg aria-hidden="true"
+                                     class="es_icon es_icon-reddit-color">
                                     <use href="#es_icon-reddit-color"></use>
                                 </svg>
                                 <span class="sr-only">Reddit</span>
@@ -2511,12 +2580,9 @@
         </div>
     </div>
 </footer>
-
     
-    <script src="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/lib/jquery/jquery.min.js"></script>
-    
-    <script id="evostrap" src="https://www.europarl.europa.eu/commonFrontResources/evostrap/6.2.0//lib/dist/js/evostrap.js"></script>
-    <script src="https://www.europarl.europa.eu/commonFrontResources/evostrap-oeil/1.0.0//dist/js/oeil.js"></script>
+    <script id="evostrap" type="module" src="https://evokits.europarl.europa.eu/evostrap/7.0.0/lib/dist/js/evostrap.js"></script>
+    <script src="https://evokits.europarl.europa.eu/evostrap-oeil/1.0.1/dist/js/oeil.js"></script>
 
     
     <script src="/oeil/oeil-addons/documents-loading.js"></script>


### PR DESCRIPTION
The EP website updated the prefix from `erpl_` to `es_` ~everywhere~ in many places