### PR TITLE
Disable Chromium core dumps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,3 +105,7 @@ services:
       - "chromium"
     expose:
       - "9222"
+    ulimits:
+      core:
+        hard: 0
+        soft: 0


### PR DESCRIPTION
Chromium generates a core dump whenever it crashes. Every dump can be several hundred MB, consuming a lot of disk space.