### PR TITLE
Add new MEP role

### DIFF
--- a/backend/howtheyvote/scrapers/members.py
+++ b/backend/howtheyvote/scrapers/members.py
@@ -200,6 +200,7 @@ class MemberGroupsScraper(BeautifulSoupScraper):
             "Co-treasurer",
             "Member",
             "First Vice-Chair/Member of the Bureau",
+            "Treasurer/Vice-Chair/Member of the Bureau",
         ]
 
         for pos in positions:


### PR DESCRIPTION
"Treasurer/Vice-Chair/Member of the Bureau" found here: https://www.europarl.europa.eu/meps/en/197573/NAME/history/10

We should re-run the members pipeline after this has been merged and deployed.