### PR TITLE
Fix 10 second delay when restarting frontend container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ volumes:
 services:
   frontend:
     image: "ghcr.io/howtheyvote/howtheyvote-frontend:${HTV_TAG:-main}"
+    init: true
     depends_on:
       - backend
     expose:
@@ -19,6 +20,7 @@ services:
 
   backend:
     image: "ghcr.io/howtheyvote/howtheyvote-backend:${HTV_TAG:-main}"
+    init: true
     depends_on:
       - chromium
     volumes:
@@ -38,6 +40,7 @@ services:
   worker:
     image: "ghcr.io/howtheyvote/howtheyvote-backend:${HTV_TAG:-main}"
     command: "htv worker"
+    init: true
     depends_on:
       - chromium
     volumes:

--- a/frontend/scripts/watch
+++ b/frontend/scripts/watch
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-trap exit SIGINT SIGTERM
 export ENTR_INOTIFY_WORKAROUND=1
 
 while true; do


### PR DESCRIPTION
When Docker restarts a container, it sends a SIGTERM signal. The root cause was probably related to the default init process in the container not properly forwarding this signal to the Node process. So instead of shutting down the Node process gracefully, Docker would wait for 10 seconds until timeouting and force-restarting the container. Setting `init: true` will include a proper `init` in the container that handles signals correctly.