### PR TITLE
Simulate redirects in tests

### DIFF
--- a/backend/tests/scrapers/test_votes.py
+++ b/backend/tests/scrapers/test_votes.py
@@ -459,6 +459,13 @@ def test_procedure_scraper(responses):
 def test_procedure_scraper_fallback_document_reference(responses):
     responses.get(
         "https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=A9-0335/2023",
+        status=301,
+        headers={
+            "Location": "https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2023/2019(INI)"
+        },
+    )
+    responses.get(
+        "https://oeil.secure.europarl.europa.eu/oeil/en/procedure-file?reference=2023/2019(INI)",
         body=load_fixture("scrapers/data/votes/oeil-procedure-file_2023-2019-ini.html"),
     )
 


### PR DESCRIPTION
This is a follow-up to c14405a0, which broke the test case if request mocks were enabled.