### PR TITLE
Improve compatibility with custom Datawrapper themes

### DIFF
--- a/frontend/src/components/DatawrapperLinkList.tsx
+++ b/frontend/src/components/DatawrapperLinkList.tsx
@@ -5,6 +5,20 @@ import { formatDate } from "../lib/dates";
 import List from "./List";
 import ListItem from "./ListItem";
 
+const COLORS = {
+  FOR: "rgb(0, 144, 118)",
+  AGAINST: "rgb(199, 30, 29)",
+  ABSTENTION: "rgb(29, 129, 162)",
+  DID_NOT_VOTE: "rgb(114, 114, 114)",
+};
+
+const LABELS = {
+  FOR: "For",
+  AGAINST: "Against",
+  ABSTENTION: "Abstention",
+  DID_NOT_VOTE: "Didn’t vote",
+};
+
 type EmbedType = "members" | "groups" | "countries";
 
 type DatawrapperLinkProps = {
@@ -125,11 +139,6 @@ function DataWrapperLinkList({ vote }: { vote: Vote }) {
   );
 }
 
-const GREEN = "rgb(0, 144, 118)";
-const RED = "rgb(199, 30, 29)";
-const BLUE = "rgb(29, 129, 162)";
-const GRAY = "rgb(114, 114, 114)";
-
 function populateConfigForGroups(
   config: Record<string, string>,
   voteId: number,
@@ -145,16 +154,16 @@ function populateConfigForGroups(
     "color-by-column": true,
     "color-category": {
       map: {
-        count_for: GREEN,
-        count_against: RED,
-        count_abstentions: BLUE,
-        count_did_not_vote: GRAY,
+        count_for: COLORS.FOR,
+        count_against: COLORS.AGAINST,
+        count_abstentions: COLORS.ABSTENTION,
+        count_did_not_vote: COLORS.DID_NOT_VOTE,
       },
       categoryLabels: {
-        count_for: "In Favor",
-        count_against: "Against",
-        count_abstentions: "Abstention",
-        count_did_not_vote: "Did not vote",
+        count_for: LABELS.FOR,
+        count_against: LABELS.AGAINST,
+        count_abstentions: LABELS.ABSTENTION,
+        count_did_not_vote: LABELS.DID_NOT_VOTE,
       },
     },
   };
@@ -181,16 +190,16 @@ function populateConfigForCountries(
     "color-by-column": true,
     "color-category": {
       map: {
-        count_for: GREEN,
-        count_against: RED,
-        count_abstentions: BLUE,
-        count_did_not_vote: GRAY,
+        count_for: COLORS.FOR,
+        count_against: COLORS.AGAINST,
+        count_abstentions: COLORS.ABSTENTION,
+        count_did_not_vote: COLORS.DID_NOT_VOTE,
       },
       categoryLabels: {
-        count_for: "In Favor",
-        count_against: "Against",
-        count_abstentions: "Abstention",
-        count_did_not_vote: "Did not vote",
+        count_for: LABELS.FOR,
+        count_against: LABELS.AGAINST,
+        count_abstentions: LABELS.ABSTENTION,
+        count_did_not_vote: LABELS.DID_NOT_VOTE,
       },
     },
   };
@@ -271,10 +280,10 @@ function populateConfigForMembers(
         name: "Vote",
         formula: `CONCAT(
           "<b style='background:currentColor; padding:1px 4px;'><span style='color:white'>",
-          IF(position == "VotePosition.FOR", "For", ""),
-          IF(position == "VotePosition.AGAINST", "Against", ""),
-          IF(position == "VotePosition.ABSTENTION", "Abstention", ""),
-          IF(position == "VotePosition.DID_NOT_VOTE", "Didn’t vote", ""),
+          IF(position == "VotePosition.FOR", "${LABELS.FOR}", ""),
+          IF(position == "VotePosition.AGAINST", "${LABELS.AGAINST}", ""),
+          IF(position == "VotePosition.ABSTENTION", "${LABELS.ABSTENTION}", ""),
+          IF(position == "VotePosition.DID_NOT_VOTE", "${LABELS.DID_NOT_VOTE}", ""),
           "</span></b>"
         )`,
       },
@@ -295,10 +304,10 @@ function populateConfigForMembers(
         customColor: true,
         customColorBy: "Vote",
         customColorText: {
-          For: GREEN,
-          Against: RED,
-          Abstention: BLUE,
-          "Didn’t vote": GRAY,
+          For: COLORS.FOR,
+          Against: COLORS.AGAINST,
+          Abstention: COLORS.ABSTENTION,
+          "Didn’t vote": COLORS.DID_NOT_VOTE,
         },
       },
     },

--- a/frontend/src/components/DatawrapperLinkList.tsx
+++ b/frontend/src/components/DatawrapperLinkList.tsx
@@ -270,10 +270,12 @@ function populateConfigForMembers(
       {
         name: "Vote",
         formula: `CONCAT(
-          IF(position == "VotePosition.FOR", "<b style='background:${GREEN}; color:white; padding:1px 4px;'>For</b>", ""),
-          IF(position == "VotePosition.AGAINST", "<b style='background:${RED}; color:white; padding:1px 4px;'>Against</b>", ""),
-          IF(position == "VotePosition.ABSTENTION", "<b style='background:${BLUE}; color:white; padding:1px 4px'>Abstention</b>", ""),
-          IF(position == "VotePosition.DID_NOT_VOTE", "<b style='background:${GRAY}; color:white; padding:1px 4px'>Didn’t vote</b>", "")
+          "<b style='background:currentColor; padding:1px 4px;'><span style='color:white'>",
+          IF(position == "VotePosition.FOR", "For", ""),
+          IF(position == "VotePosition.AGAINST", "Against", ""),
+          IF(position == "VotePosition.ABSTENTION", "Abstention", ""),
+          IF(position == "VotePosition.DID_NOT_VOTE", "Didn’t vote", ""),
+          "</span></b>"
         )`,
       },
     ],

--- a/frontend/src/components/DatawrapperLinkList.tsx
+++ b/frontend/src/components/DatawrapperLinkList.tsx
@@ -292,6 +292,14 @@ function populateConfigForMembers(
       },
       Vote: {
         alignment: "right",
+        customColor: true,
+        customColorBy: "Vote",
+        customColorText: {
+          For: GREEN,
+          Against: RED,
+          Abstention: BLUE,
+          "Didn’t vote": GRAY,
+        },
       },
     },
     perPage: 10,
@@ -327,9 +335,9 @@ function getPresetConfig(
     `${formatDate(timestamp)} · ` +
     (reference && `${reference} · `) +
     (description && `${description}</br>`) +
-    `<b style="border-bottom: 2px solid ${GREEN};">${stats.FOR} votes in favor</b>, ` +
-    `<b style="border-bottom:2px solid ${RED};">${stats.AGAINST} votes against</b>, ` +
-    `<b style="border-bottom:2px solid ${BLUE};">${stats.ABSTENTION} abstentions</b>.`;
+    `<b>${stats.FOR} votes in favor</b>, ` +
+    `<b>${stats.AGAINST} votes against</b>, ` +
+    `<b>${stats.ABSTENTION} abstentions</b>.`;
 
   config.source_url = `https://howtheyvote.eu/votes/${voteId}`;
   config.source_name = "HowTheyVote.eu (Open Database License)";

--- a/frontend/src/components/DatawrapperLinkList.tsx
+++ b/frontend/src/components/DatawrapperLinkList.tsx
@@ -343,10 +343,10 @@ function getPresetConfig(
   config.description =
     `${formatDate(timestamp)} · ` +
     (reference && `${reference} · `) +
-    (description && `${description}</br>`) +
-    `<b>${stats.FOR} votes in favor</b>, ` +
-    `<b>${stats.AGAINST} votes against</b>, ` +
-    `<b>${stats.ABSTENTION} abstentions</b>.`;
+    (description && `${description}<br/>`) +
+    `${stats.FOR} votes in favor, ` +
+    `${stats.AGAINST} votes against, ` +
+    `${stats.ABSTENTION} abstentions.`;
 
   config.source_url = `https://howtheyvote.eu/votes/${voteId}`;
   config.source_name = "HowTheyVote.eu (Open Database License)";


### PR DESCRIPTION
This PR contains two changes to improve compatibility with custom Datawrapper themes.

I’ve removed the colored underlines in the chart description. They are a nice touch, but the colors are hard-coded meaning that they do not adapt to custom themes.

| Before | After |
| --- | --- |
| <img width="610" height="108" alt="Screenshot 2026-08-26 at 5 30 58 PM" src="https://github.com/user-attachments/assets/0daa5205-18ee-4f99-93f2-f070cfc98f4b" /> | <img width="605" height="111" alt="Screenshot 2026-08-26 at 5 31 43 PM" src="https://github.com/user-attachments/assets/c8c7339d-faa9-4a4b-9104-0fa698c49838" /> |

The colors of the vote position labels in the table visualization are not hard-coded in the colum formula anymore, but use the conditional colors feature in Datawrapper. This means they can be updated in the Datawrapper UI. This still means that a user needs to manually reassign the colors after updating the theme, but at least that’s much easier now.

<img width="443" height="462" alt="Screenshot 2026-08-26 at 5 35 29 PM" src="https://github.com/user-attachments/assets/a1a24f8e-debd-48c7-b5ac-7e56a00a0fe6" />