### PR TITLE
Use EP identifier of committee if available

### DIFF
--- a/backend/howtheyvote/cli/dev.py
+++ b/backend/howtheyvote/cli/dev.py
@@ -288,7 +288,7 @@ def load_committees() -> None:
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX euvoc: <http://publications.europa.eu/ontology/euvoc#>
 
-    SELECT ?code ?label ?abbr ?start_date ?end_date
+    SELECT ?code ?label ?abbr ?ep_identifier ?start_date ?end_date
     FROM <http://publications.europa.eu/resource/authority/corporate-body>
     WHERE {
         ?committee dct:type <http://publications.europa.eu/resource/authority/corporate-body-classification/EP_CMT>.
@@ -314,6 +314,12 @@ def load_committees() -> None:
                 ?abbr_status = <http://publications.europa.eu/resource/authority/concept-status/CURRENT>
             )
         }
+
+        # Get the EP identifier
+        OPTIONAL {
+            ?committee skos:notation ?ep_identifier .
+            FILTER(DATATYPE(?ep_identifier) = euvoc:EP)
+        }
     }
     """  # noqa: E501
 
@@ -337,7 +343,12 @@ def load_committees() -> None:
             .strip()
         )
 
-        abbreviation = result["abbr"]["value"] if result.get("abbr") else code
+        if "ep_identifier" in result:
+            abbreviation = result["ep_identifier"]["value"]
+        elif "abbr" in result:
+            abbreviation = result["abbr"]["value"]
+        else:
+            abbreviation = code
 
         start_date = datetime.date.fromisoformat(result["start_date"]["value"])
         end_date = (

--- a/backend/howtheyvote/data/committees.json
+++ b/backend/howtheyvote/data/committees.json
@@ -131,7 +131,7 @@
     "code": "CODE",
     "official_label": "Parliament\u2019s delegation to the Conciliation Committee",
     "label": "Parliament\u2019s delegation to the Conciliation Committee",
-    "abbreviation": "CODE",
+    "abbreviation": "LEGI",
     "start_date": "2004-01-19",
     "end_date": "2018-07-14"
   },


### PR DESCRIPTION
In most cases, this is the same as the code and abbreviation, except for the Delegation to the Conciliation Committee which has the code "CODE" and the EP identifier "LEGI". The legislative observatory uses the latter, which is why the `ProcedureScraper` failed when scraping https://oeil.europarl.europa.eu/oeil/en/procedure-file?reference=2013/0072(COD)

Here is a [table of all committees](https://publications.europa.eu/webapi/rdf/sparql?default-graph-uri=&query=++++PREFIX+skos%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2004%2F02%2Fskos%2Fcore%23%3E%0D%0A++++PREFIX+skosxl%3A+%3Chttp%3A%2F%2Fwww.w3.org%2F2008%2F05%2Fskos-xl%23%3E%0D%0A++++PREFIX+org%3A+%3Chttp%3A%2F%2Fwww.w3.org%2Fns%2Forg%23%3E%0D%0A++++PREFIX+dc%3A+%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%3E%0D%0A++++PREFIX+dct%3A+%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%0D%0A++++PREFIX+euvoc%3A+%3Chttp%3A%2F%2Fpublications.europa.eu%2Fontology%2Feuvoc%23%3E%0D%0A%0D%0A++++SELECT+%3Fcode+%3Flabel+%3Fabbr+%3Fep_identifier+%3Fstart_date+%3Fend_date%0D%0A++++FROM+%3Chttp%3A%2F%2Fpublications.europa.eu%2Fresource%2Fauthority%2Fcorporate-body%3E%0D%0A++++WHERE+%7B%0D%0A++++++++%3Fcommittee+dct%3Atype+%3Chttp%3A%2F%2Fpublications.europa.eu%2Fresource%2Fauthority%2Fcorporate-body-classification%2FEP_CMT%3E.%0D%0A%0D%0A++++++++%3Fcommittee+dc%3Aidentifier+%3Fcode.%0D%0A%0D%0A++++++++%3Fcommittee+skos%3AprefLabel+%3Flabel.%0D%0A++++++++FILTER%28lang%28%3Flabel%29+%3D+%22en%22%29%0D%0A%0D%0A++++++++%23+The+end+date+is+set+if+the+committee+isn%27t+active+anymore.%0D%0A++++++++%3Fcommittee+euvoc%3AstartDate+%3Fstart_date.%0D%0A++++++++OPTIONAL+%7B+%3Fcommittee+euvoc%3AendDate+%3Fend_date+%7D%0D%0A%0D%0A++++++++%23+Get+the+current+acronym%0D%0A++++++++OPTIONAL+%7B%0D%0A++++++++++++%3Fcommittee+skosxl%3AaltLabel+%3Fabbr_node.%0D%0A++++++++++++%3Fabbr_node+skosxl%3AliteralForm+%3Fabbr.%0D%0A++++++++++++%3Fabbr_node+dct%3Atype+%3Fabbr_type.%0D%0A++++++++++++%3Fabbr_node+euvoc%3Astatus+%3Fabbr_status.%0D%0A++++++++++++FILTER%28%0D%0A++++++++++++++++lang%28%3Fabbr%29+%3D+%22en%22+%26%26%0D%0A++++++++++++++++%3Fabbr_type+%3D+%3Chttp%3A%2F%2Fpublications.europa.eu%2Fresource%2Fauthority%2Flabel-type%2FACRONYM%3E+%26%26%0D%0A++++++++++++++++%3Fabbr_status+%3D+%3Chttp%3A%2F%2Fpublications.europa.eu%2Fresource%2Fauthority%2Fconcept-status%2FCURRENT%3E%0D%0A++++++++++++%29%0D%0A++++++++%7D%0D%0A%0D%0A++++++++%23+Get+the+EP+identifier%0D%0A++++++++OPTIONAL+%7B%0D%0A++++++++++++%3Fcommittee+skos%3Anotation+%3Fep_identifier+.%0D%0A++++++++++++FILTER%28DATATYPE%28%3Fep_identifier%29+%3D+euvoc%3AEP%29%0D%0A++++++++%7D%0D%0A++++%7D&format=text%2Fhtml&should-sponge=&timeout=0&signal_void=on&signal_unconnected=on) and the different codes/identifiers/abbreviations.