### PR TITLE
Add link to feed in footer

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -39,6 +39,15 @@ export default function Footer({ style, copyright }: FooterProps) {
           </a>
         </li>
         <li>
+          <a
+            href="/api/votes/feed.xml"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            RSS
+          </a>
+        </li>
+        <li>
           <a href="/about#license">License</a>
         </li>
         <li>


### PR DESCRIPTION
Technically, it’s an Atom feed and not RSS, but I guess RSS is more commonly used?