### PR TITLE
Remove unnecessary packages

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -45,23 +45,11 @@ FROM python:3.14-alpine3.24
 
 ARG PYTHON_VERSION
 
-RUN apk add --no-cache \
-    build-base \
-    libffi-dev \
-    # TODO: Switch back to LibreSSL once conflicts on Alpine 3.17 are resolved.
-    openssl-dev \
-    libxml2-dev \
-    libxslt-dev \
-    python3-dev \
-    bash \
-    less \
-    make \
-    cargo \
-    sqlite \
-    tmux
+RUN apk add --no-cache libstdc++ bash less make sqlite tmux
 
 # Copy Xapian and the Python bindings from the builder stage
 COPY --from=builder /usr/local/lib/libxapian.so* /usr/local/lib/
+COPY --from=builder /usr/lib/libpython${PYTHON_VERSION}.so.1.0 /usr/lib/
 COPY --from=builder /usr/local/lib/python${PYTHON_VERSION}/site-packages/xapian /usr/local/lib/python${PYTHON_VERSION}/site-packages/xapian
 COPY --from=builder /usr/local/share/xapian-core/stopwords/english.list /usr/local/share/xapian-core/stopwords/english.list
 RUN ldconfig /usr/local/lib

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -35,7 +35,7 @@ RUN pip install --no-cache-dir sphinx docutils
 RUN wget -q https://oligarchy.co.uk/xapian/${XAPIAN_VERSION}/xapian-bindings-${XAPIAN_VERSION}.tar.xz \
     && tar xf xapian-bindings-${XAPIAN_VERSION}.tar.xz \
     && cd xapian-bindings-${XAPIAN_VERSION} \
-    && ./configure --with-python3 PYTHON=/usr/local/bin/python3 \
+    && ./configure --with-python3 PYTHON=/usr/local/bin/python3 LDFLAGS="-Wl,-rpath,/usr/local/lib" \
     && make -j$(nproc) \
     && make install \
     && cd /build \
@@ -49,7 +49,6 @@ RUN apk add --no-cache libstdc++ bash less make sqlite tmux
 
 # Copy Xapian and the Python bindings from the builder stage
 COPY --from=builder /usr/local/lib/libxapian.so* /usr/local/lib/
-COPY --from=builder /usr/lib/libpython${PYTHON_VERSION}.so.1.0 /usr/lib/
 COPY --from=builder /usr/local/lib/python${PYTHON_VERSION}/site-packages/xapian /usr/local/lib/python${PYTHON_VERSION}/site-packages/xapian
 COPY --from=builder /usr/local/share/xapian-core/stopwords/english.list /usr/local/share/xapian-core/stopwords/english.list
 RUN ldconfig /usr/local/lib


### PR DESCRIPTION
I think these were necessary some time ago because some of the Python packages needed to be built from source (e.g. cryptography as a transitive dependency). It seems that all of these packages are now available as pre-built binaries, so the build-time dependencies aren’t required anymore.

This reduces the backend image size from 1.9 GB to 800 MB.

I tested the following:

* Stop the backend container: `docker compose down backend`
* Rebuild backend image: `docker compose build --no-cache backend`
* Remove the virtualenv directory (`.venv`)
* Reinstall Python packages: `docker compose run --rm backend poetry install`
* Start the backend container: `docker compose up -d --force-recreate backend`
* Run the tests: `docker compose exec backend make test`
* Run a pipeline: `docker compose exec backend htv pipeline rcv-list --term=10 --date=2026-05-21`