### PR TITLE
Intercept HTTP requests in worker tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -64,7 +64,7 @@ class DummyRegistry(FirstMatchRegistry):
         return response
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def responses(request):
     """Allows mocking HTTP requests made with `requests`. Request mocking can be
     disabled globally using the `HTV_TEST_MOCK_REQUESTS=false` env variable to

--- a/backend/tests/worker/test_init.py
+++ b/backend/tests/worker/test_init.py
@@ -6,7 +6,6 @@ from sqlalchemy import select
 from howtheyvote.models import PipelineRun, PipelineStatus, PlenarySession
 from howtheyvote.pipelines import (
     PipelineResult,
-    PressPipeline,
     RCVListPipeline,
     VOTListPipeline,
 )
@@ -23,16 +22,6 @@ def test_rcv_list_pipeline(db_session, mocker, responses):
     db_session.commit()
 
     rcv_mock = mocker.patch.object(RCVListPipeline, "run")
-
-    # TODO: For some reason tests will take a very long time if we do not mock the
-    # press pipeline. Probably that's because it’s being executed many times due to
-    # time travel, and each time it’s retrying requests over and over again. But
-    # should double-check that.
-    press_mock = mocker.patch.object(PressPipeline, "run")
-    press_mock.return_value = PipelineResult(
-        status=PipelineStatus.SUCCESS,
-        checksum=None,
-    )
 
     query = (
         select(PipelineRun)
@@ -144,13 +133,6 @@ def test_rcv_list_notification_no_votes(db_session, mocker, responses):
     db_session.commit()
 
     rcv_mock = mocker.patch.object(RCVListPipeline, "run")
-    press_mock = mocker.patch.object(PressPipeline, "run")
-
-    press_mock.return_value = PipelineResult(
-        status=PipelineStatus.SUCCESS,
-        checksum=None,
-    )
-
     pushover_mock = mocker.patch("howtheyvote.worker.send_notification")
 
     query = (
@@ -249,18 +231,6 @@ def test_vot_list_pipeline(db_session, mocker, responses):
         VOTListPipeline,
         "run",
         autospec=True,
-    )
-
-    rcv_mock = mocker.patch.object(RCVListPipeline, "run")
-    rcv_mock.return_value = PipelineResult(
-        status=PipelineStatus.SUCCESS,
-        checksum=None,
-    )
-
-    press_mock = mocker.patch.object(PressPipeline, "run")
-    press_mock.return_value = PipelineResult(
-        status=PipelineStatus.SUCCESS,
-        checksum=None,
     )
 
     query = (

--- a/backend/tests/worker/test_init.py
+++ b/backend/tests/worker/test_init.py
@@ -13,7 +13,7 @@ from howtheyvote.pipelines import (
 from howtheyvote.worker import get_worker
 
 
-def test_rcv_list_pipeline(db_session, mocker):
+def test_rcv_list_pipeline(db_session, mocker, responses):
     plenary_session = PlenarySession(
         id="2025-07-07",
         start_date=datetime.date(2025, 7, 7),
@@ -134,7 +134,7 @@ def test_rcv_list_pipeline(db_session, mocker):
         assert runs[4].status == PipelineStatus.SUCCESS
 
 
-def test_rcv_list_notification_no_votes(db_session, mocker):
+def test_rcv_list_notification_no_votes(db_session, mocker, responses):
     plenary_session = PlenarySession(
         id="2025-07-07",
         start_date=datetime.date(2025, 7, 7),
@@ -236,7 +236,7 @@ def test_rcv_list_notification_no_votes(db_session, mocker):
         assert pushover_mock.call_args.kwargs["title"] == "No RCV list found at end of day"
 
 
-def test_vot_list_pipeline(db_session, mocker):
+def test_vot_list_pipeline(db_session, mocker, responses):
     plenary_session = PlenarySession(
         id="2025-07-07",
         start_date=datetime.date(2025, 7, 7),

--- a/backend/tests/worker/test_init.py
+++ b/backend/tests/worker/test_init.py
@@ -12,7 +12,7 @@ from howtheyvote.pipelines import (
 from howtheyvote.worker import get_worker
 
 
-def test_rcv_list_pipeline(db_session, mocker, responses):
+def test_rcv_list_pipeline(db_session, mocker):
     plenary_session = PlenarySession(
         id="2025-07-07",
         start_date=datetime.date(2025, 7, 7),
@@ -123,7 +123,7 @@ def test_rcv_list_pipeline(db_session, mocker, responses):
         assert runs[4].status == PipelineStatus.SUCCESS
 
 
-def test_rcv_list_notification_no_votes(db_session, mocker, responses):
+def test_rcv_list_notification_no_votes(db_session, mocker):
     plenary_session = PlenarySession(
         id="2025-07-07",
         start_date=datetime.date(2025, 7, 7),
@@ -218,7 +218,7 @@ def test_rcv_list_notification_no_votes(db_session, mocker, responses):
         assert pushover_mock.call_args.kwargs["title"] == "No RCV list found at end of day"
 
 
-def test_vot_list_pipeline(db_session, mocker, responses):
+def test_vot_list_pipeline(db_session, mocker):
     plenary_session = PlenarySession(
         id="2025-07-07",
         start_date=datetime.date(2025, 7, 7),


### PR DESCRIPTION
I noticed that the `rcv_list_pipeline` test was very slow. It turned out that the VOTListPipeline wasn’t mocked, so the worker would execute it in between the RCVListPipeline runs against real data. This fixes that by intercepting all HTTP requests.