### PR TITLE
Fix rounding in vote result charts

### DIFF
--- a/frontend/src/components/VoteResultChart.css
+++ b/frontend/src/components/VoteResultChart.css
@@ -65,7 +65,7 @@
 }
 
 @container vote-result-chart-bar (width < 30px) {
-  .vote-result-chart__thumb {
+  .vote-result-chart__label {
     display: none;
   }
 }

--- a/frontend/src/components/VoteResultChart.test.tsx
+++ b/frontend/src/components/VoteResultChart.test.tsx
@@ -28,4 +28,29 @@ describe("VoteResultChart", () => {
       "For: 5 (50%). Against: 3 (30%). Abstentions: 2 (20%). In total, 10 MEPs voted. 1 MEPs didn’t vote.",
     );
   });
+
+  it("rounds vote position percentages correctly", () => {
+    // https://howtheyvote.eu/votes/186909
+    render(
+      <VoteResultChart
+        stats={{
+          FOR: 458,
+          AGAINST: 72,
+          ABSTENTION: 98,
+          DID_NOT_VOTE: 90,
+        }}
+      />,
+    );
+
+    screen.getByTitle("458 MEPs voted FOR (73%)");
+    screen.getByTitle("72 MEPs voted AGAINST (11%)");
+    screen.getByTitle("98 MEPs voted ABSTENTION (16%)");
+
+    const summary = screen.getByTestId("vote-result-chart-summary");
+
+    assert.strictEqual(
+      summary.textContent,
+      "For: 458 (73%). Against: 72 (11%). Abstentions: 98 (16%). In total, 628 MEPs voted. 90 MEPs didn’t vote.",
+    );
+  });
 });

--- a/frontend/src/components/VoteResultChart.test.tsx
+++ b/frontend/src/components/VoteResultChart.test.tsx
@@ -1,0 +1,31 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { render, screen } from "@testing-library/preact";
+import type { VotePositionCounts } from "../api";
+import VoteResultChart from "./VoteResultChart";
+
+const stats: VotePositionCounts = {
+  FOR: 5,
+  AGAINST: 3,
+  ABSTENTION: 2,
+  DID_NOT_VOTE: 1,
+};
+
+describe("VoteResultChart", () => {
+  it("renders the vote result bars", () => {
+    render(<VoteResultChart stats={stats} />);
+    screen.getByTitle("5 MEPs voted FOR (50%)");
+    screen.getByTitle("3 MEPs voted AGAINST (30%)");
+    screen.getByTitle("2 MEPs voted ABSTENTION (20%)");
+  });
+
+  it("renders the vote summary", () => {
+    render(<VoteResultChart stats={stats} />);
+    const summary = screen.getByTestId("vote-result-chart-summary");
+
+    assert.strictEqual(
+      summary.textContent,
+      "For: 5(50 %). Against: 3(30 %). Abstentions: 2(20 %). In total, 10 MEPs voted. 1 MEPs didn’t vote.",
+    );
+  });
+});

--- a/frontend/src/components/VoteResultChart.test.tsx
+++ b/frontend/src/components/VoteResultChart.test.tsx
@@ -25,7 +25,7 @@ describe("VoteResultChart", () => {
 
     assert.strictEqual(
       summary.textContent,
-      "For: 5(50 %). Against: 3(30 %). Abstentions: 2(20 %). In total, 10 MEPs voted. 1 MEPs didn’t vote.",
+      "For: 5 (50%). Against: 3 (30%). Abstentions: 2 (20%). In total, 10 MEPs voted. 1 MEPs didn’t vote.",
     );
   });
 });

--- a/frontend/src/components/VoteResultChart.tsx
+++ b/frontend/src/components/VoteResultChart.tsx
@@ -51,12 +51,12 @@ function Summary({ stats }: SummaryProps) {
 
   return (
     <p class="text--sm text--light" data-testid="vote-result-chart-summary">
-      For: <strong>{stats.FOR}</strong>
-      <span class="visually-hidden">({percentageFor} %)</span>. Against:{" "}
-      <strong>{stats.AGAINST}</strong>
-      <span class="visually-hidden">({percentageAgainst} %)</span>. Abstentions:{" "}
-      <strong>{stats.ABSTENTION}</strong>
-      <span class="visually-hidden">({percentageAbstention} %)</span>. In total,{" "}
+      For: <strong>{stats.FOR}</strong>{" "}
+      <span class="visually-hidden">({percentageFor}%)</span>. Against:{" "}
+      <strong>{stats.AGAINST}</strong>{" "}
+      <span class="visually-hidden">({percentageAgainst}%)</span>. Abstentions:{" "}
+      <strong>{stats.ABSTENTION}</strong>{" "}
+      <span class="visually-hidden">({percentageAbstention}%)</span>. In total,{" "}
       <strong>{total} MEPs</strong> voted.{" "}
       <strong>{stats.DID_NOT_VOTE} MEPs</strong> didn’t vote.
     </p>

--- a/frontend/src/components/VoteResultChart.tsx
+++ b/frontend/src/components/VoteResultChart.tsx
@@ -50,7 +50,7 @@ function Summary({ stats }: SummaryProps) {
   const percentageAbstention = Math.round((stats.ABSTENTION / total) * 100);
 
   return (
-    <p class="text--sm text--light">
+    <p class="text--sm text--light" data-testid="vote-result-chart-summary">
       For: <strong>{stats.FOR}</strong>
       <span class="visually-hidden">({percentageFor} %)</span>. Against:{" "}
       <strong>{stats.AGAINST}</strong>

--- a/frontend/src/components/VoteResultChart.tsx
+++ b/frontend/src/components/VoteResultChart.tsx
@@ -26,7 +26,7 @@ function Bar({ value, total, position }: BarProps) {
     return null;
   }
 
-  const percentage = Math.round(ratio * 100);
+  const percentage = Math.round((value / total) * 100);
   const style = position.toLowerCase().replaceAll("_", "-");
 
   return (

--- a/frontend/src/components/VoteResultChart.tsx
+++ b/frontend/src/components/VoteResultChart.tsx
@@ -20,13 +20,16 @@ type SummaryProps = {
 };
 
 function Bar({ value, total, position }: BarProps) {
-  const ratio = Math.round((value / total) * 1000) / 1000;
-
   if (value === 0) {
     return null;
   }
 
+  // Used to determine bar width
+  const ratio = Math.round((value / total) * 1000) / 1000;
+
+  // Used as a text label, lower precision than `ratio` above
   const percentage = Math.round((value / total) * 100);
+
   const style = position.toLowerCase().replaceAll("_", "-");
 
   return (

--- a/frontend/src/components/VoteResultChart.tsx
+++ b/frontend/src/components/VoteResultChart.tsx
@@ -54,12 +54,12 @@ function Summary({ stats }: SummaryProps) {
 
   return (
     <p class="text--sm text--light" data-testid="vote-result-chart-summary">
-      For: <strong>{stats.FOR}</strong>{" "}
-      <span class="visually-hidden">({percentageFor}%)</span>. Against:{" "}
-      <strong>{stats.AGAINST}</strong>{" "}
-      <span class="visually-hidden">({percentageAgainst}%)</span>. Abstentions:{" "}
-      <strong>{stats.ABSTENTION}</strong>{" "}
-      <span class="visually-hidden">({percentageAbstention}%)</span>. In total,{" "}
+      For: <strong>{stats.FOR}</strong>
+      <span class="visually-hidden"> ({percentageFor}%)</span>. Against:{" "}
+      <strong>{stats.AGAINST}</strong>
+      <span class="visually-hidden"> ({percentageAgainst}%)</span>. Abstentions:{" "}
+      <strong>{stats.ABSTENTION}</strong>
+      <span class="visually-hidden"> ({percentageAbstention}%)</span>. In total,{" "}
       <strong>{total} MEPs</strong> voted.{" "}
       <strong>{stats.DID_NOT_VOTE} MEPs</strong> didn’t vote.
     </p>


### PR DESCRIPTION
A user reported that we’re sometimes rounding the percentages incorrectly (see test cases for an example). The reason for that is that we were rounding twice, first to 3 decimal places, then again to 2.