### PR TITLE
Add Fediverse attribution meta tag

### DIFF
--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -55,6 +55,10 @@ export default function App({
           content="black-translucent"
         />
         <meta name="theme-color" content="var(--blue-darkest)" />
+        <meta
+          name="fediverse:creator"
+          content="@HowTheyVote.eu@eupolicy.social"
+        />
 
         <link
           rel="alternate"


### PR DESCRIPTION
This will display a link to our profile when any page on HowTheyVote.eu is shared on Mastodon: https://docs.joinmastodon.org/user/profile/#attribution