### PR TITLE
Fix chrome crashes when generating share pics

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -22,7 +22,7 @@
         Content-Security-Policy "
             default-src 'self';
             style-src 'self' 'unsafe-inline';
-            image-src 'self' 'unsafe-inline';
+            img-src 'self' data:;
         "
         Referrer-Policy "same-origin"
         X-Content-Type-Options "nosniff"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,7 @@ services:
     image: "chromedp/headless-shell:145.0.7632.26"
     command:
       - "--disable-gpu"
+      - "--disable-software-rasterizer"
       - "--remote-allow-origins=*"
       - "--hide-scrollbars"
     networks:


### PR DESCRIPTION
I’m not 100% sure whether this will actually solve the crashes, but it will definitely remove a lot of noise from the Chromium logs, which should make it much easier to debug the issue if it persists.