### PR TITLE
Make links in lists underlined by default

### DIFF
--- a/frontend/src/components/ListItem.css
+++ b/frontend/src/components/ListItem.css
@@ -24,13 +24,3 @@
 .list-item__chart {
   margin: var(--space-xxs) 0;
 }
-
-.list-item a {
-  text-decoration: none;
-}
-
-.list-item a:hover,
-.list-item a:focus-visible {
-  text-decoration: underline;
-  text-underline-offset: 0.1em;
-}


### PR DESCRIPTION
Currently, the underline becomes visible only when hovering over a link. I think I originally implemented that to reduce visual clutter. However, it also obscures the fact that they are actually clickable links (e.g., the names of MEPs or the titles in the "More information" section), especially given that most other links are underlined by default.

The links in the page nav still don’t have underlines by default. I think because it’s a navigation bar, it’s much clearer from context that these are links, but I wouldn’t mind making them underlined by default as well if you prefer