### PR TITLE
Group votes based on session start date (instead of vote date)

### DIFF
--- a/backend/howtheyvote/analysis/votes.py
+++ b/backend/howtheyvote/analysis/votes.py
@@ -17,15 +17,15 @@ class VoteGroupsAnalyzer:
     session and title. The key can be used to retrieve other votes from the same group,
     e.g. in order to display a list of amendment votes for a given main vote."""
 
-    def __init__(self, date: datetime.date, votes: Iterable[Vote]):
-        self.date = date
+    def __init__(self, session_start_date: datetime.date, votes: Iterable[Vote]):
+        self.session_start_date = session_start_date
         self.votes = votes
 
     def run(self) -> Iterator[Fragment]:
         groups: dict[str, list[int]] = defaultdict(list)
 
         for vote in self.votes:
-            group_key = self._make_group_key(self.date, vote)
+            group_key = self._make_group_key(self.session_start_date, vote)
             if group_key:
                 groups[group_key].append(vote.id)
 
@@ -39,13 +39,13 @@ class VoteGroupsAnalyzer:
                     data={"group_key": group_key},
                 )
 
-    def _make_group_key(self, date: datetime.date, vote: Vote) -> str | None:
+    def _make_group_key(self, session_start_date: datetime.date, vote: Vote) -> str | None:
         title = vote.display_title
 
         if not title:
             return None
 
-        return make_key(date.isoformat(), title)
+        return make_key(session_start_date.isoformat(), title)
 
 
 class MainVoteAnalyzer:

--- a/backend/howtheyvote/api/votes_api.py
+++ b/backend/howtheyvote/api/votes_api.py
@@ -819,7 +819,7 @@ def _load_related(vote: Vote) -> Iterable[Vote]:
     if not vote.group_key:
         return []
 
-    stmt = select(Vote).where(Vote.group_key == vote.group_key).order_by(Vote.order)
+    stmt = select(Vote).where(Vote.group_key == vote.group_key).order_by(Vote.date, Vote.order)
 
     return Session.execute(stmt).scalars()
 

--- a/backend/howtheyvote/cli/temp.py
+++ b/backend/howtheyvote/cli/temp.py
@@ -275,7 +275,8 @@ def vote_groups() -> None:
             votes = Session.execute(
                 select(Vote).where(func.date(Vote.timestamp) == date)
             ).scalars()
-            writer.add(VoteGroupsAnalyzer(date, votes).run())
+            analyzer = VoteGroupsAnalyzer(session_start_date=session.start_date, votes=votes)
+            writer.add(analyzer.run())
             writer.flush()
 
 

--- a/backend/howtheyvote/pipelines/rcv_list.py
+++ b/backend/howtheyvote/pipelines/rcv_list.py
@@ -13,9 +13,9 @@ from ..analysis import (
 )
 from ..db import Session
 from ..helpers import frontend_url
-from ..models import Member, Vote
+from ..models import Member, PlenarySession, Vote
 from ..pushover import send_notification
-from ..query import member_active_at
+from ..query import member_active_at, session_is_current_at
 from ..scrapers import (
     DocumentScraper,
     EurlexDocumentScraper,
@@ -284,7 +284,13 @@ class RCVListPipeline(BasePipeline):
     def _analyze_vote_groups(self) -> None:
         log.info("Running vote groups analysis", date=self.date, term=self.term)
         writer = BulkWriter()
-        analyzer = VoteGroupsAnalyzer(date=self.date, votes=self._votes())
+        session = Session.execute(
+            select(PlenarySession).where(session_is_current_at(self.date))
+        ).scalar_one()
+        analyzer = VoteGroupsAnalyzer(
+            session_start_date=session.start_date,
+            votes=self._votes(),
+        )
         writer.add(analyzer.run())
         writer.flush()
 

--- a/backend/howtheyvote/pipelines/vot_list.py
+++ b/backend/howtheyvote/pipelines/vot_list.py
@@ -1,10 +1,13 @@
 import datetime
 from collections.abc import Iterator
 
+from sqlalchemy import select
 from structlog import get_logger
 
 from ..analysis import VoteGroupsAnalyzer
-from ..models import Vote
+from ..db import Session
+from ..models import PlenarySession, Vote
+from ..query import session_is_current_at
 from ..scrapers import NoWorkingUrlError, VOTListScraper
 from ..store import Aggregator, BulkWriter, index_records, map_vote
 from .common import BasePipeline, DataUnavailable, generate_vote_sharepics
@@ -44,7 +47,13 @@ class VOTListPipeline(BasePipeline):
     def _analyze_vote_groups(self) -> None:
         self._log.info("Running vote groups analysis")
         writer = BulkWriter()
-        analyzer = VoteGroupsAnalyzer(date=self.date, votes=self._votes())
+        session = Session.execute(
+            select(PlenarySession).where(session_is_current_at(self.date))
+        ).scalar_one()
+        analyzer = VoteGroupsAnalyzer(
+            session_start_date=session.start_date,
+            votes=self._votes(),
+        )
         writer.add(analyzer.run())
         writer.flush()
 

--- a/backend/tests/analysis/test_votes.py
+++ b/backend/tests/analysis/test_votes.py
@@ -41,7 +41,7 @@ def test_vote_group_analyzer_title():
     ]
 
     analyzer = VoteGroupsAnalyzer(
-        date=datetime.date(2026, 1, 1),
+        session_start_date=datetime.date(2026, 1, 1),
         votes=votes,
     )
     fragments = list(analyzer.run())
@@ -75,7 +75,7 @@ def test_vote_group_analyzer_dlv_title():
     ]
 
     analyzer = VoteGroupsAnalyzer(
-        date=datetime.date(2026, 1, 1),
+        session_start_date=datetime.date(2026, 1, 1),
         votes=votes,
     )
     fragments = list(analyzer.run())
@@ -84,6 +84,36 @@ def test_vote_group_analyzer_dlv_title():
     assert fragments[0].data["group_key"] == fragments[1].data["group_key"]
     assert fragments[0].data["group_key"] != fragments[2].data["group_key"]
     assert fragments[1].data["group_key"] != fragments[2].data["group_key"]
+
+
+def test_vote_group_analyzer_across_session_days():
+    votes = [
+        Vote(
+            id=130991,
+            timestamp=datetime.datetime(2021, 5, 18),
+            title="2019-2020 Reports on Montenegro",
+            reference="A9-0131/2021",
+            description="Am 6",
+        ),
+        Vote(
+            id=131714,
+            timestamp=datetime.datetime(2021, 5, 19),
+            title="2019-2020 Reports on Montenegro",
+            reference="A9-0131/2021",
+            description="Proposition de résolution",
+        ),
+    ]
+
+    analyzer = VoteGroupsAnalyzer(
+        session_start_date=datetime.date(2021, 5, 17),
+        votes=votes,
+    )
+    fragments = list(analyzer.run())
+
+    assert len(fragments) == 2
+    assert fragments[0].group_key == 130991
+    assert fragments[1].group_key == 131714
+    assert fragments[0].data["group_key"] == fragments[1].data["group_key"]
 
 
 def test_main_vote_analyzer_description():

--- a/backend/tests/api/test_votes_api.py
+++ b/backend/tests/api/test_votes_api.py
@@ -1002,6 +1002,39 @@ def test_votes_api_related_votes(db_session, api):
     assert res.json["related"] == expected
 
 
+def test_votes_api_related_votes_order(db_session, api):
+    amendment = Vote(
+        id=130991,
+        is_main=False,
+        timestamp=datetime.datetime(2021, 5, 18, 0, 0, 0),
+        order=261,
+        title="2019-2020 Reports on Montenegro",
+        reference="A9-0131/2021",
+        description="Am 6",
+        group_key="abc123",
+    )
+
+    main_vote = Vote(
+        id=131714,
+        is_main=True,
+        timestamp=datetime.datetime(2021, 5, 19, 0, 0, 0),
+        order=60,
+        title="2019-2020 Reports on Montenegro",
+        reference="A9-0131/2021",
+        description="Proposition de résolution",
+        group_key="abc123",
+    )
+
+    db_session.add_all([amendment, main_vote])
+    db_session.commit()
+
+    res = api.get("/api/votes/131714")
+
+    # Related votes are sorted by date first, and by order second
+    assert res.json["related"][0]["id"] == 130991
+    assert res.json["related"][1]["id"] == 131714
+
+
 def test_votes_api_not_found(api):
     res = api.get("/api/votes/123")
 

--- a/backend/tests/pipelines/test_rcv_list.py
+++ b/backend/tests/pipelines/test_rcv_list.py
@@ -11,12 +11,28 @@ from howtheyvote.models import (
     MemberVote,
     OEILSubject,
     PipelineStatus,
+    PlenarySession,
     Vote,
     VotePosition,
 )
 from howtheyvote.pipelines import RCVListPipeline
 
 from ..helpers import load_fixture
+
+
+@pytest.fixture
+def plenary_session(db_session):
+    session = PlenarySession(
+        id="2024-04-22",
+        term=9,
+        start_date=datetime.date(2024, 4, 22),
+        end_date=datetime.date(2024, 4, 25),
+    )
+
+    db_session.add(session)
+    db_session.commit()
+
+    yield session
 
 
 @pytest.fixture
@@ -49,7 +65,7 @@ def test_run_source_not_available(responses, db_session):
 
 
 @pytest.mark.always_mock_requests
-def test_run(responses, db_session, member, mocker):
+def test_run(responses, db_session, member, plenary_session, mocker):
     responses.get(
         "https://www.europarl.europa.eu/doceo/document/PV-9-2024-04-24-RCV_FR.xml",
         body=load_fixture("pipelines/data/rcv-list_pv-9-2024-04-24-rcv-fr-noon.xml"),
@@ -91,7 +107,7 @@ def test_run(responses, db_session, member, mocker):
 
 
 @pytest.mark.always_mock_requests
-def test_run_data_unchanged(responses, db_session, member):
+def test_run_data_unchanged(responses, db_session, member, plenary_session):
     responses.get(
         "https://www.europarl.europa.eu/doceo/document/PV-9-2024-04-24-RCV_FR.xml",
         body=load_fixture("pipelines/data/rcv-list_pv-9-2024-04-24-rcv-fr-noon.xml"),


### PR DESCRIPTION
Amendment votes and final votes may be cast on different days of the same plenary session. Currently, in such a case, the amendment votes and final vote wouldn’t be grouped together (i.e., no amendments would be displayed on the website). This changes the analyzer to group based on the plenary session start date. So if there are multiple votes with the same title that were all cast during the same plenary session, they will all be grouped together.

Fixes #1465

Run the following commands to recompute group keys:

```
htv temp vote-groups
htv aggregate votes
```

After that, amendments should be displayed for [this vote](http://localhost:8000/votes/131714), even though they were cast on different days.

Todos:

- [x] Order votes on amendments page by date