### PR TITLE
Simplify docker workflow after adding build step to separate workflows

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -3,7 +3,11 @@ name: Backend CI
 on:
   push:
     branches: ["main"]
-  pull_request: {}
+    paths:
+      - "backend/**"
+  pull_request:
+    paths:
+      - "backend/**"
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,32 +4,21 @@ on:
   workflow_dispatch: {}
   push:
     branches: ["main"]
-  pull_request: {}
 
 permissions:
   contents: read
   packages: write
 
 jobs:
-  prepare:
-    runs-on: ubuntu-latest
-    outputs:
-      images: ${{ steps.set.outputs.images }}
-    steps:
-      - id: set
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo 'images=["frontend","backend","caddy"]' >> "$GITHUB_OUTPUT"
-          else
-            echo 'images=["frontend","backend"]' >> "$GITHUB_OUTPUT"
-          fi
   docker:
-    needs: prepare 
     runs-on: ubuntu-26.04-arm
 
     strategy:
       matrix:
-        image: ${{ fromJson(needs.prepare.outputs.images) }}
+        image:
+          - frontend
+          - backend
+          - caddy
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,6 @@ name: Docker images
 
 on:
   workflow_dispatch: {}
-  push:
-    branches: ["main"]
 
 permissions:
   contents: read

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -3,7 +3,11 @@ name: Frontend CI
 on:
   push:
     branches: ["main"]
-  pull_request: {}
+    paths:
+      - "frontend/**"
+  pull_request:
+    paths:
+      - "frontend/**"
 
 jobs:
   build:


### PR DESCRIPTION
Removing the  pull_request trigger as mentioned in #1050 and also the workaround to conditionally skip the caddy build as we don't need that when the pull_request trigger is gone.