### PR TITLE
Datawrapper Embeds for Groups and Countries

### DIFF
--- a/frontend/src/client.entry.ts
+++ b/frontend/src/client.entry.ts
@@ -1,6 +1,6 @@
 import Banner from "./components/Banner";
 import CountryStatsList from "./components/CountryStatsList";
-import DatawrapperLink from "./components/DatawrapperLink";
+import DatawrapperLink from "./components/DatawrapperLinkList";
 import Eyes from "./components/Eyes";
 import GroupStatsList from "./components/GroupStatsList";
 import MemberVotesList from "./components/MemberVotesList";

--- a/frontend/src/components/DatawrapperLinkList.tsx
+++ b/frontend/src/components/DatawrapperLinkList.tsx
@@ -1,10 +1,9 @@
 import type { ComponentChildren } from "preact";
 import type { MouseEventHandler } from "preact/compat";
 import type { Vote, VotePositionCounts } from "../api";
-import List from "../components/List";
-import ListItem from "../components/ListItem";
 import { formatDate } from "../lib/dates";
-import { Island } from "../lib/islands";
+import List from "./List";
+import ListItem from "./ListItem";
 
 type EmbedType = "members" | "groups" | "countries";
 
@@ -74,55 +73,49 @@ function DataWrapperLinkList({ vote }: { vote: Vote }) {
     <List space="xxs">
       <ListItem
         title={
-          <Island>
-            <DatawrapperLink
-              type="members"
-              voteId={vote.id}
-              title={vote.display_title || vote.id.toString()}
-              timestamp={vote.timestamp}
-              reference={vote.reference}
-              description={vote.description}
-              stats={vote.stats.total}
-            >
-              Individual votes
-            </DatawrapperLink>
-          </Island>
+          <DatawrapperLink
+            type="members"
+            voteId={vote.id}
+            title={vote.display_title || vote.id.toString()}
+            timestamp={vote.timestamp}
+            reference={vote.reference}
+            description={vote.description}
+            stats={vote.stats.total}
+          >
+            Individual votes
+          </DatawrapperLink>
         }
         subtitle={"A searchable table showing how each individual MEP voted."}
       />
       <ListItem
         title={
-          <Island>
-            <DatawrapperLink
-              type="groups"
-              voteId={vote.id}
-              title={vote.display_title || vote.id.toString()}
-              timestamp={vote.timestamp}
-              reference={vote.reference}
-              description={vote.description}
-              stats={vote.stats.total}
-            >
-              Votes by groups
-            </DatawrapperLink>
-          </Island>
+          <DatawrapperLink
+            type="groups"
+            voteId={vote.id}
+            title={vote.display_title || vote.id.toString()}
+            timestamp={vote.timestamp}
+            reference={vote.reference}
+            description={vote.description}
+            stats={vote.stats.total}
+          >
+            Votes by groups
+          </DatawrapperLink>
         }
         subtitle={"A bar chart showing how MEPs of each political group voted."}
       />
       <ListItem
         title={
-          <Island>
-            <DatawrapperLink
-              type="countries"
-              voteId={vote.id}
-              title={vote.display_title || vote.id.toString()}
-              timestamp={vote.timestamp}
-              reference={vote.reference}
-              description={vote.description}
-              stats={vote.stats.total}
-            >
-              Votes by countries
-            </DatawrapperLink>
-          </Island>
+          <DatawrapperLink
+            type="countries"
+            voteId={vote.id}
+            title={vote.display_title || vote.id.toString()}
+            timestamp={vote.timestamp}
+            reference={vote.reference}
+            description={vote.description}
+            stats={vote.stats.total}
+          >
+            Votes by countries
+          </DatawrapperLink>
         }
         subtitle={
           "A bar chart showing how MEPs from different countries voted."
@@ -353,5 +346,4 @@ function getPresetConfig(
   return config;
 }
 
-export default DatawrapperLink;
-export { DataWrapperLinkList };
+export default DataWrapperLinkList;

--- a/frontend/src/pages/VotePage.tsx
+++ b/frontend/src/pages/VotePage.tsx
@@ -3,7 +3,7 @@ import App from "../components/App";
 import BaseLayout from "../components/BaseLayout";
 import Callout from "../components/Callout";
 import CopyrightLink from "../components/CopyrightLink";
-import { DataWrapperLinkList } from "../components/DatawrapperLink";
+import DataWrapperLinkList from "../components/DatawrapperLinkList";
 import ExternalLinks from "../components/ExternalLinks";
 import Footer from "../components/Footer";
 import PageNav from "../components/PageNav";
@@ -149,7 +149,9 @@ export const VotePage: Page<Vote> = ({ data }) => {
                 Want to embed the results of this vote on your website? Use one
                 of our Datawrapper templates:
               </p>
-              <DataWrapperLinkList vote={data} />
+              <Island>
+                <DataWrapperLinkList vote={data} />
+              </Island>
             </Wrapper>
           </div>
           <div class="px">


### PR DESCRIPTION
## Groups

<img width="1271" height="829" alt="image" src="https://github.com/user-attachments/assets/7f45b9be-fe3f-436f-a7fe-4c531bd5a857" />

## Countries

<img width="1271" height="1705" alt="image" src="https://github.com/user-attachments/assets/a9aa8e99-dbac-4935-a5e8-3892c1f21357" />

## Embed Section

<img width="1422" height="557" alt="image" src="https://github.com/user-attachments/assets/ea340447-29f3-41ae-aee9-e51078048017" />

---

1. I personally would have preferred to have the country chart rotated as I find that easier to read than a very long list, but the stacked column chart works very different than the stacked bar chart and I did not find a way to rotate that one.
2. Having flags in the chart would have also been cool, but that required having emoji codes for the flags in the data. Maybe some other time...
3. The code for the `DataWrapperLinkList` is for sure not the cleanest solution to this. I would appreciate an opinion on what you say would be the best implementation.