### PR TITLE
Introduce whitespace when removing nested tags from summaries

### DIFF
--- a/backend/howtheyvote/scrapers/votes.py
+++ b/backend/howtheyvote/scrapers/votes.py
@@ -1004,7 +1004,7 @@ class OEILSummaryScraper(BeautifulSoupScraper):
         )
 
     def _normalize_paragraph(self, paragraph: Tag) -> str:
-        text = html.escape(paragraph.get_text(strip=True).replace("\n", " "))
+        text = html.escape(paragraph.get_text(strip=True, separator=" ").replace("\n", " "))
         style = paragraph.get("style")
 
         # Headings aren't marked up using appropriate HTML tags.


### PR DESCRIPTION
Closes #1354.
I checked the behavior exemplary with https://howtheyvote.eu/votes/182460.

```
(Pdb) html.escape(paragraph.get_text(strip=True).replace("\n", " "))
'The European Parliament adopted by 431 votes to 161, with 70 abstentions,amendmentson the proposal for a regulation of the European Parliament and of the Council implementing the bilateral safeguard clause of the EU-Mercosur Partnership Agreement and the EU-Mercosur Interim Trade Agreement for agricultural products.'
(Pdb) html.escape(paragraph.get_text(strip=True, separator=' ').replace("\n", " "))
'The European Parliament adopted by 431 votes to 161, with 70 abstentions, amendments on the proposal for a regulation of the European Parliament and of the Council implementing the bilateral safeguard clause of the EU-Mercosur Partnership Agreement and the EU-Mercosur Interim Trade Agreement for agricultural products.'
```