### PR TITLE
:rotating_light:  Load correct csv data when creating datawrapper embedding

### DIFF
--- a/frontend/src/components/DatawrapperLink.tsx
+++ b/frontend/src/components/DatawrapperLink.tsx
@@ -97,7 +97,7 @@ function getPresetConfig(
   config.last_edit_step = "2";
 
   // Load CSV data from our website
-  config.external_data = "https://howtheyvote.eu/api/votes/178149.csv";
+  config.external_data = `https://howtheyvote.eu/api/votes/${voteId}.csv`;
 
   // For some reason, Datawrapper requires that `data` is set even if `external_data` is
   // provided. Has to be a valid JSON string.


### PR DESCRIPTION
Another instance of my review failing spectacularly. The CSV file that was embedded was hard coded which resulted in the same list being embedded for all votes.
I will merge and deploy this directly, as this is quite unfortunate :D